### PR TITLE
Group meal tags into categorized filter sections

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -493,6 +493,27 @@ textarea:focus {
   gap: 0.4rem;
 }
 
+.tag-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.tag-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.tag-group__title {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+}
+
 .checkbox-option {
   display: flex;
   gap: 0.4rem;


### PR DESCRIPTION
## Summary
- add tag category definitions so meal tags are grouped by meal time, cuisine, season, diet, and more
- render the meal tag filter using grouped sections while keeping pantry tags as a flat grid
- style the new grouped tag layout in the filter panel

## Testing
- node --check scripts/app.js

------
https://chatgpt.com/codex/tasks/task_e_68cfffc7f7fc83259379e48a99ad22ce