### PR TITLE
Adjust Copper Glow text contrast on burnished sections

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -2272,6 +2272,23 @@ textarea:focus {
   --color-text-instruction: rgba(42, 52, 57, 0.68);
 }
 
+:root[data-mode='sepia'][data-theme='copper'] .meal-card__header,
+:root[data-mode='sepia'][data-theme='copper'] .meal-card__section,
+:root[data-mode='sepia'][data-theme='copper'] .meal-card__details > div {
+  color: var(--color-header-foreground, #fbe6d5);
+  --color-text-strong: var(--color-header-foreground, #fbe6d5);
+  --color-text-emphasis: var(--color-header-foreground, #fbe6d5);
+  --color-text-tertiary: rgba(251, 230, 213, 0.82);
+  --color-text-muted: rgba(251, 230, 213, 0.76);
+  --color-text-soft: rgba(251, 230, 213, 0.65);
+  --color-text-badge: var(--color-header-foreground, #fbe6d5);
+  --color-tag-text: var(--color-header-foreground, #fbe6d5);
+  --color-inline-tag-text: var(--color-header-foreground, #fbe6d5);
+  --color-text-inline: var(--color-header-foreground, #fbe6d5);
+  --color-text-instruction: rgba(251, 230, 213, 0.88);
+  --color-accent-secondary-contrast: var(--color-header-foreground, #fbe6d5);
+}
+
 :root[data-mode='sepia'][data-theme='copper'] .favorite-filter,
 :root[data-mode='sepia'][data-theme='copper'] .reset-button,
 :root[data-mode='sepia'][data-theme='copper'] .tag-group__summary,


### PR DESCRIPTION
## Summary
- update the Copper Glow theme so content on burnished copper panels uses the theme's light sepia foreground
- override supporting text variables to keep descriptions, tags, and instructions legible against the darker background

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1e6bfcb7c8325b98c8d29e4e7e7dc