### PR TITLE
Add settings gear menu and measurement toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,51 +13,87 @@
         <div class="header-grid">
           <div class="header-grid__secondary">
             <div class="menu-column">
-              <div class="view-toggle">
-                <button
-                  type="button"
-                  class="view-toggle__button view-toggle__button--active"
-                  data-view-target="meals"
-                >
-                  Meal Library
-                </button>
-                <button type="button" class="view-toggle__button" data-view-target="pantry">
-                  Pantry
-                </button>
-              </div>
-              <details class="settings-panel" id="settings-panel">
-                <summary class="settings-panel__summary">
-                  <span class="settings-panel__label">Display Settings</span>
-                  <span class="settings-panel__chevron" aria-hidden="true"></span>
-                </summary>
-                <div class="settings-panel__content">
-                  <div class="theme-toolbar" id="theme-toolbar">
-                    <div class="theme-toolbar__group">
-                      <span class="theme-toolbar__label">Mode</span>
-                      <div class="theme-toolbar__options" id="mode-toggle">
-                        <button
-                          type="button"
-                          class="mode-toggle__button mode-toggle__button--active"
-                          data-mode="light"
-                          aria-pressed="true"
-                        >
-                          Light
-                        </button>
-                        <button type="button" class="mode-toggle__button" data-mode="dark" aria-pressed="false">
-                          Dark
-                        </button>
-                        <button type="button" class="mode-toggle__button" data-mode="sepia" aria-pressed="false">
-                          Sepia
-                        </button>
+              <div class="menu-column__row">
+                <div class="view-toggle">
+                  <button
+                    type="button"
+                    class="view-toggle__button view-toggle__button--active"
+                    data-view-target="meals"
+                  >
+                    Recipes
+                  </button>
+                  <button type="button" class="view-toggle__button" data-view-target="pantry">
+                    Pantry
+                  </button>
+                </div>
+                <details class="settings-panel" id="settings-panel">
+                  <summary
+                    class="settings-panel__summary"
+                    aria-label="Display and unit settings"
+                    aria-haspopup="true"
+                    title="Display and unit settings"
+                  >
+                    <span class="settings-panel__icon" aria-hidden="true">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          d="M11.997 2.25a.75.75 0 0 0-.75.75v1.013a8.71 8.71 0 0 0-1.951.563l-.717-.717a.75.75 0 0 0-1.061 0l-1.06 1.06a.75.75 0 0 0 0 1.062l.717.717a8.71 8.71 0 0 0-.563 1.95H5.25a.75.75 0 0 0-.75.75v1.5c0 .414.336.75.75.75h1.013c.126.673.34 1.316.633 1.913l-.717.717a.75.75 0 0 0 0 1.061l1.06 1.061c.293.293.768.293 1.061 0l.717-.717c.597.293 1.24.507 1.913.633v1.013c0 .414.336.75.75.75h1.5a.75.75 0 0 0 .75-.75v-1.013a8.71 8.71 0 0 0 1.95-.563l.717.717c.293.293.768.293 1.061 0l1.061-1.06a.75.75 0 0 0 0-1.062l-.717-.717a8.71 8.71 0 0 0 .563-1.95h1.013a.75.75 0 0 0 .75-.75v-1.5a.75.75 0 0 0-.75-.75h-1.013a8.71 8.71 0 0 0-.563-1.95l.717-.717a.75.75 0 0 0 0-1.061l-1.06-1.061a.75.75 0 0 0-1.062 0l-.717.717a8.71 8.71 0 0 0-1.95-.563V3a.75.75 0 0 0-.75-.75h-1.5z"
+                        ></path>
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"></path>
+                      </svg>
+                    </span>
+                  </summary>
+                  <div class="settings-panel__content">
+                    <div class="theme-toolbar" id="theme-toolbar">
+                      <div class="theme-toolbar__group">
+                        <span class="theme-toolbar__label">Mode</span>
+                        <div class="theme-toolbar__options" id="mode-toggle">
+                          <button
+                            type="button"
+                            class="mode-toggle__button mode-toggle__button--active"
+                            data-mode="light"
+                            aria-pressed="true"
+                          >
+                            Light
+                          </button>
+                          <button type="button" class="mode-toggle__button" data-mode="dark" aria-pressed="false">
+                            Dark
+                          </button>
+                          <button type="button" class="mode-toggle__button" data-mode="sepia" aria-pressed="false">
+                            Sepia
+                          </button>
+                        </div>
+                      </div>
+                      <div class="theme-toolbar__group">
+                        <span class="theme-toolbar__label">Palette</span>
+                        <div class="theme-toolbar__options theme-toolbar__options--themes" id="theme-options"></div>
+                      </div>
+                      <div class="theme-toolbar__group">
+                        <span class="theme-toolbar__label">Units</span>
+                        <div class="theme-toolbar__options" id="measurement-toggle">
+                          <button
+                            type="button"
+                            class="mode-toggle__button measurement-toggle__button"
+                            data-measurement="imperial"
+                            aria-pressed="false"
+                          >
+                            Imperial
+                          </button>
+                          <button
+                            type="button"
+                            class="mode-toggle__button measurement-toggle__button"
+                            data-measurement="metric"
+                            aria-pressed="false"
+                          >
+                            Metric
+                          </button>
+                        </div>
                       </div>
                     </div>
