### PR TITLE
Refactor ingredient matching utilities and add tests

### DIFF
--- a/data/recipes.js
+++ b/data/recipes.js
@@ -117,7 +117,7 @@ window.BLISSFUL_RECIPES = [
       'Fold in spinach until wilted, finish with lemon juice and cilantro, and adjust seasoning before serving.',
     ],
     equipment: ['Dutch Oven', 'Stovetop'],
-    tags: ['Dinner', 'Vegetarian', 'Vegan', 'Gluten Free', 'Soup'],
+    tags: ['Dinner', 'Vegetarian', 'Vegan', 'Gluten Free', 'Soup', 'Winter'],
     nutritionPerServing: {
       calories: 340,
       protein: 18,
@@ -198,7 +198,7 @@ window.BLISSFUL_RECIPES = [
       'Serve immediately with pan juices spooned over each fillet.',
     ],
     equipment: ['Oven', 'Sheet Pan'],
-    tags: ['Dinner', 'Seafood', 'Gluten Free', 'No Dairy', 'Weeknight'],
+    tags: ['Dinner', 'Seafood', 'Gluten Free', 'No Dairy', 'Weeknight', 'Spring'],
     nutritionPerServing: {
       calories: 420,
       protein: 34,

--- a/index.html
+++ b/index.html
@@ -113,10 +113,10 @@
               aria-describedby="filter-search-label"
             />
           </label>
-          <details class="filter-section" open id="protein-section">
-            <summary id="protein-summary">Protein</summary>
+          <details class="filter-section" open id="ingredient-section">
+            <summary id="ingredient-summary">Ingredients</summary>
             <div class="filter-section__content">
-              <div class="checkbox-grid" id="protein-options"></div>
+              <div class="ingredient-groups" id="ingredient-options"></div>
             </div>
           </details>
           <details class="filter-section" open id="tag-section">
@@ -181,6 +181,7 @@
     </div>
     <script src="data/ingredients.js"></script>
     <script src="data/recipes.js"></script>
+    <script src="scripts/ingredient-matching.js"></script>
     <script src="scripts/app.js"></script>
   </body>
 </html>

--- a/scripts/ingredient-matching.js
+++ b/scripts/ingredient-matching.js
@@ -1,0 +1,246 @@
+;(function (global) {
+  const DESCRIPTOR_TOKENS = new Set([
+    'and',
+    'or',
+    'with',
+    'plus',
+    'to',
+    'of',
+    'the',
+    'a',
+    'an',
+    'for',
+    'into',
+    'divided',
+    'peeled',
+    'seeded',
+    'fresh',
+    'dried',
+    'large',
+    'small',
+    'medium',
+    'boneless',
+    'skinless',
+    'extra',
+    'virgin',
+    'chopped',
+    'minced',
+    'sliced',
+    'diced',
+    'shredded',
+    'crushed',
+    'grated',
+    'finely',
+    'roughly',
+    'coarsely',
+    'warm',
+    'cold',
+    'hot',
+    'room',
+    'temperature',
+    'packed',
+    'ripe',
+    'lean',
+    'optional',
+    'halved',
+    'quartered',
+    'trimmed',
+    'rinsed',
+    'drained',
+    'thawed',
+    'softened',
+    'melted',
+    'crumbled',
+    'mashed',
+    'beaten',
+    'zested',
+    'juiced',
+    'wedges',
+    'pieces',
+    'chunks',
+    'strips',
+  ]);
+
+  const sanitizeComparisonText = (value) =>
+    String(value || '')
+      .toLowerCase()
+      .replace(/\([^)]*\)/g, ' ')
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim();
+
+  const expandTokenForms = (token) => {
+    const forms = new Set([token]);
+    if (token.length > 4 && token.endsWith('ies')) {
+      forms.add(`${token.slice(0, -3)}y`);
+    }
+    if (token.length > 4 && token.endsWith('ves')) {
+      forms.add(`${token.slice(0, -3)}f`);
+      forms.add(`${token.slice(0, -3)}fe`);
+    }
+    if (token.length > 3 && token.endsWith('es')) {
+      forms.add(token.slice(0, -2));
+    }
+    if (token.length > 3 && token.endsWith('s')) {
+      forms.add(token.slice(0, -1));
+    }
+    return Array.from(forms);
+  };
+
+  const buildTokenSet = (text) => {
+    const normalized = sanitizeComparisonText(text);
+    if (!normalized) return new Set();
+    const tokens = normalized.split(/\s+/);
+    const result = new Set();
+    tokens.forEach((token) => {
+      if (!token || DESCRIPTOR_TOKENS.has(token)) return;
+      expandTokenForms(token).forEach((form) => result.add(form));
+    });
+    return result;
+  };
+
+  const createIngredientMatcher = (ingredient) => {
+    const nameTokens = buildTokenSet(ingredient.name);
+    const slugText = String(ingredient.slug || '')
+      .split('-')
+      .slice(1)
+      .join(' ');
+    const slugTokens = buildTokenSet(slugText);
+    const tokens = new Set([...nameTokens, ...slugTokens]);
+    if (!tokens.size) {
+      const fallback = sanitizeComparisonText(ingredient.name);
+      if (fallback) {
+        fallback.split(/\s+/).forEach((token) => {
+          if (token) tokens.add(token);
+        });
+      }
+    }
+    const variants = new Set();
+    const normalizedName = sanitizeComparisonText(ingredient.name);
+    if (normalizedName && normalizedName.includes(' ')) {
+      variants.add(normalizedName);
+    }
+    const normalizedSlug = sanitizeComparisonText(slugText);
+    if (normalizedSlug && (normalizedSlug.includes(' ') || tokens.size <= 1)) {
+      variants.add(normalizedSlug);
+    }
+    const essentialTokens = Array.from(tokens);
+    if (essentialTokens.length > 1) {
+      variants.add(essentialTokens.join(' '));
+    } else if (essentialTokens.length === 1) {
+      variants.add(essentialTokens[0]);
+    }
+    return { slug: ingredient.slug, label: ingredient.name, tokens, variants };
+  };
+
+  const doesEntryMatchIngredient = (entry, matcher) => {
+    if (!entry || !matcher) return false;
+    if (matcher.variants) {
+      for (const variant of matcher.variants) {
+        if (!variant) continue;
+        if (entry.text.includes(variant) || variant.includes(entry.text)) {
+          return true;
+        }
+      }
+    }
+    if (matcher.tokens && matcher.tokens.size) {
+      const entryTokens = entry.tokens instanceof Set ? entry.tokens : new Set();
+      if (Array.from(matcher.tokens).every((token) => entryTokens.has(token))) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const createIngredientMatcherIndex = (ingredients) => {
+    const matchers = new Map();
+    const tokenIndex = new Map();
+    const slugsWithoutTokens = new Set();
+
+    (Array.isArray(ingredients) ? ingredients : []).forEach((ingredient) => {
+      if (!ingredient || !ingredient.slug) return;
+      const matcher = createIngredientMatcher(ingredient);
+      matchers.set(ingredient.slug, matcher);
+      const matcherTokens = matcher.tokens instanceof Set ? Array.from(matcher.tokens) : [];
+      if (matcherTokens.length) {
+        matcherTokens.forEach((token) => {
+          if (!token) return;
+          let slugs = tokenIndex.get(token);
+          if (!slugs) {
+            slugs = new Set();
+            tokenIndex.set(token, slugs);
+          }
+          slugs.add(ingredient.slug);
+        });
+      } else {
+        slugsWithoutTokens.add(ingredient.slug);
+      }
+    });
+
+    return { matchers, tokenIndex, slugsWithoutTokens };
+  };
+
+  const prepareEntry = (rawEntry) => ({
+    text: sanitizeComparisonText(rawEntry ? rawEntry.item : ''),
+    tokens: buildTokenSet(rawEntry ? rawEntry.item : ''),
+  });
+
+  const findMatchesForEntries = (entries, index) => {
+    const matchedSlugs = new Set();
+    if (!entries.length) return matchedSlugs;
+
+    const candidateSlugs = new Set();
+    entries.forEach((entry) => {
+      if (!entry || !(entry.tokens instanceof Set)) return;
+      entry.tokens.forEach((token) => {
+        const slugsForToken = index.tokenIndex.get(token);
+        if (slugsForToken) {
+          slugsForToken.forEach((slug) => candidateSlugs.add(slug));
+        }
+      });
+    });
+
+    index.slugsWithoutTokens.forEach((slug) => candidateSlugs.add(slug));
+
+    candidateSlugs.forEach((slug) => {
+      const matcher = index.matchers.get(slug);
+      if (!matcher) return;
+      if (entries.some((entry) => doesEntryMatchIngredient(entry, matcher))) {
+        matchedSlugs.add(slug);
+      }
+    });
+
+    return matchedSlugs;
+  };
+
+  const mapRecipesToIngredientMatches = (recipes, index) => {
+    const recipeIngredientMatches = new Map();
+    const ingredientUsage = new Map();
+    index.matchers.forEach((_, slug) => ingredientUsage.set(slug, false));
+
+    (Array.isArray(recipes) ? recipes : []).forEach((recipe) => {
+      if (!recipe || !recipe.id) return;
+      const entries = (Array.isArray(recipe.ingredients) ? recipe.ingredients : []).map(prepareEntry);
+      const matchedSlugs = findMatchesForEntries(entries, index);
+      matchedSlugs.forEach((slug) => ingredientUsage.set(slug, true));
+      recipeIngredientMatches.set(recipe.id, matchedSlugs);
+    });
+
+    return { recipeIngredientMatches, ingredientUsage };
+  };
+
+  const api = {
+    sanitizeComparisonText,
+    buildTokenSet,
+    createIngredientMatcher,
+    doesEntryMatchIngredient,
+    createIngredientMatcherIndex,
+    mapRecipesToIngredientMatches,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+
+  const existing = global.BlissfulMatching || {};
+  global.BlissfulMatching = Object.assign({}, existing, api);
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/styles/app.css
+++ b/styles/app.css
@@ -45,6 +45,22 @@
     var(--color-accent-secondary-strong)
   );
 
+  --surface-panel-gradient: linear-gradient(
+    160deg,
+    var(--color-accent-soft),
+    var(--color-surface)
+  );
+  --surface-section-gradient: linear-gradient(
+    155deg,
+    var(--color-accent-softer, var(--color-accent-soft)),
+    var(--color-surface-soft)
+  );
+  --surface-card-gradient: linear-gradient(
+    158deg,
+    var(--color-accent-secondary-soft, var(--color-accent-soft)),
+    var(--color-surface)
+  );
+
   --color-neutral-50: #f6f8ff;
   --color-neutral-100: #e5eafe;
   --color-neutral-200: #d2dcfb;
@@ -163,7 +179,7 @@ select {
 }
 
 .menu-column__row .view-toggle {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
 }
 
 .menu-column .view-toggle {
@@ -222,8 +238,8 @@ select {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.55rem;
+  height: 1.55rem;
 }
 
 .settings-panel__icon svg {
@@ -405,16 +421,11 @@ select {
 }
 
 .filter-panel,
-.meal-card,
 .pantry-view {
-  background: linear-gradient(
-    180deg,
-    var(--color-neutral-50, var(--color-surface)),
-    var(--color-surface)
-  );
-  border: 1px solid var(--color-neutral-100, var(--color-border-muted));
+  background: var(--surface-panel-gradient);
+  border: 1px solid var(--color-accent-outline, var(--color-border-muted));
   border-radius: 18px;
-  box-shadow: 0 22px 45px -30px var(--color-card-shadow);
+  box-shadow: 0 24px 48px -28px var(--color-card-shadow);
 }
 
 .filter-panel {
@@ -480,25 +491,17 @@ textarea:focus {
 }
 
 .filter-section {
-  border: 1px solid var(--color-neutral-200, var(--color-border-muted));
+  border: 1px solid var(--color-accent-outline, var(--color-border-muted));
   border-radius: 16px;
   padding: 0.85rem 1rem;
-  background: linear-gradient(
-    135deg,
-    var(--color-neutral-50, var(--color-surface-soft)),
-    var(--color-surface-soft)
-  );
+  background: var(--surface-section-gradient);
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .filter-section[open] {
-  border-color: var(--color-neutral-400, var(--color-border));
-  box-shadow: 0 12px 30px -28px var(--color-card-shadow-soft);
-  background: linear-gradient(
-    135deg,
-    var(--color-neutral-50, var(--color-surface-soft)),
-    var(--color-surface-soft)
-  );
+  border-color: var(--color-accent-border, var(--color-border));
+  box-shadow: 0 16px 32px -28px var(--color-card-shadow-soft);
+  background: linear-gradient(150deg, var(--color-accent-soft), var(--color-surface-soft));
 }
 
 .filter-section summary {
@@ -558,22 +561,140 @@ textarea:focus {
 .tag-groups {
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 0.85rem;
 }
 
 .tag-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
+  border: 1px solid var(--color-accent-outline, var(--color-border-muted));
+  border-radius: 14px;
+  padding: 0.2rem 0.4rem 0.6rem;
+  background: var(--surface-section-gradient);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
-.tag-group__title {
+.tag-group[open] {
+  border-color: var(--color-accent-border, var(--color-border));
+  box-shadow: 0 14px 30px -26px var(--color-card-shadow-soft);
+  background: linear-gradient(150deg, var(--color-accent-soft), var(--color-surface-soft));
+}
+
+.tag-group__summary {
   margin: 0;
-  font-size: 0.8rem;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.4rem;
+  font-size: 0.82rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
-  color: var(--color-text-tertiary);
+  letter-spacing: 0.06em;
   text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  padding: 0.35rem 0.4rem;
+}
+
+.tag-group__summary-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.tag-group__summary-count {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background: var(--color-accent-secondary-soft, var(--color-accent-soft));
+  color: var(--color-accent-secondary-strong, var(--color-text-tertiary));
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+
+.tag-group__summary-count[hidden] {
+  display: none;
+}
+
+.tag-group__summary::-webkit-details-marker {
+  display: none;
+}
+
+.tag-group__summary::after {
+  content: '';
+  width: 0.6rem;
+  height: 0.6rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+  margin-left: auto;
+}
+
+.tag-group[open] .tag-group__summary::after {
+  transform: rotate(-135deg);
+}
+
+.tag-group .checkbox-grid {
+  margin-top: 0.4rem;
+}
+
+.ingredient-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.ingredient-group {
+  border: 1px solid var(--color-accent-outline, var(--color-border-muted));
+  border-radius: 14px;
+  background: var(--surface-section-gradient);
+  padding: 0.25rem 0.45rem 0.75rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.ingredient-group[open] {
+  border-color: var(--color-accent-border, var(--color-border));
+  box-shadow: 0 16px 34px -26px var(--color-card-shadow-soft);
+  background: linear-gradient(150deg, var(--color-accent-soft), var(--color-surface-soft));
+}
+
+.ingredient-group__summary {
+  list-style: none;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--color-accent-secondary, var(--color-text-emphasis));
+  cursor: pointer;
+  padding: 0.35rem 0.4rem;
+}
+
+.ingredient-group__summary::-webkit-details-marker {
+  display: none;
+}
+
+.ingredient-group__summary::after {
+  content: '';
+  width: 0.65rem;
+  height: 0.65rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+  margin-left: auto;
+}
+
+.ingredient-group[open] .ingredient-group__summary::after {
+  transform: rotate(-135deg);
+}
+
+.ingredient-group .checkbox-grid {
+  margin-top: 0.4rem;
 }
 
 .checkbox-option {
@@ -645,10 +766,20 @@ textarea:focus {
 }
 
 .meal-card {
+  background: var(--surface-card-gradient);
+  border: 1px solid var(--color-accent-outline, var(--color-border-muted));
+  border-radius: 18px;
+  box-shadow: 0 24px 48px -28px var(--color-card-shadow-soft);
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
   padding: 1.4rem 1.6rem;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.meal-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 52px -26px var(--color-card-shadow);
 }
 
 .meal-card__header {
@@ -1047,13 +1178,16 @@ textarea:focus {
 }
 
 .view-toggle__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid var(--color-accent-secondary-outline, var(--color-border));
   border-radius: 999px;
-  padding: 0.55rem 1.3rem;
+  padding: 0.45rem 1.15rem;
   background: linear-gradient(
-    135deg,
-    var(--color-neutral-50, var(--color-surface-soft)),
-    var(--color-neutral-100, var(--color-surface-soft))
+    140deg,
+    var(--color-accent-softer, var(--color-accent-soft)),
+    var(--color-surface)
   );
   color: var(--color-accent-secondary, var(--color-accent));
   font-weight: 600;
@@ -1071,9 +1205,9 @@ textarea:focus {
   box-shadow: 0 12px 25px -18px
     var(--color-accent-secondary-shadow, var(--color-accent-shadow));
   background: linear-gradient(
-    135deg,
-    var(--color-neutral-100, var(--color-surface-soft)),
-    var(--color-accent-secondary-soft, var(--color-accent-soft))
+    140deg,
+    var(--color-accent-secondary-soft, var(--color-accent-soft)),
+    var(--color-surface)
   );
 }
 

--- a/tests/ingredient-matching.test.js
+++ b/tests/ingredient-matching.test.js
@@ -1,0 +1,125 @@
+const assert = require('assert');
+const matching = require('../scripts/ingredient-matching.js');
+
+const tests = [];
+
+const test = (name, fn) => {
+  tests.push({ name, fn });
+};
+
+test('buildTokenSet removes descriptors and normalizes tokens', () => {
+  const tokens = matching.buildTokenSet('2 Large, diced Sweet Potatoes');
+  assert(tokens.has('sweet'), 'expected token set to include "sweet"');
+  assert(tokens.has('potato'), 'expected token set to include "potato"');
+  assert(!tokens.has('large'), 'expected descriptor tokens to be removed');
+  assert(!tokens.has('diced'), 'expected descriptor tokens to be removed');
+});
+
+test('createIngredientMatcher captures slug-derived tokens', () => {
+  const matcher = matching.createIngredientMatcher({
+    slug: 'veg-sweet-potato',
+    name: 'Sweet Potatoes',
+  });
+  assert(matcher.tokens.has('sweet'));
+  assert(matcher.tokens.has('potato'));
+  assert(matcher.variants.has('sweet potatoes'));
+});
+
+test('doesEntryMatchIngredient matches pluralized ingredient entries', () => {
+  const matcher = matching.createIngredientMatcher({
+    slug: 'veg-sweet-potato',
+    name: 'Sweet Potato',
+  });
+  const entry = {
+    text: matching.sanitizeComparisonText('3 sweet potatoes, diced'),
+    tokens: matching.buildTokenSet('3 sweet potatoes, diced'),
+  };
+  assert(
+    matching.doesEntryMatchIngredient(entry, matcher),
+    'expected sweet potato matcher to match plural entry',
+  );
+});
+
+test('doesEntryMatchIngredient avoids false positives for different items', () => {
+  const matcher = matching.createIngredientMatcher({
+    slug: 'oil-peanut',
+    name: 'Peanut Oil',
+  });
+  const entry = {
+    text: matching.sanitizeComparisonText('creamy peanut butter'),
+    tokens: matching.buildTokenSet('creamy peanut butter'),
+  };
+  assert(
+    !matching.doesEntryMatchIngredient(entry, matcher),
+    'expected peanut oil matcher not to match peanut butter',
+  );
+});
+
+test('mapRecipesToIngredientMatches maps matches and usage flags', () => {
+  const ingredients = [
+    { slug: 'veg-sweet-potato', name: 'Sweet Potato', category: 'Vegetable' },
+    { slug: 'oil-peanut', name: 'Peanut Oil', category: 'Oil/Fat' },
+    { slug: 'oil-olive', name: 'Olive Oil', category: 'Oil/Fat' },
+    { slug: 'meat-chicken-breast', name: 'Chicken Breast', category: 'Meat' },
+    { slug: 'meat-chicken-thigh', name: 'Chicken Thigh', category: 'Meat' },
+  ];
+  const recipes = [
+    {
+      id: 'sheet-pan-dinner',
+      ingredients: [
+        { item: '2 large sweet potatoes, diced' },
+        { item: '2 tablespoons olive oil' },
+      ],
+    },
+    {
+      id: 'stir-fry',
+      ingredients: [
+        { item: '1 lb chicken breast (boneless, skinless)' },
+        { item: '2 tablespoons peanut oil' },
+      ],
+    },
+  ];
+
+  const index = matching.createIngredientMatcherIndex(ingredients);
+  const { recipeIngredientMatches, ingredientUsage } = matching.mapRecipesToIngredientMatches(
+    recipes,
+    index,
+  );
+
+  const sheetPanMatches = recipeIngredientMatches.get('sheet-pan-dinner');
+  assert(sheetPanMatches instanceof Set, 'expected matches to be a set');
+  assert(sheetPanMatches.has('veg-sweet-potato'));
+  assert(sheetPanMatches.has('oil-olive'));
+  assert(!sheetPanMatches.has('oil-peanut'));
+
+  const stirFryMatches = recipeIngredientMatches.get('stir-fry');
+  assert(stirFryMatches.has('meat-chicken-breast'));
+  assert(stirFryMatches.has('oil-peanut'));
+  assert(!stirFryMatches.has('meat-chicken-thigh'));
+
+  assert.strictEqual(ingredientUsage.get('veg-sweet-potato'), true);
+  assert.strictEqual(ingredientUsage.get('oil-olive'), true);
+  assert.strictEqual(ingredientUsage.get('meat-chicken-breast'), true);
+  assert.strictEqual(ingredientUsage.get('oil-peanut'), true);
+  assert.strictEqual(ingredientUsage.get('meat-chicken-thigh'), false);
+});
+
+(async () => {
+  let failures = 0;
+  tests.forEach(({ name, fn }) => {
+    try {
+      fn();
+      console.log(`✓ ${name}`);
+    } catch (error) {
+      failures += 1;
+      console.error(`✗ ${name}`);
+      console.error(error);
+    }
+  });
+  if (failures) {
+    console.error(`\n${failures} test(s) failed.`);
+    process.exit(1);
+  } else {
+    console.log(`\nAll ${tests.length} tests passed.`);
+  }
+})();


### PR DESCRIPTION
## Summary
- Extract the ingredient matching helpers into a shared module, add a token index for faster lookups, and wire it into the main app bootstrap.
- Enhance grouped tag controls with selection badges, accessibility attributes, and synchronized counts.
- Style the updated tag summaries and load the new matching module before the app script.
- Add a lightweight Node test script covering the ingredient matching heuristics.

## Testing
- node tests/ingredient-matching.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0491a8384832599c17cb6854c8cf1