### PR TITLE
Refactor pantry into dedicated inventory view

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
                 >
                   Meal Library
                 </button>
-                <button type="button" class="view-toggle__button" data-view-target="ingredients">
-                  Ingredient Directory
+                <button type="button" class="view-toggle__button" data-view-target="pantry">
+                  Pantry
                 </button>
               </div>
               <details class="settings-panel" id="settings-panel">
@@ -70,102 +70,86 @@
           </div>
         </div>
       </header>
-      <main class="layout" id="meal-view">
+      <main class="layout" id="app-layout">
         <aside class="filter-panel" id="filter-panel">
           <div class="panel-header">
-            <h2>Filter Meals</h2>
+            <h2 id="filter-panel-title">Filter Meals</h2>
             <button type="button" class="reset-button" id="reset-filters">Reset</button>
           </div>
           <label class="input-group">
-            <span>Search</span>
-            <input type="search" id="filter-search" placeholder="Search by name, description, or tag" />
+            <span id="filter-search-label">Search</span>
+            <input
+              type="search"
+              id="filter-search"
+              placeholder="Search by name, description, or tag"
+              aria-describedby="filter-search-label"
+            />
           </label>
-          <details class="filter-section" open>
-            <summary>Protein</summary>
+          <details class="filter-section" open id="protein-section">
+            <summary id="protein-summary">Protein</summary>
             <div class="filter-section__content">
               <div class="checkbox-grid" id="protein-options"></div>
             </div>
           </details>
-          <details class="filter-section" open>
-            <summary>Tags</summary>
+          <details class="filter-section" open id="tag-section">
+            <summary id="tag-summary">Tags</summary>
             <div class="filter-section__content">
               <div class="checkbox-grid" id="tag-options"></div>
             </div>
           </details>
-          <details class="filter-section" open>
-            <summary>Allergies to Avoid</summary>
+          <details class="filter-section" open id="allergy-section">
+            <summary id="allergy-summary">Allergies to Avoid</summary>
             <div class="filter-section__content">
               <div class="checkbox-grid" id="allergy-options"></div>
             </div>
           </details>
-          <details class="filter-section" open>
-            <summary>Equipment</summary>
+          <details class="filter-section" open id="equipment-section">
+            <summary id="equipment-summary">Equipment</summary>
             <div class="filter-section__content">
               <div class="checkbox-grid" id="equipment-options"></div>
             </div>
           </details>
         </aside>
-        <section class="content">
+        <section class="content" id="meal-view">
           <div class="content-header">
             <h2>Meal Library</h2>
             <p id="meal-count">0 meals match your filters.</p>
           </div>
           <div class="meal-grid" id="meal-grid"></div>
         </section>
-        <aside class="pantry-panel">
-          <h2>Your Pantry</h2>
-          <form class="pantry-form" id="pantry-form">
-            <input id="pantry-input" placeholder="Add an ingredient (e.g., chicken, cumin)" />
-            <button type="submit">Add Item</button>
-          </form>
-          <ul class="pantry-list" id="pantry-list"></ul>
-          <div class="cookable-toggle">
-            <label>
-              <input type="checkbox" id="show-cookable" />
-              Show only cookable meals
-            </label>
-          </div>
-          <section class="cookable-list">
-            <h3>
-              Meals you can make (<span id="cookable-count">0</span>)
-            </h3>
-            <div id="cookable-results"></div>
-          </section>
-        </aside>
-      </main>
-      <main class="ingredients-layout" id="ingredient-view" hidden>
-        <section class="ingredient-directory">
-          <header class="ingredient-directory__header">
+        <section class="pantry-view" id="pantry-view" hidden>
+          <header class="pantry-view__header">
             <div>
-              <h2>Ingredient Directory</h2>
-              <p>Browse pantry staples, herbs, produce, and more with quick allergen-friendly filters.</p>
+              <h2>Pantry</h2>
+              <p>Adjust quantities for every ingredient you keep on hand.</p>
             </div>
-            <div class="ingredient-directory__summary">
-              <span id="ingredient-count">0</span>
-              <p>ingredients match your filters</p>
+            <div class="pantry-view__summary">
+              <span id="pantry-count">0</span>
+              <p>items match your filters</p>
             </div>
           </header>
-          <div class="ingredient-directory__controls">
-            <label class="ingredient-directory__control">
-              <span>Category</span>
-              <select id="ingredient-category"></select>
-            </label>
-            <label class="ingredient-directory__control ingredient-directory__control--search">
-              <span>Search</span>
-              <input type="search" id="ingredient-search" placeholder="Search name, slug, or tag" />
-            </label>
-            <label class="ingredient-directory__toggle">
-              <input type="checkbox" id="ingredient-gluten-free" />
-              <span>Gluten-Free only</span>
-            </label>
-            <label class="ingredient-directory__toggle">
-              <input type="checkbox" id="ingredient-vegan" />
-              <span>Vegan only</span>
-            </label>
-          </div>
-          <div class="ingredient-grid" id="ingredient-grid"></div>
+          <div class="pantry-grid" id="pantry-grid"></div>
         </section>
       </main>
