### PR TITLE
Adjust pantry controls inline layout

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -889,10 +889,57 @@
     const details = document.createElement('div');
     details.className = 'pantry-card__details';
 
+    const header = document.createElement('div');
+    header.className = 'pantry-card__header';
+
     const title = document.createElement('h3');
     title.className = 'pantry-card__name';
     title.textContent = ingredient.name;
-    details.appendChild(title);
+    header.appendChild(title);
+
+    const inlineControls = document.createElement('div');
+    inlineControls.className = 'pantry-card__inline-controls';
+
+    const quantityInput = document.createElement('input');
+    quantityInput.className = 'pantry-card__inline-input pantry-card__inline-input--quantity';
+    quantityInput.type = 'number';
+    quantityInput.min = '0';
+    quantityInput.step = '0.25';
+    quantityInput.inputMode = 'decimal';
+    quantityInput.autocomplete = 'off';
+    quantityInput.setAttribute('aria-label', `Quantity for ${ingredient.name}`);
+    quantityInput.title = `Quantity for ${ingredient.name}`;
+    if (entry.quantity !== undefined && entry.quantity !== '') {
+      quantityInput.value = entry.quantity;
+    } else {
+      quantityInput.value = '';
+    }
+    quantityInput.placeholder = '0';
+    quantityInput.addEventListener('input', (event) => {
+      updatePantryEntry(ingredient.slug, { quantity: event.target.value });
+    });
+    inlineControls.appendChild(quantityInput);
+
+    const unitInput = document.createElement('input');
+    unitInput.className = 'pantry-card__inline-input pantry-card__inline-input--unit';
+    unitInput.type = 'text';
+    unitInput.setAttribute('list', 'pantry-unit-options');
+    unitInput.placeholder = DEFAULT_PANTRY_UNIT;
+    const normalizedUnit = entry.unit || DEFAULT_PANTRY_UNIT;
+    unitInput.value = normalizedUnit === DEFAULT_PANTRY_UNIT ? '' : normalizedUnit;
+    unitInput.autocomplete = 'off';
+    unitInput.spellcheck = false;
+    unitInput.setAttribute('aria-label', `Unit for ${ingredient.name}`);
+    unitInput.title = `Unit for ${ingredient.name}`;
+    const handleUnitChange = (event) => {
+      updatePantryEntry(ingredient.slug, { unit: event.target.value });
+    };
+    unitInput.addEventListener('input', handleUnitChange);
+    unitInput.addEventListener('change', handleUnitChange);
+    inlineControls.appendChild(unitInput);
+
+    header.appendChild(inlineControls);
+    details.appendChild(header);
 
     if (Array.isArray(ingredient.tags) && ingredient.tags.length) {
       const tags = document.createElement('div');
@@ -906,52 +953,6 @@
     }
 
     card.appendChild(details);
-
-    const controls = document.createElement('div');
-    controls.className = 'pantry-card__controls';
-
-    const quantityControl = document.createElement('label');
-    quantityControl.className = 'pantry-card__control';
-    const quantityLabel = document.createElement('span');
-    quantityLabel.textContent = 'Quantity';
-    const quantityInput = document.createElement('input');
-    quantityInput.type = 'number';
-    quantityInput.min = '0';
-    quantityInput.step = '0.25';
-    quantityInput.inputMode = 'decimal';
-    if (entry.quantity !== undefined && entry.quantity !== '') {
-      quantityInput.value = entry.quantity;
-    } else {
-      quantityInput.value = '';
-    }
-    quantityInput.placeholder = '0';
-    quantityInput.addEventListener('input', (event) => {
-      updatePantryEntry(ingredient.slug, { quantity: event.target.value });
-    });
-    quantityControl.appendChild(quantityLabel);
-    quantityControl.appendChild(quantityInput);
-    controls.appendChild(quantityControl);
-
-    const unitControl = document.createElement('label');
-    unitControl.className = 'pantry-card__control';
-    const unitLabel = document.createElement('span');
-    unitLabel.textContent = 'Unit';
-    const unitInput = document.createElement('input');
-    unitInput.type = 'text';
-    unitInput.setAttribute('list', 'pantry-unit-options');
-    unitInput.placeholder = DEFAULT_PANTRY_UNIT;
-    const normalizedUnit = entry.unit || DEFAULT_PANTRY_UNIT;
-    unitInput.value = normalizedUnit === DEFAULT_PANTRY_UNIT ? '' : normalizedUnit;
-    const handleUnitChange = (event) => {
-      updatePantryEntry(ingredient.slug, { unit: event.target.value });
-    };
-    unitInput.addEventListener('input', handleUnitChange);
-    unitInput.addEventListener('change', handleUnitChange);
-    unitControl.appendChild(unitLabel);
-    unitControl.appendChild(unitInput);
-    controls.appendChild(unitControl);
-
-    card.appendChild(controls);
 
     return card;
   };

--- a/styles/app.css
+++ b/styles/app.css
@@ -807,10 +807,9 @@ textarea:focus {
   background: var(--color-surface-soft);
   border-radius: 16px;
   padding: 1rem 1.2rem;
-  display: grid;
-  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
-  gap: 1.25rem;
-  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
   border: 1px solid transparent;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
@@ -823,13 +822,22 @@ textarea:focus {
 .pantry-card__details {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.6rem;
+}
+
+.pantry-card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .pantry-card__name {
   margin: 0;
   font-size: 1.1rem;
   color: var(--color-text-strong);
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .pantry-card__tags {
@@ -846,38 +854,44 @@ textarea:focus {
   font-size: 0.78rem;
 }
 
-.pantry-card__controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.8rem;
-  justify-content: flex-end;
-  align-items: flex-end;
+.pantry-card__inline-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+  flex: 0 0 auto;
 }
 
-.pantry-card__control {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-  min-width: 120px;
-}
-
-.pantry-card__control input,
-.pantry-card__control select {
+.pantry-card__inline-input {
   border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: 0.5rem 0.6rem;
-  font-size: 0.95rem;
-  width: 100%;
+  border-radius: 10px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.9rem;
+  background: var(--color-surface);
+  color: var(--color-text-strong);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.pantry-card__control input[type='number'] {
+.pantry-card__inline-input:focus {
+  outline: none;
+  border-color: var(--color-accent-border);
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
+}
+
+.pantry-card__inline-input--quantity {
+  width: 4.5rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
   appearance: textfield;
+  -moz-appearance: textfield;
 }
 
-.pantry-card__control input[type='number']::-webkit-inner-spin-button,
-.pantry-card__control input[type='number']::-webkit-outer-spin-button {
+.pantry-card__inline-input--unit {
+  width: 5.5rem;
+}
+
+.pantry-card__inline-input--quantity::-webkit-inner-spin-button,
+.pantry-card__inline-input--quantity::-webkit-outer-spin-button {
   appearance: none;
   margin: 0;
 }
@@ -921,13 +935,8 @@ textarea:focus {
     grid-template-columns: 1fr;
   }
 
-  .pantry-card {
-    grid-template-columns: 1fr;
-    align-items: stretch;
-  }
-
-  .pantry-card__controls {
-    justify-content: flex-start;
+  .pantry-card__inline-controls {
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- render pantry quantity and unit inputs inline with item titles and remove redundant text labels while keeping accessibility hints
- restyle pantry cards so the compact inputs align beside the ingredient name and respond gracefully on smaller screens

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d005d5c6d08325b00c28fa41ba150e