### PR TITLE
Enable full width meal plan layout

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1053,6 +1053,7 @@
 
   const cacheElements = () => {
     elements.viewToggleButtons = Array.from(document.querySelectorAll('[data-view-target]'));
+    elements.appLayout = document.getElementById('app-layout');
     elements.filterPanel = document.getElementById('filter-panel');
     elements.mealView = document.getElementById('meal-view');
     elements.pantryView = document.getElementById('pantry-view');
@@ -2281,6 +2282,7 @@
         button.classList.remove('view-toggle__button--active');
       }
     });
+    const hideFilter = state.activeView === 'meal-plan';
     if (elements.mealView) {
       elements.mealView.hidden = state.activeView !== 'meals';
     }
@@ -2290,8 +2292,10 @@
     if (elements.mealPlanView) {
       elements.mealPlanView.hidden = state.activeView !== 'meal-plan';
     }
+    if (elements.appLayout) {
+      elements.appLayout.classList.toggle('layout--single-column', hideFilter);
+    }
     if (elements.filterPanel) {
-      const hideFilter = state.activeView === 'meal-plan';
       elements.filterPanel.hidden = hideFilter;
       if (hideFilter) {
         elements.filterPanel.setAttribute('aria-hidden', 'true');

--- a/styles/app.css
+++ b/styles/app.css
@@ -484,6 +484,10 @@ select {
   border-radius: 0;
 }
 
+.layout.layout--single-column {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .filter-panel,
 .pantry-view {
   border: 1px solid var(--color-accent-outline, var(--color-border-muted));


### PR DESCRIPTION
## Summary
- add a layout--single-column modifier so the main grid can expand to the full viewport width
- toggle the single-column layout when the Meal Plan view hides the filter panel

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d36242e90883259743effa7dd570cd