### PR TITLE
Add collapsible filter sections with protein category

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,36 +55,52 @@
             <span>Search</span>
             <input type="search" id="filter-search" placeholder="Search by name, description, or tag" />
           </label>
-          <section class="filter-section">
-            <h3>Tags</h3>
-            <div class="checkbox-grid" id="tag-options"></div>
-          </section>
-          <section class="filter-section">
-            <h3>Allergies to Avoid</h3>
-            <div class="checkbox-grid" id="allergy-options"></div>
-          </section>
-          <section class="filter-section">
-            <h3>Equipment</h3>
-            <div class="checkbox-grid" id="equipment-options"></div>
-          </section>
-          <section class="filter-section">
-            <h3>Ingredients to Include</h3>
-            <div class="ingredient-input">
-              <input list="include-ingredients" id="include-input" placeholder="Add ingredient keyword" />
-              <button type="button" id="include-add">Add</button>
-              <datalist id="include-ingredients"></datalist>
+          <details class="filter-section" open>
+            <summary>Protein</summary>
+            <div class="filter-section__content">
+              <div class="checkbox-grid" id="protein-options"></div>
             </div>
-            <div class="chip-row" id="include-chips"></div>
-          </section>
-          <section class="filter-section">
-            <h3>Ingredients to Exclude</h3>
-            <div class="ingredient-input">
-              <input list="exclude-ingredients" id="exclude-input" placeholder="Add ingredient keyword" />
-              <button type="button" id="exclude-add">Add</button>
-              <datalist id="exclude-ingredients"></datalist>
+          </details>
+          <details class="filter-section" open>
+            <summary>Tags</summary>
+            <div class="filter-section__content">
+              <div class="checkbox-grid" id="tag-options"></div>
             </div>
-            <div class="chip-row" id="exclude-chips"></div>
-          </section>
+          </details>
+          <details class="filter-section" open>
+            <summary>Allergies to Avoid</summary>
+            <div class="filter-section__content">
+              <div class="checkbox-grid" id="allergy-options"></div>
+            </div>
+          </details>
+          <details class="filter-section" open>
+            <summary>Equipment</summary>
+            <div class="filter-section__content">
+              <div class="checkbox-grid" id="equipment-options"></div>
+            </div>
+          </details>
+          <details class="filter-section" open>
+            <summary>Ingredients to Include</summary>
+            <div class="filter-section__content">
+              <div class="ingredient-input">
+                <input list="include-ingredients" id="include-input" placeholder="Add ingredient keyword" />
+                <button type="button" id="include-add">Add</button>
+                <datalist id="include-ingredients"></datalist>
+              </div>
+              <div class="chip-row" id="include-chips"></div>
+            </div>
+          </details>
+          <details class="filter-section" open>
+            <summary>Ingredients to Exclude</summary>
+            <div class="filter-section__content">
+              <div class="ingredient-input">
+                <input list="exclude-ingredients" id="exclude-input" placeholder="Add ingredient keyword" />
+                <button type="button" id="exclude-add">Add</button>
+                <datalist id="exclude-ingredients"></datalist>
+              </div>
+              <div class="chip-row" id="exclude-chips"></div>
+            </div>
+          </details>
         </aside>
         <section class="content">
           <div class="content-header">

--- a/styles/app.css
+++ b/styles/app.css
@@ -294,10 +294,65 @@ textarea:focus {
   box-shadow: 0 0 0 3px var(--color-focus-ring);
 }
 
-.filter-section h3 {
-  margin: 0 0 0.45rem;
+.filter-section {
+  border: 1px solid var(--color-border-muted);
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  background: var(--color-surface-soft);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filter-section[open] {
+  border-color: var(--color-border);
+  box-shadow: 0 12px 30px -28px var(--color-card-shadow-soft);
+}
+
+.filter-section summary {
+  margin: 0;
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
   font-size: 1rem;
+  font-weight: 600;
   color: var(--color-text-badge);
+}
+
+.filter-section summary::-webkit-details-marker {
+  display: none;
+}
+
+.filter-section summary::after {
+  content: '';
+  width: 0.7rem;
+  height: 0.7rem;
+  border-right: 2px solid var(--color-text-muted);
+  border-bottom: 2px solid var(--color-text-muted);
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.filter-section[open] summary::after {
+  transform: rotate(-135deg);
+}
+
+.filter-section summary:focus {
+  outline: none;
+}
+
+.filter-section summary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
+  border-radius: 12px;
+}
+
+.filter-section__content {
+  margin-top: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
 }
 
 .checkbox-grid {


### PR DESCRIPTION
## Summary
- convert meal filter sections into collapsible panels with refreshed styling
- add a dedicated protein filter while excluding equipment overlaps from tag options
- update filtering logic and control synchronization for the new protein selections

## Testing
- python3 -m http.server 4173 (manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_e_68cefec7cae0832583e03a3ed81d340c