### PR TITLE
Remove redundant ingredient filters and adjust panel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,28 +104,6 @@
               <div class="checkbox-grid" id="equipment-options"></div>
             </div>
           </details>
-          <details class="filter-section" open>
-            <summary>Ingredients to Include</summary>
-            <div class="filter-section__content">
-              <div class="ingredient-input">
-                <input list="include-ingredients" id="include-input" placeholder="Add ingredient keyword" />
-                <button type="button" id="include-add">Add</button>
-                <datalist id="include-ingredients"></datalist>
-              </div>
-              <div class="chip-row" id="include-chips"></div>
-            </div>
-          </details>
-          <details class="filter-section" open>
-            <summary>Ingredients to Exclude</summary>
-            <div class="filter-section__content">
-              <div class="ingredient-input">
-                <input list="exclude-ingredients" id="exclude-input" placeholder="Add ingredient keyword" />
-                <button type="button" id="exclude-add">Add</button>
-                <datalist id="exclude-ingredients"></datalist>
-              </div>
-              <div class="chip-row" id="exclude-chips"></div>
-            </div>
-          </details>
         </aside>
         <section class="content">
           <div class="content-header">

--- a/styles/app.css
+++ b/styles/app.css
@@ -374,8 +374,6 @@ select {
   flex-direction: column;
   gap: 1.4rem;
   padding: 1.5rem;
-  max-height: calc(100vh - 6rem);
-  overflow-y: auto;
 }
 
 .panel-header {
@@ -410,7 +408,6 @@ select {
 }
 
 .input-group input,
-.ingredient-input input,
 .pantry-form input {
   border: 1px solid var(--color-border);
   border-radius: 12px;
@@ -419,7 +416,6 @@ select {
 }
 
 .input-group input:focus,
-.ingredient-input input:focus,
 .pantry-form input:focus,
 .serving-controls input:focus,
 textarea:focus {
@@ -507,12 +503,6 @@ textarea:focus {
   accent-color: var(--color-accent);
 }
 
-.ingredient-input {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.ingredient-input button,
 .pantry-form button,
 .meal-card__footer button {
   border: none;
@@ -525,31 +515,10 @@ textarea:focus {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.ingredient-input button:hover,
 .pantry-form button:hover,
 .meal-card__footer button:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 25px -15px var(--color-accent-shadow);
-}
-
-.chip-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.chip {
-  border: none;
-  border-radius: 999px;
-  padding: 0.35rem 0.8rem;
-  background: var(--color-accent-soft);
-  color: var(--color-accent);
-  cursor: pointer;
-}
-
-.chip-danger {
-  background: var(--color-danger-soft);
-  color: var(--color-danger);
 }
 
 .content {


### PR DESCRIPTION
## Summary
- remove the ingredient include/exclude filter sections from the meal filter panel
- update the filter panel styling to grow with the page rather than scrolling and clean up unused styles
- streamline the filter logic and event bindings to match the simplified UI

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf1f34f6c88325af262ab931d47c9a