### PR TITLE
Fix GitHub Pages deployment paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Blissful Reverie Meal Planner</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- switch the Vite build to emit relative asset URLs so the UI works when hosted from a GitHub Pages subdirectory
- update the HTML entrypoint to use relative asset references and reflect the meal planner branding

## Testing
- npm run lint
- npm run validate:data
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cde61e37588325962a7617b012ef11