### PR TITLE
Increase theme contrast for accessibility

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -3,58 +3,58 @@
 }
 
 :root {
-  --color-background: #f6f7fb;
+  --color-background: #eef1fb;
   --body-gradient-start: #ffffff;
-  --body-gradient-mid: #eef1fb;
-  --body-gradient-end: #dfe7ff;
+  --body-gradient-mid: #dde3fb;
+  --body-gradient-end: #c4d3ff;
 
-  --color-text-primary: #1d2433;
-  --color-text-strong: #14213d;
-  --color-text-secondary: #536087;
-  --color-text-tertiary: #56617f;
-  --color-text-muted: #7a88a8;
-  --color-text-badge: #39486f;
-  --color-text-soft: #5a678a;
-  --color-text-instruction: #3f4d6b;
-  --color-text-inline: #435274;
-  --color-tag-text: #3730a3;
+  --color-text-primary: #0f172a;
+  --color-text-strong: #0b1120;
+  --color-text-secondary: #2e3a59;
+  --color-text-tertiary: #3a4666;
+  --color-text-muted: #4b5674;
+  --color-text-badge: #243256;
+  --color-text-soft: #36425f;
+  --color-text-instruction: #283756;
+  --color-text-inline: #2a3a5a;
+  --color-tag-text: #1c2a6d;
   --color-text-inverse: #ffffff;
-  --color-text-emphasis: #21304f;
+  --color-text-emphasis: #1b2848;
 
-  --color-accent: #5160d9;
-  --color-accent-strong: #8c79ff;
-  --color-accent-soft: rgba(81, 96, 217, 0.12);
-  --color-accent-softer: rgba(81, 96, 217, 0.08);
-  --color-accent-outline: rgba(81, 96, 217, 0.1);
-  --color-accent-border: #c7d2fe;
-  --color-accent-shadow: rgba(81, 96, 217, 0.9);
-  --color-accent-shadow-strong: rgba(81, 96, 217, 0.85);
+  --color-accent: #4453d6;
+  --color-accent-strong: #6f63ff;
+  --color-accent-soft: rgba(68, 83, 214, 0.18);
+  --color-accent-softer: rgba(68, 83, 214, 0.12);
+  --color-accent-outline: rgba(68, 83, 214, 0.2);
+  --color-accent-border: #a2b0f8;
+  --color-accent-shadow: rgba(68, 83, 214, 0.75);
+  --color-accent-shadow-strong: rgba(68, 83, 214, 0.85);
   --color-accent-contrast: #ffffff;
 
   --gradient-accent: linear-gradient(135deg, var(--color-accent), var(--color-accent-strong));
 
-  --color-border: #d8def5;
-  --color-border-strong: #e2e8f0;
-  --color-border-muted: #edf0fa;
-  --color-code-background: #f1f5f9;
-  --color-inline-tag-background: #eef2ff;
-  --color-inline-tag-text: #3730a3;
+  --color-border: #b8c4e3;
+  --color-border-strong: #9caad3;
+  --color-border-muted: #d3daf1;
+  --color-code-background: #e8ecf8;
+  --color-inline-tag-background: #e0e6ff;
+  --color-inline-tag-text: #1c2a6d;
 
-  --color-neutral-soft: rgba(20, 33, 61, 0.06);
+  --color-neutral-soft: rgba(15, 23, 42, 0.08);
   --color-surface: #ffffff;
-  --color-surface-soft: rgba(20, 33, 61, 0.03);
-  --color-surface-highlight: rgba(81, 96, 217, 0.08);
-  --color-header-background: rgba(255, 255, 255, 0.85);
+  --color-surface-soft: rgba(15, 23, 42, 0.05);
+  --color-surface-highlight: rgba(68, 83, 214, 0.12);
+  --color-header-background: rgba(255, 255, 255, 0.92);
 
   --color-header-shadow: rgba(20, 33, 61, 0.45);
   --color-card-shadow: rgba(20, 33, 61, 0.35);
-  --color-card-shadow-muted: rgba(20, 33, 61, 0.18);
-  --color-card-shadow-soft: rgba(81, 96, 217, 0.35);
+  --color-card-shadow-muted: rgba(20, 33, 61, 0.2);
+  --color-card-shadow-soft: rgba(68, 83, 214, 0.38);
 
-  --color-danger: #d7263d;
-  --color-danger-soft: rgba(245, 83, 123, 0.1);
+  --color-danger: #b91c1c;
+  --color-danger-soft: rgba(185, 28, 28, 0.14);
 
-  --color-focus-ring: rgba(81, 96, 217, 0.2);
+  --color-focus-ring: rgba(68, 83, 214, 0.28);
 
   font-family: 'Inter', 'Segoe UI', sans-serif;
   line-height: 1.6;
@@ -1053,34 +1053,34 @@ textarea:focus {
   --body-gradient-mid: #ffe2d0;
   --body-gradient-end: #ffcba4;
 
-  --color-header-background: rgba(255, 244, 236, 0.88);
+  --color-header-background: rgba(255, 244, 236, 0.94);
 
   --color-accent: #f97316;
   --color-accent-strong: #f43f5e;
-  --color-accent-soft: rgba(249, 115, 22, 0.16);
-  --color-accent-softer: rgba(249, 115, 22, 0.12);
-  --color-accent-outline: rgba(249, 115, 22, 0.2);
-  --color-accent-border: #fdba74;
-  --color-accent-shadow: rgba(249, 115, 22, 0.38);
-  --color-accent-shadow-strong: rgba(244, 63, 94, 0.42);
+  --color-accent-soft: rgba(249, 115, 22, 0.22);
+  --color-accent-softer: rgba(249, 115, 22, 0.16);
+  --color-accent-outline: rgba(249, 115, 22, 0.26);
+  --color-accent-border: #fca15d;
+  --color-accent-shadow: rgba(249, 115, 22, 0.48);
+  --color-accent-shadow-strong: rgba(244, 63, 94, 0.52);
 
-  --color-inline-tag-background: rgba(254, 215, 170, 0.35);
-  --color-inline-tag-text: #9a3412;
+  --color-inline-tag-background: rgba(254, 215, 170, 0.42);
+  --color-inline-tag-text: #7c2d12;
 
-  --color-neutral-soft: rgba(120, 53, 15, 0.08);
-  --color-surface-soft: rgba(249, 115, 22, 0.06);
-  --color-surface-highlight: rgba(249, 115, 22, 0.12);
+  --color-neutral-soft: rgba(120, 53, 15, 0.12);
+  --color-surface-soft: rgba(249, 115, 22, 0.08);
+  --color-surface-highlight: rgba(249, 115, 22, 0.18);
 
-  --color-border: #fbd5bd;
-  --color-border-strong: #f8c4a5;
-  --color-border-muted: #fde3d1;
-  --color-code-background: #fff4ec;
+  --color-border: #f4b791;
+  --color-border-strong: #ea8e58;
+  --color-border-muted: #fbd6b6;
+  --color-code-background: #ffeadd;
 
-  --color-card-shadow: rgba(191, 90, 29, 0.26);
-  --color-card-shadow-muted: rgba(249, 115, 22, 0.18);
-  --color-card-shadow-soft: rgba(249, 115, 22, 0.28);
+  --color-card-shadow: rgba(191, 90, 29, 0.32);
+  --color-card-shadow-muted: rgba(249, 115, 22, 0.24);
+  --color-card-shadow-soft: rgba(249, 115, 22, 0.34);
 
-  --color-focus-ring: rgba(249, 115, 22, 0.22);
+  --color-focus-ring: rgba(249, 115, 22, 0.32);
 }
 
 :root[data-mode='light'][data-theme='meadow'] {
@@ -1089,34 +1089,34 @@ textarea:focus {
   --body-gradient-mid: #dcfce7;
   --body-gradient-end: #bbf7d0;
 
-  --color-header-background: rgba(239, 253, 243, 0.9);
+  --color-header-background: rgba(239, 253, 243, 0.94);
 
   --color-accent: #2f855a;
   --color-accent-strong: #38a169;
-  --color-accent-soft: rgba(47, 133, 90, 0.16);
-  --color-accent-softer: rgba(47, 133, 90, 0.12);
-  --color-accent-outline: rgba(47, 133, 90, 0.18);
-  --color-accent-border: #9ae6b4;
-  --color-accent-shadow: rgba(47, 133, 90, 0.38);
-  --color-accent-shadow-strong: rgba(56, 189, 148, 0.42);
+  --color-accent-soft: rgba(47, 133, 90, 0.22);
+  --color-accent-softer: rgba(47, 133, 90, 0.16);
+  --color-accent-outline: rgba(47, 133, 90, 0.24);
+  --color-accent-border: #8cd9a8;
+  --color-accent-shadow: rgba(47, 133, 90, 0.45);
+  --color-accent-shadow-strong: rgba(56, 189, 148, 0.48);
 
-  --color-inline-tag-background: rgba(134, 239, 172, 0.32);
-  --color-inline-tag-text: #065f46;
+  --color-inline-tag-background: rgba(134, 239, 172, 0.38);
+  --color-inline-tag-text: #064e3b;
 
-  --color-neutral-soft: rgba(15, 118, 110, 0.08);
-  --color-surface-soft: rgba(15, 118, 110, 0.06);
-  --color-surface-highlight: rgba(34, 197, 94, 0.14);
+  --color-neutral-soft: rgba(15, 118, 110, 0.12);
+  --color-surface-soft: rgba(15, 118, 110, 0.08);
+  --color-surface-highlight: rgba(34, 197, 94, 0.18);
 
-  --color-border: #bde7c8;
-  --color-border-strong: #a3d9b6;
-  --color-border-muted: #d5f0dc;
-  --color-code-background: #ebfff1;
+  --color-border: #9ddbb1;
+  --color-border-strong: #7fcf9c;
+  --color-border-muted: #ccecd7;
+  --color-code-background: #e3f9ec;
 
-  --color-card-shadow: rgba(15, 118, 110, 0.26);
-  --color-card-shadow-muted: rgba(47, 133, 90, 0.18);
-  --color-card-shadow-soft: rgba(52, 211, 153, 0.3);
+  --color-card-shadow: rgba(15, 118, 110, 0.32);
+  --color-card-shadow-muted: rgba(47, 133, 90, 0.24);
+  --color-card-shadow-soft: rgba(52, 211, 153, 0.36);
 
-  --color-focus-ring: rgba(56, 161, 105, 0.22);
+  --color-focus-ring: rgba(56, 161, 105, 0.3);
 }
 
 :root[data-mode='light'][data-theme='mist'] {
@@ -1125,34 +1125,34 @@ textarea:focus {
   --body-gradient-mid: #e0f2fe;
   --body-gradient-end: #bae6fd;
 
-  --color-header-background: rgba(242, 249, 255, 0.9);
+  --color-header-background: rgba(242, 249, 255, 0.94);
 
   --color-accent: #38bdf8;
   --color-accent-strong: #0ea5e9;
-  --color-accent-soft: rgba(56, 189, 248, 0.18);
-  --color-accent-softer: rgba(14, 165, 233, 0.12);
-  --color-accent-outline: rgba(56, 189, 248, 0.2);
-  --color-accent-border: #bae6fd;
-  --color-accent-shadow: rgba(56, 189, 248, 0.28);
-  --color-accent-shadow-strong: rgba(14, 165, 233, 0.38);
+  --color-accent-soft: rgba(56, 189, 248, 0.24);
+  --color-accent-softer: rgba(14, 165, 233, 0.16);
+  --color-accent-outline: rgba(56, 189, 248, 0.26);
+  --color-accent-border: #8ecdf5;
+  --color-accent-shadow: rgba(56, 189, 248, 0.36);
+  --color-accent-shadow-strong: rgba(14, 165, 233, 0.44);
 
-  --color-inline-tag-background: rgba(59, 130, 246, 0.2);
-  --color-inline-tag-text: #0c4a6e;
+  --color-inline-tag-background: rgba(59, 130, 246, 0.26);
+  --color-inline-tag-text: #0b3d5c;
 
-  --color-neutral-soft: rgba(12, 74, 110, 0.12);
-  --color-surface-soft: rgba(56, 189, 248, 0.08);
-  --color-surface-highlight: rgba(56, 189, 248, 0.16);
+  --color-neutral-soft: rgba(12, 74, 110, 0.16);
+  --color-surface-soft: rgba(56, 189, 248, 0.1);
+  --color-surface-highlight: rgba(56, 189, 248, 0.2);
 
-  --color-border: #d6e8ff;
-  --color-border-strong: #c0dafc;
-  --color-border-muted: #e8f4ff;
-  --color-code-background: #f0f9ff;
+  --color-border: #b0cff5;
+  --color-border-strong: #90bdf0;
+  --color-border-muted: #dbeafb;
+  --color-code-background: #e6f4ff;
 
-  --color-card-shadow: rgba(12, 74, 110, 0.16);
-  --color-card-shadow-muted: rgba(14, 165, 233, 0.14);
-  --color-card-shadow-soft: rgba(56, 189, 248, 0.26);
+  --color-card-shadow: rgba(12, 74, 110, 0.22);
+  --color-card-shadow-muted: rgba(14, 165, 233, 0.2);
+  --color-card-shadow-soft: rgba(56, 189, 248, 0.32);
 
-  --color-focus-ring: rgba(56, 189, 248, 0.24);
+  --color-focus-ring: rgba(56, 189, 248, 0.32);
 }
 
 :root[data-mode='light'][data-theme='blossom'] {
@@ -1161,34 +1161,34 @@ textarea:focus {
   --body-gradient-mid: #fde4f2;
   --body-gradient-end: #fbcfe8;
 
-  --color-header-background: rgba(255, 245, 250, 0.9);
+  --color-header-background: rgba(255, 245, 250, 0.94);
 
   --color-accent: #ec4899;
   --color-accent-strong: #db2777;
-  --color-accent-soft: rgba(236, 72, 153, 0.18);
-  --color-accent-softer: rgba(236, 72, 153, 0.12);
-  --color-accent-outline: rgba(236, 72, 153, 0.22);
-  --color-accent-border: #f9a8d4;
-  --color-accent-shadow: rgba(190, 24, 93, 0.28);
-  --color-accent-shadow-strong: rgba(236, 72, 153, 0.32);
+  --color-accent-soft: rgba(236, 72, 153, 0.24);
+  --color-accent-softer: rgba(236, 72, 153, 0.16);
+  --color-accent-outline: rgba(236, 72, 153, 0.28);
+  --color-accent-border: #f472b6;
+  --color-accent-shadow: rgba(190, 24, 93, 0.36);
+  --color-accent-shadow-strong: rgba(236, 72, 153, 0.4);
 
-  --color-inline-tag-background: rgba(244, 114, 182, 0.26);
-  --color-inline-tag-text: #9d174d;
+  --color-inline-tag-background: rgba(244, 114, 182, 0.32);
+  --color-inline-tag-text: #831843;
 
-  --color-neutral-soft: rgba(190, 24, 93, 0.1);
-  --color-surface-soft: rgba(236, 72, 153, 0.08);
-  --color-surface-highlight: rgba(244, 114, 182, 0.16);
+  --color-neutral-soft: rgba(190, 24, 93, 0.14);
+  --color-surface-soft: rgba(236, 72, 153, 0.1);
+  --color-surface-highlight: rgba(244, 114, 182, 0.22);
 
-  --color-border: #f9c5dd;
-  --color-border-strong: #f6a5ca;
-  --color-border-muted: #fde5f3;
-  --color-code-background: #fff2f8;
+  --color-border: #f5b4d3;
+  --color-border-strong: #ee8bb8;
+  --color-border-muted: #fbd9e9;
+  --color-code-background: #ffeaf4;
 
-  --color-card-shadow: rgba(190, 24, 93, 0.2);
-  --color-card-shadow-muted: rgba(236, 72, 153, 0.16);
-  --color-card-shadow-soft: rgba(236, 72, 153, 0.3);
+  --color-card-shadow: rgba(190, 24, 93, 0.26);
+  --color-card-shadow-muted: rgba(236, 72, 153, 0.2);
+  --color-card-shadow-soft: rgba(236, 72, 153, 0.36);
 
-  --color-focus-ring: rgba(236, 72, 153, 0.24);
+  --color-focus-ring: rgba(236, 72, 153, 0.32);
 }
 
 :root[data-mode='light'][data-theme='citrine'] {
@@ -1197,34 +1197,34 @@ textarea:focus {
   --body-gradient-mid: #fef3c7;
   --body-gradient-end: #fde68a;
 
-  --color-header-background: rgba(255, 251, 234, 0.92);
+  --color-header-background: rgba(255, 251, 234, 0.95);
 
   --color-accent: #facc15;
   --color-accent-strong: #f59e0b;
-  --color-accent-soft: rgba(250, 204, 21, 0.18);
-  --color-accent-softer: rgba(250, 204, 21, 0.12);
-  --color-accent-outline: rgba(234, 179, 8, 0.24);
-  --color-accent-border: #fde047;
-  --color-accent-shadow: rgba(234, 179, 8, 0.26);
-  --color-accent-shadow-strong: rgba(250, 204, 21, 0.32);
+  --color-accent-soft: rgba(250, 204, 21, 0.24);
+  --color-accent-softer: rgba(250, 204, 21, 0.16);
+  --color-accent-outline: rgba(234, 179, 8, 0.3);
+  --color-accent-border: #f5c54d;
+  --color-accent-shadow: rgba(234, 179, 8, 0.34);
+  --color-accent-shadow-strong: rgba(250, 204, 21, 0.4);
 
-  --color-inline-tag-background: rgba(250, 204, 21, 0.26);
-  --color-inline-tag-text: #92400e;
+  --color-inline-tag-background: rgba(250, 204, 21, 0.32);
+  --color-inline-tag-text: #7c2d12;
 
-  --color-neutral-soft: rgba(180, 83, 9, 0.1);
-  --color-surface-soft: rgba(250, 204, 21, 0.08);
-  --color-surface-highlight: rgba(250, 204, 21, 0.18);
+  --color-neutral-soft: rgba(180, 83, 9, 0.14);
+  --color-surface-soft: rgba(250, 204, 21, 0.1);
+  --color-surface-highlight: rgba(250, 204, 21, 0.22);
 
-  --color-border: #f6df9c;
-  --color-border-strong: #f2cf6a;
-  --color-border-muted: #fbeec5;
-  --color-code-background: #fff8df;
+  --color-border: #f0c86b;
+  --color-border-strong: #e2a93a;
+  --color-border-muted: #f7e3a1;
+  --color-code-background: #fff3c4;
 
-  --color-card-shadow: rgba(146, 64, 14, 0.18);
-  --color-card-shadow-muted: rgba(217, 119, 6, 0.16);
-  --color-card-shadow-soft: rgba(250, 204, 21, 0.28);
+  --color-card-shadow: rgba(146, 64, 14, 0.24);
+  --color-card-shadow-muted: rgba(217, 119, 6, 0.22);
+  --color-card-shadow-soft: rgba(250, 204, 21, 0.34);
 
-  --color-focus-ring: rgba(250, 204, 21, 0.26);
+  --color-focus-ring: rgba(250, 204, 21, 0.34);
 }
 
 :root[data-mode='dark'] {
@@ -1233,48 +1233,48 @@ textarea:focus {
   --body-gradient-mid: #061228;
   --body-gradient-end: #010816;
 
-  --color-text-primary: #e2e8f0;
+  --color-text-primary: #f1f5ff;
   --color-text-strong: #f8fafc;
-  --color-text-secondary: #cbd5f5;
-  --color-text-tertiary: #a5b4fc;
-  --color-text-muted: #94a3b8;
-  --color-text-badge: #dbeafe;
-  --color-text-soft: #94a3b8;
-  --color-text-instruction: #cbd5f5;
-  --color-text-inline: #dbeafe;
+  --color-text-secondary: #d5defa;
+  --color-text-tertiary: #b8c4ff;
+  --color-text-muted: #a5b4d6;
+  --color-text-badge: #e2ecff;
+  --color-text-soft: #a5b4d6;
+  --color-text-instruction: #d5defa;
+  --color-text-inline: #e2ecff;
   --color-tag-text: #e0e7ff;
 
-  --color-surface: #111827;
-  --color-surface-soft: rgba(15, 23, 42, 0.7);
-  --color-surface-highlight: rgba(59, 130, 246, 0.18);
-  --color-header-background: rgba(15, 23, 42, 0.92);
-  --color-header-shadow: rgba(2, 6, 23, 0.72);
+  --color-surface: #0f172a;
+  --color-surface-soft: rgba(15, 23, 42, 0.85);
+  --color-surface-highlight: rgba(96, 165, 250, 0.24);
+  --color-header-background: rgba(15, 23, 42, 0.94);
+  --color-header-shadow: rgba(2, 6, 23, 0.78);
 
-  --color-border: rgba(148, 163, 184, 0.32);
-  --color-border-strong: rgba(148, 163, 184, 0.45);
-  --color-border-muted: rgba(148, 163, 184, 0.25);
-  --color-code-background: rgba(30, 41, 59, 0.8);
-  --color-inline-tag-background: rgba(59, 130, 246, 0.25);
-  --color-inline-tag-text: #dbeafe;
-  --color-neutral-soft: rgba(148, 163, 184, 0.2);
+  --color-border: rgba(148, 163, 184, 0.48);
+  --color-border-strong: rgba(191, 219, 254, 0.62);
+  --color-border-muted: rgba(148, 163, 184, 0.32);
+  --color-code-background: rgba(30, 41, 59, 0.86);
+  --color-inline-tag-background: rgba(96, 165, 250, 0.32);
+  --color-inline-tag-text: #e2ecff;
+  --color-neutral-soft: rgba(148, 163, 184, 0.28);
 
-  --color-card-shadow: rgba(2, 6, 23, 0.7);
-  --color-card-shadow-muted: rgba(2, 6, 23, 0.5);
-  --color-card-shadow-soft: rgba(59, 130, 246, 0.32);
+  --color-card-shadow: rgba(2, 6, 23, 0.72);
+  --color-card-shadow-muted: rgba(2, 6, 23, 0.52);
+  --color-card-shadow-soft: rgba(59, 130, 246, 0.36);
 
   --color-danger: #f87171;
-  --color-danger-soft: rgba(248, 113, 113, 0.22);
+  --color-danger-soft: rgba(248, 113, 113, 0.28);
 
-  --color-focus-ring: rgba(96, 165, 250, 0.4);
+  --color-focus-ring: rgba(96, 165, 250, 0.46);
 
-  --color-accent: #2563eb;
+  --color-accent: #2f6df0;
   --color-accent-strong: #60a5fa;
-  --color-accent-soft: rgba(37, 99, 235, 0.22);
-  --color-accent-softer: rgba(59, 130, 246, 0.16);
-  --color-accent-outline: rgba(96, 165, 250, 0.35);
-  --color-accent-border: rgba(96, 165, 250, 0.55);
-  --color-accent-shadow: rgba(37, 99, 235, 0.45);
-  --color-accent-shadow-strong: rgba(59, 130, 246, 0.5);
+  --color-accent-soft: rgba(47, 109, 240, 0.28);
+  --color-accent-softer: rgba(59, 130, 246, 0.2);
+  --color-accent-outline: rgba(96, 165, 250, 0.42);
+  --color-accent-border: rgba(125, 181, 255, 0.65);
+  --color-accent-shadow: rgba(47, 109, 240, 0.55);
+  --color-accent-shadow-strong: rgba(59, 130, 246, 0.58);
 }
 
 :root[data-mode='dark'][data-theme='nebula'] {
@@ -1284,32 +1284,32 @@ textarea:focus {
   --body-gradient-end: #050311;
 
   --color-surface: #1f1936;
-  --color-header-background: rgba(31, 25, 54, 0.92);
+  --color-header-background: rgba(31, 25, 54, 0.95);
   --color-header-shadow: rgba(9, 6, 25, 0.72);
 
   --color-accent: #a855f7;
   --color-accent-strong: #6366f1;
-  --color-accent-soft: rgba(168, 85, 247, 0.25);
-  --color-accent-softer: rgba(99, 102, 241, 0.18);
-  --color-accent-outline: rgba(129, 140, 248, 0.35);
-  --color-accent-border: rgba(196, 181, 253, 0.6);
-  --color-accent-shadow: rgba(129, 140, 248, 0.45);
-  --color-accent-shadow-strong: rgba(168, 85, 247, 0.5);
+  --color-accent-soft: rgba(168, 85, 247, 0.32);
+  --color-accent-softer: rgba(99, 102, 241, 0.24);
+  --color-accent-outline: rgba(129, 140, 248, 0.45);
+  --color-accent-border: rgba(209, 196, 255, 0.7);
+  --color-accent-shadow: rgba(129, 140, 248, 0.52);
+  --color-accent-shadow-strong: rgba(168, 85, 247, 0.58);
 
-  --color-inline-tag-background: rgba(168, 85, 247, 0.3);
-  --color-inline-tag-text: #ede9fe;
-  --color-surface-highlight: rgba(139, 92, 246, 0.22);
+  --color-inline-tag-background: rgba(168, 85, 247, 0.36);
+  --color-inline-tag-text: #f4f3ff;
+  --color-surface-highlight: rgba(139, 92, 246, 0.28);
 
-  --color-border: rgba(196, 181, 253, 0.32);
-  --color-border-strong: rgba(196, 181, 253, 0.45);
-  --color-border-muted: rgba(196, 181, 253, 0.28);
-  --color-neutral-soft: rgba(196, 181, 253, 0.18);
-  --color-card-shadow: rgba(9, 6, 25, 0.68);
-  --color-card-shadow-muted: rgba(9, 6, 25, 0.48);
-  --color-card-shadow-soft: rgba(168, 85, 247, 0.32);
+  --color-border: rgba(196, 181, 253, 0.5);
+  --color-border-strong: rgba(209, 196, 255, 0.65);
+  --color-border-muted: rgba(196, 181, 253, 0.36);
+  --color-neutral-soft: rgba(196, 181, 253, 0.24);
+  --color-card-shadow: rgba(9, 6, 25, 0.72);
+  --color-card-shadow-muted: rgba(9, 6, 25, 0.54);
+  --color-card-shadow-soft: rgba(168, 85, 247, 0.36);
 
-  --color-focus-ring: rgba(168, 85, 247, 0.36);
-  --color-code-background: rgba(44, 28, 72, 0.8);
+  --color-focus-ring: rgba(168, 85, 247, 0.46);
+  --color-code-background: rgba(44, 28, 72, 0.86);
 }
 
 :root[data-mode='dark'][data-theme='forest'] {
@@ -1319,32 +1319,32 @@ textarea:focus {
   --body-gradient-end: #010f0c;
 
   --color-surface: #0f1f1a;
-  --color-header-background: rgba(15, 31, 26, 0.92);
+  --color-header-background: rgba(15, 31, 26, 0.95);
   --color-header-shadow: rgba(1, 15, 12, 0.7);
 
   --color-accent: #34d399;
   --color-accent-strong: #10b981;
-  --color-accent-soft: rgba(52, 211, 153, 0.25);
-  --color-accent-softer: rgba(16, 185, 129, 0.2);
-  --color-accent-outline: rgba(52, 211, 153, 0.32);
-  --color-accent-border: rgba(110, 231, 183, 0.55);
-  --color-accent-shadow: rgba(16, 185, 129, 0.45);
-  --color-accent-shadow-strong: rgba(45, 212, 191, 0.5);
+  --color-accent-soft: rgba(52, 211, 153, 0.32);
+  --color-accent-softer: rgba(16, 185, 129, 0.24);
+  --color-accent-outline: rgba(52, 211, 153, 0.4);
+  --color-accent-border: rgba(134, 239, 172, 0.65);
+  --color-accent-shadow: rgba(16, 185, 129, 0.55);
+  --color-accent-shadow-strong: rgba(45, 212, 191, 0.6);
 
-  --color-inline-tag-background: rgba(45, 212, 191, 0.3);
-  --color-inline-tag-text: #ccfbf1;
-  --color-surface-highlight: rgba(45, 212, 191, 0.22);
+  --color-inline-tag-background: rgba(45, 212, 191, 0.36);
+  --color-inline-tag-text: #e0fdf6;
+  --color-surface-highlight: rgba(45, 212, 191, 0.28);
 
-  --color-border: rgba(110, 231, 183, 0.28);
-  --color-border-strong: rgba(110, 231, 183, 0.4);
-  --color-border-muted: rgba(110, 231, 183, 0.22);
-  --color-neutral-soft: rgba(15, 118, 110, 0.18);
-  --color-card-shadow: rgba(1, 15, 12, 0.68);
-  --color-card-shadow-muted: rgba(1, 15, 12, 0.48);
-  --color-card-shadow-soft: rgba(45, 212, 191, 0.32);
+  --color-border: rgba(134, 239, 172, 0.45);
+  --color-border-strong: rgba(167, 243, 208, 0.6);
+  --color-border-muted: rgba(110, 231, 183, 0.34);
+  --color-neutral-soft: rgba(15, 118, 110, 0.24);
+  --color-card-shadow: rgba(1, 15, 12, 0.72);
+  --color-card-shadow-muted: rgba(1, 15, 12, 0.52);
+  --color-card-shadow-soft: rgba(45, 212, 191, 0.36);
 
-  --color-focus-ring: rgba(45, 212, 191, 0.36);
-  --color-code-background: rgba(15, 52, 40, 0.75);
+  --color-focus-ring: rgba(45, 212, 191, 0.48);
+  --color-code-background: rgba(15, 52, 40, 0.82);
 }
 
 :root[data-mode='dark'][data-theme='ember'] {
@@ -1354,32 +1354,32 @@ textarea:focus {
   --body-gradient-end: #080402;
 
   --color-surface: #1e130a;
-  --color-header-background: rgba(30, 19, 10, 0.92);
+  --color-header-background: rgba(30, 19, 10, 0.95);
   --color-header-shadow: rgba(8, 4, 2, 0.76);
 
   --color-accent: #f97316;
   --color-accent-strong: #fb923c;
-  --color-accent-soft: rgba(249, 115, 22, 0.3);
-  --color-accent-softer: rgba(249, 115, 22, 0.2);
-  --color-accent-outline: rgba(251, 146, 60, 0.42);
-  --color-accent-border: rgba(251, 146, 60, 0.55);
-  --color-accent-shadow: rgba(249, 115, 22, 0.5);
-  --color-accent-shadow-strong: rgba(249, 115, 22, 0.58);
+  --color-accent-soft: rgba(249, 115, 22, 0.34);
+  --color-accent-softer: rgba(249, 115, 22, 0.24);
+  --color-accent-outline: rgba(251, 146, 60, 0.48);
+  --color-accent-border: rgba(251, 146, 60, 0.68);
+  --color-accent-shadow: rgba(249, 115, 22, 0.58);
+  --color-accent-shadow-strong: rgba(249, 115, 22, 0.64);
 
-  --color-inline-tag-background: rgba(249, 115, 22, 0.25);
-  --color-inline-tag-text: #fff7ed;
-  --color-surface-highlight: rgba(251, 146, 60, 0.3);
+  --color-inline-tag-background: rgba(249, 115, 22, 0.32);
+  --color-inline-tag-text: #ffedd5;
+  --color-surface-highlight: rgba(251, 146, 60, 0.36);
 
-  --color-border: rgba(251, 146, 60, 0.28);
-  --color-border-strong: rgba(251, 146, 60, 0.42);
-  --color-border-muted: rgba(251, 146, 60, 0.2);
-  --color-neutral-soft: rgba(249, 115, 22, 0.2);
-  --color-card-shadow: rgba(8, 4, 2, 0.75);
-  --color-card-shadow-muted: rgba(8, 4, 2, 0.55);
-  --color-card-shadow-soft: rgba(249, 115, 22, 0.35);
+  --color-border: rgba(251, 146, 60, 0.4);
+  --color-border-strong: rgba(251, 146, 60, 0.55);
+  --color-border-muted: rgba(251, 146, 60, 0.32);
+  --color-neutral-soft: rgba(249, 115, 22, 0.26);
+  --color-card-shadow: rgba(8, 4, 2, 0.8);
+  --color-card-shadow-muted: rgba(8, 4, 2, 0.6);
+  --color-card-shadow-soft: rgba(249, 115, 22, 0.4);
 
-  --color-focus-ring: rgba(251, 146, 60, 0.4);
-  --color-code-background: rgba(60, 32, 18, 0.78);
+  --color-focus-ring: rgba(251, 146, 60, 0.48);
+  --color-code-background: rgba(60, 32, 18, 0.84);
 }
 
 :root[data-mode='dark'][data-theme='abyss'] {
@@ -1389,32 +1389,32 @@ textarea:focus {
   --body-gradient-end: #01070b;
 
   --color-surface: #0b1f24;
-  --color-header-background: rgba(11, 31, 36, 0.92);
+  --color-header-background: rgba(11, 31, 36, 0.95);
   --color-header-shadow: rgba(1, 7, 11, 0.72);
 
   --color-accent: #14b8a6;
   --color-accent-strong: #38bdf8;
-  --color-accent-soft: rgba(20, 184, 166, 0.3);
-  --color-accent-softer: rgba(14, 165, 233, 0.22);
-  --color-accent-outline: rgba(20, 184, 166, 0.42);
-  --color-accent-border: rgba(94, 234, 212, 0.55);
-  --color-accent-shadow: rgba(14, 116, 144, 0.5);
-  --color-accent-shadow-strong: rgba(56, 189, 248, 0.5);
+  --color-accent-soft: rgba(20, 184, 166, 0.36);
+  --color-accent-softer: rgba(14, 165, 233, 0.26);
+  --color-accent-outline: rgba(20, 184, 166, 0.48);
+  --color-accent-border: rgba(94, 234, 212, 0.65);
+  --color-accent-shadow: rgba(14, 116, 144, 0.58);
+  --color-accent-shadow-strong: rgba(56, 189, 248, 0.58);
 
-  --color-inline-tag-background: rgba(13, 148, 136, 0.25);
-  --color-inline-tag-text: #ccfbf1;
-  --color-surface-highlight: rgba(14, 165, 233, 0.25);
+  --color-inline-tag-background: rgba(13, 148, 136, 0.32);
+  --color-inline-tag-text: #d5fef9;
+  --color-surface-highlight: rgba(14, 165, 233, 0.3);
 
-  --color-border: rgba(14, 165, 233, 0.28);
-  --color-border-strong: rgba(14, 165, 233, 0.42);
-  --color-border-muted: rgba(20, 184, 166, 0.22);
-  --color-neutral-soft: rgba(45, 212, 191, 0.24);
-  --color-card-shadow: rgba(1, 7, 11, 0.75);
-  --color-card-shadow-muted: rgba(1, 7, 11, 0.55);
-  --color-card-shadow-soft: rgba(14, 165, 233, 0.35);
+  --color-border: rgba(14, 165, 233, 0.38);
+  --color-border-strong: rgba(56, 189, 248, 0.52);
+  --color-border-muted: rgba(20, 184, 166, 0.3);
+  --color-neutral-soft: rgba(45, 212, 191, 0.32);
+  --color-card-shadow: rgba(1, 7, 11, 0.78);
+  --color-card-shadow-muted: rgba(1, 7, 11, 0.58);
+  --color-card-shadow-soft: rgba(14, 165, 233, 0.4);
 
-  --color-focus-ring: rgba(56, 189, 248, 0.42);
-  --color-code-background: rgba(10, 35, 41, 0.82);
+  --color-focus-ring: rgba(56, 189, 248, 0.5);
+  --color-code-background: rgba(10, 35, 41, 0.88);
 }
 
 :root[data-mode='dark'][data-theme='velvet'] {
@@ -1424,70 +1424,70 @@ textarea:focus {
   --body-gradient-end: #08010a;
 
   --color-surface: #240b20;
-  --color-header-background: rgba(36, 11, 32, 0.92);
+  --color-header-background: rgba(36, 11, 32, 0.95);
   --color-header-shadow: rgba(8, 1, 10, 0.74);
 
   --color-accent: #f472b6;
   --color-accent-strong: #db2777;
-  --color-accent-soft: rgba(244, 114, 182, 0.28);
-  --color-accent-softer: rgba(219, 39, 119, 0.22);
-  --color-accent-outline: rgba(236, 72, 153, 0.4);
-  --color-accent-border: rgba(244, 114, 182, 0.5);
-  --color-accent-shadow: rgba(131, 24, 67, 0.48);
-  --color-accent-shadow-strong: rgba(236, 72, 153, 0.5);
+  --color-accent-soft: rgba(244, 114, 182, 0.34);
+  --color-accent-softer: rgba(219, 39, 119, 0.26);
+  --color-accent-outline: rgba(236, 72, 153, 0.48);
+  --color-accent-border: rgba(244, 114, 182, 0.6);
+  --color-accent-shadow: rgba(131, 24, 67, 0.54);
+  --color-accent-shadow-strong: rgba(236, 72, 153, 0.56);
 
-  --color-inline-tag-background: rgba(236, 72, 153, 0.28);
-  --color-inline-tag-text: #fdf2f8;
-  --color-surface-highlight: rgba(236, 72, 153, 0.28);
+  --color-inline-tag-background: rgba(236, 72, 153, 0.34);
+  --color-inline-tag-text: #fde8f3;
+  --color-surface-highlight: rgba(236, 72, 153, 0.34);
 
-  --color-border: rgba(236, 72, 153, 0.28);
-  --color-border-strong: rgba(236, 72, 153, 0.42);
-  --color-border-muted: rgba(236, 72, 153, 0.22);
-  --color-neutral-soft: rgba(236, 72, 153, 0.25);
-  --color-card-shadow: rgba(8, 1, 10, 0.72);
-  --color-card-shadow-muted: rgba(8, 1, 10, 0.52);
-  --color-card-shadow-soft: rgba(236, 72, 153, 0.35);
+  --color-border: rgba(236, 72, 153, 0.38);
+  --color-border-strong: rgba(236, 72, 153, 0.52);
+  --color-border-muted: rgba(236, 72, 153, 0.3);
+  --color-neutral-soft: rgba(236, 72, 153, 0.32);
+  --color-card-shadow: rgba(8, 1, 10, 0.76);
+  --color-card-shadow-muted: rgba(8, 1, 10, 0.56);
+  --color-card-shadow-soft: rgba(236, 72, 153, 0.4);
 
-  --color-focus-ring: rgba(236, 72, 153, 0.38);
-  --color-code-background: rgba(44, 10, 36, 0.82);
+  --color-focus-ring: rgba(236, 72, 153, 0.46);
+  --color-code-background: rgba(44, 10, 36, 0.86);
 }
 
 :root[data-mode='sepia'] {
-  --color-text-primary: #433026;
-  --color-text-strong: #2f2018;
-  --color-text-secondary: #5a4031;
-  --color-text-tertiary: #6c4e3b;
-  --color-text-muted: #8a6349;
-  --color-text-badge: #5c4031;
-  --color-text-soft: #8b6349;
-  --color-text-instruction: #714e38;
-  --color-text-inline: #70492f;
-  --color-tag-text: #5c2f1f;
+  --color-text-primary: #2b1a11;
+  --color-text-strong: #1e120b;
+  --color-text-secondary: #4a3121;
+  --color-text-tertiary: #5b3a27;
+  --color-text-muted: #704a33;
+  --color-text-badge: #3c2619;
+  --color-text-soft: #704a33;
+  --color-text-instruction: #5a3a25;
+  --color-text-inline: #5b331c;
+  --color-tag-text: #4a2517;
   --color-text-inverse: #fdf4e7;
-  --color-text-emphasis: #2f2018;
+  --color-text-emphasis: #1e120b;
 
-  --color-surface: #fff7ec;
-  --color-surface-soft: rgba(139, 99, 73, 0.08);
-  --color-surface-highlight: rgba(193, 140, 98, 0.16);
-  --color-header-background: rgba(255, 247, 236, 0.88);
-  --color-header-shadow: rgba(68, 49, 37, 0.32);
+  --color-surface: #fff6e6;
+  --color-surface-soft: rgba(112, 74, 51, 0.1);
+  --color-surface-highlight: rgba(193, 140, 98, 0.2);
+  --color-header-background: rgba(255, 247, 236, 0.94);
+  --color-header-shadow: rgba(68, 49, 37, 0.36);
 
-  --color-border: rgba(193, 140, 98, 0.35);
-  --color-border-strong: rgba(193, 140, 98, 0.5);
-  --color-border-muted: rgba(193, 140, 98, 0.24);
-  --color-code-background: rgba(255, 243, 223, 0.92);
-  --color-inline-tag-background: rgba(193, 140, 98, 0.22);
-  --color-inline-tag-text: #4f3324;
-  --color-neutral-soft: rgba(126, 87, 57, 0.2);
+  --color-border: rgba(193, 140, 98, 0.48);
+  --color-border-strong: rgba(193, 140, 98, 0.62);
+  --color-border-muted: rgba(193, 140, 98, 0.28);
+  --color-code-background: rgba(255, 241, 215, 0.95);
+  --color-inline-tag-background: rgba(193, 140, 98, 0.26);
+  --color-inline-tag-text: #452916;
+  --color-neutral-soft: rgba(126, 87, 57, 0.26);
 
-  --color-card-shadow: rgba(68, 49, 37, 0.22);
-  --color-card-shadow-muted: rgba(68, 49, 37, 0.16);
-  --color-card-shadow-soft: rgba(193, 140, 98, 0.25);
+  --color-card-shadow: rgba(68, 49, 37, 0.26);
+  --color-card-shadow-muted: rgba(68, 49, 37, 0.18);
+  --color-card-shadow-soft: rgba(193, 140, 98, 0.3);
 
-  --color-danger: #c7503b;
-  --color-danger-soft: rgba(199, 80, 59, 0.22);
+  --color-danger: #b8432e;
+  --color-danger-soft: rgba(184, 67, 46, 0.26);
 
-  --color-focus-ring: rgba(193, 140, 98, 0.28);
+  --color-focus-ring: rgba(193, 140, 98, 0.34);
 }
 
 :root[data-mode='sepia'][data-theme='classic'] {
@@ -1496,33 +1496,33 @@ textarea:focus {
   --body-gradient-mid: #f0e2cd;
   --body-gradient-end: #e2c9a9;
 
-  --color-header-background: rgba(255, 246, 232, 0.92);
+  --color-header-background: rgba(255, 246, 232, 0.95);
 
   --color-accent: #b7791f;
   --color-accent-strong: #d8a441;
-  --color-accent-soft: rgba(183, 121, 31, 0.18);
-  --color-accent-softer: rgba(183, 121, 31, 0.12);
-  --color-accent-outline: rgba(183, 121, 31, 0.28);
-  --color-accent-border: rgba(226, 177, 94, 0.55);
-  --color-accent-shadow: rgba(183, 121, 31, 0.38);
-  --color-accent-shadow-strong: rgba(183, 121, 31, 0.46);
+  --color-accent-soft: rgba(183, 121, 31, 0.24);
+  --color-accent-softer: rgba(183, 121, 31, 0.16);
+  --color-accent-outline: rgba(183, 121, 31, 0.32);
+  --color-accent-border: rgba(226, 177, 94, 0.65);
+  --color-accent-shadow: rgba(183, 121, 31, 0.44);
+  --color-accent-shadow-strong: rgba(183, 121, 31, 0.5);
 
-  --color-inline-tag-background: rgba(226, 177, 94, 0.22);
-  --color-inline-tag-text: #5c3b1d;
+  --color-inline-tag-background: rgba(226, 177, 94, 0.3);
+  --color-inline-tag-text: #503213;
 
-  --color-surface-soft: rgba(183, 121, 31, 0.06);
-  --color-surface-highlight: rgba(226, 177, 94, 0.16);
+  --color-surface-soft: rgba(183, 121, 31, 0.1);
+  --color-surface-highlight: rgba(226, 177, 94, 0.2);
 
-  --color-border: rgba(226, 177, 94, 0.32);
-  --color-border-strong: rgba(226, 177, 94, 0.46);
-  --color-border-muted: rgba(226, 177, 94, 0.22);
-  --color-code-background: rgba(255, 244, 224, 0.94);
+  --color-border: rgba(226, 177, 94, 0.45);
+  --color-border-strong: rgba(226, 177, 94, 0.58);
+  --color-border-muted: rgba(226, 177, 94, 0.28);
+  --color-code-background: rgba(255, 244, 224, 0.96);
 
-  --color-card-shadow: rgba(92, 63, 36, 0.2);
-  --color-card-shadow-muted: rgba(92, 63, 36, 0.15);
-  --color-card-shadow-soft: rgba(226, 177, 94, 0.24);
+  --color-card-shadow: rgba(92, 63, 36, 0.28);
+  --color-card-shadow-muted: rgba(92, 63, 36, 0.18);
+  --color-card-shadow-soft: rgba(226, 177, 94, 0.3);
 
-  --color-focus-ring: rgba(183, 121, 31, 0.3);
+  --color-focus-ring: rgba(183, 121, 31, 0.36);
 }
 
 :root[data-mode='sepia'][data-theme='copper'] {
@@ -1531,33 +1531,33 @@ textarea:focus {
   --body-gradient-mid: #f3d3ba;
   --body-gradient-end: #e6b996;
 
-  --color-header-background: rgba(241, 228, 214, 0.92);
+  --color-header-background: rgba(241, 228, 214, 0.95);
 
   --color-accent: #c26a3d;
   --color-accent-strong: #e2814a;
-  --color-accent-soft: rgba(194, 106, 61, 0.2);
-  --color-accent-softer: rgba(226, 129, 74, 0.14);
-  --color-accent-outline: rgba(226, 129, 74, 0.28);
-  --color-accent-border: rgba(234, 173, 137, 0.55);
-  --color-accent-shadow: rgba(168, 78, 44, 0.4);
-  --color-accent-shadow-strong: rgba(226, 129, 74, 0.45);
+  --color-accent-soft: rgba(194, 106, 61, 0.32);
+  --color-accent-softer: rgba(226, 129, 74, 0.2);
+  --color-accent-outline: rgba(226, 129, 74, 0.36);
+  --color-accent-border: rgba(234, 173, 137, 0.65);
+  --color-accent-shadow: rgba(168, 78, 44, 0.52);
+  --color-accent-shadow-strong: rgba(226, 129, 74, 0.52);
 
-  --color-inline-tag-background: rgba(234, 173, 137, 0.24);
-  --color-inline-tag-text: #6f3a23;
+  --color-inline-tag-background: rgba(234, 173, 137, 0.3);
+  --color-inline-tag-text: #5c2d18;
 
-  --color-surface-soft: rgba(194, 106, 61, 0.08);
-  --color-surface-highlight: rgba(234, 173, 137, 0.2);
+  --color-surface-soft: rgba(194, 106, 61, 0.1);
+  --color-surface-highlight: rgba(234, 173, 137, 0.26);
 
-  --color-border: rgba(234, 173, 137, 0.32);
-  --color-border-strong: rgba(234, 173, 137, 0.46);
-  --color-border-muted: rgba(234, 173, 137, 0.22);
-  --color-code-background: rgba(252, 235, 216, 0.94);
+  --color-border: rgba(234, 173, 137, 0.45);
+  --color-border-strong: rgba(234, 173, 137, 0.6);
+  --color-border-muted: rgba(234, 173, 137, 0.3);
+  --color-code-background: rgba(252, 235, 216, 0.96);
 
-  --color-card-shadow: rgba(104, 59, 39, 0.22);
-  --color-card-shadow-muted: rgba(104, 59, 39, 0.16);
-  --color-card-shadow-soft: rgba(234, 173, 137, 0.26);
+  --color-card-shadow: rgba(104, 59, 39, 0.28);
+  --color-card-shadow-muted: rgba(104, 59, 39, 0.2);
+  --color-card-shadow-soft: rgba(234, 173, 137, 0.32);
 
-  --color-focus-ring: rgba(226, 129, 74, 0.3);
+  --color-focus-ring: rgba(226, 129, 74, 0.36);
 }
 
 :root[data-mode='sepia'][data-theme='umber'] {
@@ -1566,31 +1566,31 @@ textarea:focus {
   --body-gradient-mid: #e1c9a9;
   --body-gradient-end: #cfab87;
 
-  --color-header-background: rgba(233, 221, 202, 0.9);
+  --color-header-background: rgba(233, 221, 202, 0.94);
 
   --color-accent: #8a4b2a;
   --color-accent-strong: #b56a3a;
-  --color-accent-soft: rgba(138, 75, 42, 0.2);
-  --color-accent-softer: rgba(181, 106, 58, 0.16);
-  --color-accent-outline: rgba(181, 106, 58, 0.3);
-  --color-accent-border: rgba(204, 154, 120, 0.58);
-  --color-accent-shadow: rgba(92, 47, 26, 0.4);
-  --color-accent-shadow-strong: rgba(181, 106, 58, 0.45);
+  --color-accent-soft: rgba(138, 75, 42, 0.28);
+  --color-accent-softer: rgba(181, 106, 58, 0.22);
+  --color-accent-outline: rgba(181, 106, 58, 0.36);
+  --color-accent-border: rgba(204, 154, 120, 0.6);
+  --color-accent-shadow: rgba(92, 47, 26, 0.5);
+  --color-accent-shadow-strong: rgba(181, 106, 58, 0.52);
 
-  --color-inline-tag-background: rgba(204, 154, 120, 0.26);
-  --color-inline-tag-text: #42210f;
+  --color-inline-tag-background: rgba(204, 154, 120, 0.34);
+  --color-inline-tag-text: #3e1f0d;
 
-  --color-surface-soft: rgba(138, 75, 42, 0.08);
-  --color-surface-highlight: rgba(204, 154, 120, 0.22);
+  --color-surface-soft: rgba(138, 75, 42, 0.1);
+  --color-surface-highlight: rgba(204, 154, 120, 0.28);
 
-  --color-border: rgba(204, 154, 120, 0.34);
-  --color-border-strong: rgba(204, 154, 120, 0.48);
-  --color-border-muted: rgba(204, 154, 120, 0.22);
-  --color-code-background: rgba(245, 226, 203, 0.94);
+  --color-border: rgba(204, 154, 120, 0.45);
+  --color-border-strong: rgba(204, 154, 120, 0.6);
+  --color-border-muted: rgba(204, 154, 120, 0.3);
+  --color-code-background: rgba(245, 226, 203, 0.96);
 
-  --color-card-shadow: rgba(74, 41, 24, 0.22);
-  --color-card-shadow-muted: rgba(74, 41, 24, 0.16);
-  --color-card-shadow-soft: rgba(204, 154, 120, 0.26);
+  --color-card-shadow: rgba(74, 41, 24, 0.28);
+  --color-card-shadow-muted: rgba(74, 41, 24, 0.2);
+  --color-card-shadow-soft: rgba(204, 154, 120, 0.32);
 
-  --color-focus-ring: rgba(181, 106, 58, 0.32);
+  --color-focus-ring: rgba(181, 106, 58, 0.38);
 }


### PR DESCRIPTION
## Summary
- darkened the default palette text, accent, and border variables to create higher contrast across the interface
- strengthened light, dark, and sepia theme variants with bolder accent, border, and highlight values for clearer separation of surfaces

## Testing
- No tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf2e82a4888325810decb814f9e150