-                    <div class="theme-toolbar__group">
-                      <span class="theme-toolbar__label">Palette</span>
-                      <div class="theme-toolbar__options theme-toolbar__options--themes" id="theme-options"></div>
-                    </div>
                   </div>
-                </div>
-              </details>
+                </details>
+              </div>
             </div>
           </div>
         </div>
@@ -65,7 +101,7 @@
       <main class="layout" id="app-layout">
         <aside class="filter-panel" id="filter-panel">
           <div class="panel-header">
-            <h2 id="filter-panel-title">Filter Meals</h2>
+            <h2 id="filter-panel-title">Filter Recipes</h2>
             <button type="button" class="reset-button" id="reset-filters">Reset</button>
           </div>
           <label class="input-group">
@@ -104,8 +140,8 @@
         </aside>
         <section class="content" id="meal-view">
           <div class="content-header">
-            <h2>Meal Library</h2>
-            <p id="meal-count">0 meals match your filters.</p>
+            <h2>Recipes</h2>
+            <p id="meal-count">0 recipes match your filters.</p>
           </div>
           <div class="meal-grid" id="meal-grid"></div>
         </section>

--- a/styles/app.css
+++ b/styles/app.css
@@ -137,79 +137,100 @@ select {
   width: 100%;
 }
 
+.menu-column__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.menu-column__row .view-toggle {
+  flex: 1 1 auto;
+}
+
 .menu-column .view-toggle {
   justify-content: flex-start;
 }
 
 .settings-panel {
-  border: 1px solid var(--color-border);
-  border-radius: 18px;
-  background: var(--color-surface);
-  box-shadow: 0 18px 38px -28px var(--color-card-shadow);
-  width: 100%;
-  max-width: 360px;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.settings-panel[open] {
-  border-color: var(--color-border-strong);
-  box-shadow: 0 24px 46px -30px var(--color-card-shadow);
+  position: relative;
+  margin-left: auto;
+  display: inline-flex;
+  border: none;
+  background: transparent;
+  box-shadow: none;
 }
 
 .settings-panel__summary {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+  justify-content: center;
   list-style: none;
   margin: 0;
-  padding: 0.85rem 1.2rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
   cursor: pointer;
-  font-weight: 600;
   color: var(--color-text-secondary);
-  border-radius: 18px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .settings-panel__summary::-webkit-details-marker {
   display: none;
 }
 
+.settings-panel__summary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px -18px var(--color-card-shadow);
+}
+
 .settings-panel__summary:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 4px;
-  border-radius: 14px;
 }
 
 .settings-panel[open] .settings-panel__summary {
-  color: var(--color-text-strong);
+  background: var(--gradient-accent);
+  color: var(--color-accent-contrast);
+  border-color: transparent;
+  box-shadow: 0 18px 32px -20px var(--color-accent-shadow-strong);
 }
 
-.settings-panel__label {
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.settings-panel__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
 }
 
-.settings-panel__chevron {
-  width: 0.75rem;
-  height: 0.75rem;
-  border-right: 2px solid currentColor;
-  border-bottom: 2px solid currentColor;
-  transform: rotate(45deg);
-  transition: transform 0.2s ease;
-  flex-shrink: 0;
-}
-
-.settings-panel[open] .settings-panel__chevron {
-  transform: rotate(-135deg);
+.settings-panel__icon svg {
+  width: 100%;
+  height: 100%;
 }
 
 .settings-panel__content {
-  border-top: 1px solid var(--color-border-muted);
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  width: min(360px, 85vw);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  background: var(--color-surface);
+  box-shadow: 0 24px 46px -30px var(--color-card-shadow);
   padding: 1.1rem 1.2rem 1.25rem;
-  display: flex;
+  display: none;
   flex-direction: column;
   gap: 1.25rem;
+  z-index: 20;
+}
+
+.settings-panel[open] .settings-panel__content {
+  display: flex;
 }
 
 .settings-panel__content .theme-toolbar {
@@ -229,10 +250,6 @@ select {
 
   .menu-column {
     align-items: stretch;
-  }
-
-  .settings-panel {
-    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the display settings dropdown with an inline gear icon menu next to the view toggle and rename the Meal Library view to Recipes
- add an imperial/metric units preference to the settings menu and persist the selection
- convert ingredient quantities based on the selected units and refresh related labels and layout styles

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d02879ce6c832593e28f1bd34373aa