+      <datalist id="pantry-unit-options">
+        <option value="each"></option>
+        <option value="oz"></option>
+        <option value="gram"></option>
+        <option value="kilogram"></option>
+        <option value="pound"></option>
+        <option value="tsp"></option>
+        <option value="tbsp"></option>
+        <option value="cup"></option>
+        <option value="quart"></option>
+        <option value="liter"></option>
+        <option value="ml"></option>
+        <option value="jar"></option>
+        <option value="box"></option>
+        <option value="bag"></option>
+        <option value="can"></option>
+        <option value="bottle"></option>
+        <option value="pack"></option>
+      </datalist>
     </div>
     <script src="data/ingredients.js"></script>
     <script src="data/recipes.js"></script>

--- a/styles/app.css
+++ b/styles/app.css
@@ -355,15 +355,15 @@ select {
 
 .layout {
   display: grid;
-  grid-template-columns: minmax(240px, 320px) 1fr minmax(240px, 320px);
+  grid-template-columns: minmax(240px, 320px) 1fr;
   gap: 1.75rem;
   padding: 2rem 3rem 3rem;
   align-items: flex-start;
 }
 
 .filter-panel,
-.pantry-panel,
-.meal-card {
+.meal-card,
+.pantry-view {
   background: var(--color-surface);
   border-radius: 18px;
   box-shadow: 0 22px 45px -30px var(--color-card-shadow);
@@ -407,8 +407,7 @@ select {
   gap: 0.4rem;
 }
 
-.input-group input,
-.pantry-form input {
+.input-group input {
   border: 1px solid var(--color-border);
   border-radius: 12px;
   padding: 0.6rem 0.75rem;
@@ -416,7 +415,6 @@ select {
 }
 
 .input-group input:focus,
-.pantry-form input:focus,
 .serving-controls input:focus,
 textarea:focus {
   outline: none;
@@ -707,74 +705,144 @@ textarea:focus {
   resize: vertical;
 }
 
-.pantry-panel {
+.pantry-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
   padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
   max-height: calc(100vh - 6rem);
-  overflow-y: auto;
+  overflow: hidden;
 }
 
-.pantry-panel h2 {
-  margin: 0;
-}
-
-.pantry-form {
-  display: flex;
-  gap: 0.6rem;
-}
-
-.pantry-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-}
-
-.pantry-list li {
+.pantry-view__header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  padding: 0.4rem 0.55rem;
-  background: var(--color-accent-softer);
-  border-radius: 10px;
-  color: var(--color-text-badge);
+  gap: 1.5rem;
+  align-items: flex-start;
 }
 
-.pantry-list button {
-  background: none;
-  border: none;
-  color: var(--color-danger);
-  cursor: pointer;
-  font-weight: 600;
-}
-
-.cookable-toggle {
-  padding: 0.6rem 0.75rem;
-  background: var(--color-accent-softer);
-  border-radius: 12px;
-}
-
-.cookable-toggle label {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  font-weight: 600;
-}
-
-.cookable-list h3 {
-  margin: 0 0 0.5rem;
-}
-
-.cookable-list ul {
+.pantry-view__header h2 {
   margin: 0;
-  padding-left: 1rem;
+  font-size: 1.6rem;
+}
+
+.pantry-view__header p {
+  margin: 0.4rem 0 0;
+  color: var(--color-text-tertiary);
+}
+
+.pantry-view__summary {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.2rem;
+  color: var(--color-text-muted);
+}
+
+.pantry-view__summary span {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-accent);
+}
+
+.pantry-grid {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.pantry-card {
+  background: var(--color-surface-soft);
+  border-radius: 16px;
+  padding: 1.1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pantry-card:focus-within {
+  border-color: var(--color-accent-border);
+  box-shadow: 0 12px 28px -20px var(--color-card-shadow-soft);
+}
+
+.pantry-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.pantry-card__header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.pantry-card__header code {
+  display: inline-block;
+  margin-top: 0.4rem;
+  font-size: 0.8rem;
+  background: var(--color-code-background);
+  color: var(--color-text-inline);
+  padding: 0.2rem 0.4rem;
+  border-radius: 6px;
+}
+
+.pantry-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.pantry-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.pantry-card__tags span {
+  background: var(--color-inline-tag-background);
+  color: var(--color-inline-tag-text);
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.78rem;
+}
+
+.pantry-card__controls {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  align-items: end;
+}
+
+.pantry-card__control {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.pantry-card__control input,
+.pantry-card__control select {
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 0.5rem 0.6rem;
+  font-size: 0.95rem;
+}
+
+.pantry-card__control input[type='number'] {
+  appearance: textfield;
+}
+
+.pantry-card__control input[type='number']::-webkit-inner-spin-button,
+.pantry-card__control input[type='number']::-webkit-outer-spin-button {
+  appearance: none;
+  margin: 0;
 }
 
 .empty,
@@ -795,7 +863,7 @@ textarea:focus {
     grid-template-columns: minmax(240px, 300px) 1fr;
   }
 
-  .pantry-panel {
+  .pantry-view {
     position: sticky;
     top: 5.5rem;
   }
@@ -807,7 +875,7 @@ textarea:focus {
   }
 
   .filter-panel,
-  .pantry-panel {
+  .pantry-view {
     position: static;
     max-height: none;
   }
@@ -862,189 +930,6 @@ textarea:focus {
 
 .view-toggle__button--active:hover {
   box-shadow: 0 18px 35px -20px var(--color-accent-shadow-strong);
-}
-
-.ingredients-layout {
-  padding: 2rem 3rem 3rem;
-  display: flex;
-  justify-content: center;
-}
-
-.ingredient-directory {
-  width: 100%;
-  max-width: 1100px;
-  display: flex;
-  flex-direction: column;
-  gap: 1.6rem;
-}
-
-.ingredient-directory__header {
-  display: flex;
-  justify-content: space-between;
-  gap: 1.2rem;
-  flex-wrap: wrap;
-  align-items: flex-start;
-}
-
-.ingredient-directory__header h2 {
-  margin: 0;
-  font-size: 1.8rem;
-}
-
-.ingredient-directory__header p {
-  margin: 0.4rem 0 0;
-  color: var(--color-text-tertiary);
-  max-width: 640px;
-}
-
-.ingredient-directory__summary {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.2rem;
-  background: var(--color-accent-softer);
-  padding: 0.8rem 1rem;
-  border-radius: 16px;
-}
-
-.ingredient-directory__summary span {
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--color-accent);
-  line-height: 1;
-}
-
-.ingredient-directory__summary p {
-  margin: 0;
-  font-size: 0.85rem;
-  color: var(--color-text-badge);
-}
-
-.ingredient-directory__controls {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-  align-items: end;
-}
-
-.ingredient-directory__control {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-.ingredient-directory__control select,
-.ingredient-directory__control input {
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: 0.6rem 0.75rem;
-  background: var(--color-surface);
-}
-
-.ingredient-directory__control--search {
-  grid-column: span 2;
-}
-
-.ingredient-directory__toggle {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.65rem 0.85rem;
-  border: 1px solid var(--color-border);
-  border-radius: 14px;
-  background: var(--color-surface-soft);
-  color: var(--color-text-badge);
-}
-
-.ingredient-directory__toggle input {
-  accent-color: var(--color-accent);
-}
-
-.ingredient-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 1.2rem;
-}
-
-.ingredient-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border-strong);
-  border-radius: 16px;
-  padding: 1.1rem 1.2rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.8rem;
-  box-shadow: 0 22px 45px -30px var(--color-card-shadow-muted);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.ingredient-card:hover {
-  transform: translateY(-2px);
-  border-color: var(--color-accent-border);
-  box-shadow: 0 26px 45px -24px var(--color-card-shadow-soft);
-}
-
-.ingredient-card__header {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.6rem;
-  align-items: baseline;
-}
-
-.ingredient-card__header h3 {
-  margin: 0;
-  font-size: 1.2rem;
-}
-
-.ingredient-card__header code {
-  background: var(--color-code-background);
-  color: var(--color-text-secondary);
-  padding: 0.25rem 0.6rem;
-  border-radius: 8px;
-  font-size: 0.8rem;
-}
-
-.ingredient-card__meta {
-  display: flex;
-  justify-content: flex-start;
-}
-
-.ingredient-card__tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.ingredient-tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25rem 0.65rem;
-  border-radius: 999px;
-  background: var(--color-inline-tag-background);
-  border: 1px solid var(--color-accent-border);
-  color: var(--color-tag-text);
-  font-size: 0.78rem;
-  font-weight: 600;
-}
-
-.ingredient-directory__empty {
-  grid-column: 1 / -1;
-  background: var(--color-surface);
-  border: 1px dashed var(--color-border);
-  border-radius: 16px;
-  padding: 2rem;
-  text-align: center;
-  color: var(--color-text-secondary);
-}
-
-@media (max-width: 768px) {
-  .ingredient-directory__control--search {
-    grid-column: span 1;
-  }
-
-  .ingredients-layout {
-    padding: 1.5rem;
-  }
 }
 
 :root[data-mode='light'][data-theme='sunrise'] {


### PR DESCRIPTION
## Summary
- replace the secondary layout with a pantry inventory view that lists every ingredient with adjustable quantity and unit inputs
- repurpose the shared filter panel so search and checkboxes switch between meal filters and pantry filters on view change
- refresh the layout and styling to remove the old pantry sidebar, support the new grid, and keep unit suggestions available via datalist

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cf363d201083259c2a8199ff363402