### PR TITLE
Reposition filter controls and refine Copper Glow styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,9 +115,14 @@
                 <span class="favorite-filter__label">Favorites</span>
               </button>
               <button type="button" class="reset-button" id="reset-filters">Reset</button>
+              <span
+                class="filter-panel__count"
+                id="meal-count"
+                aria-live="polite"
+                aria-label="0 recipes match your filters."
+              >0</span>
             </div>
           </div>
-          <p class="filter-panel__count" id="meal-count">0 recipes match your filters.</p>
           <div class="input-group input-group--search">
             <input
               type="search"

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -2179,7 +2179,9 @@
       : filteredRecipes.length === 1
         ? 'recipe matches'
         : 'recipes match';
-    elements.mealCount.textContent = `${filteredRecipes.length} ${matchLabel} your filters.`;
+    const matchesText = `${filteredRecipes.length} ${matchLabel} your filters.`;
+    elements.mealCount.textContent = String(filteredRecipes.length);
+    elements.mealCount.setAttribute('aria-label', matchesText);
     elements.mealGrid.innerHTML = '';
     if (filteredRecipes.length) {
       filteredRecipes.forEach((recipe) => {

--- a/styles/app.css
+++ b/styles/app.css
@@ -531,13 +531,13 @@ select {
 .panel-header__actions {
   display: inline-flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   flex-wrap: wrap;
   gap: 0.75rem;
 }
 
 .panel-header--actions-only {
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .panel-header h2 {
@@ -549,8 +549,13 @@ select {
 }
 
 .filter-panel__count {
-  margin: -0.15rem 0 0;
-  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  margin: 0;
+  font-size: 1.425rem;
+  font-weight: 600;
   color: var(--color-text-muted);
 }
 
@@ -3003,6 +3008,29 @@ textarea:focus {
 :root[data-mode='sepia'][data-theme='copper'] .meal-card__favorite-button[aria-pressed='true'] {
   background: var(--favorite-heart-on);
   box-shadow: var(--favorite-heart-shadow);
+}
+
+:root[data-mode='sepia'][data-theme='copper'] .serving-controls span,
+:root[data-mode='sepia'][data-theme='copper'] .base-serving {
+  color: #000000;
+}
+
+:root[data-mode='sepia'][data-theme='copper'] .meal-plan-view {
+  background: var(--color-burnished-copper);
+  color: var(--color-header-foreground, #fbe6d5);
+  --color-text-emphasis: var(--color-header-foreground, #fbe6d5);
+  --color-text-secondary: rgba(251, 230, 213, 0.86);
+  --color-text-tertiary: rgba(251, 230, 213, 0.78);
+  --color-text-muted: rgba(251, 230, 213, 0.72);
+  --color-text-soft: rgba(251, 230, 213, 0.64);
+  --meal-plan-border: rgba(251, 230, 213, 0.32);
+}
+
+:root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar,
+:root[data-mode='sepia'][data-theme='copper'] .meal-plan-sidebar {
+  background: var(--color-burnished-copper);
+  border-color: rgba(251, 230, 213, 0.32);
+  box-shadow: 0 18px 32px -24px rgba(28, 14, 10, 0.65);
 }
 
 :root[data-mode='sepia'][data-theme='umber'] {


### PR DESCRIPTION
## Summary
- move the favorites/reset controls to the left edge and show the numeric recipe count beside reset
- update the meal count rendering to expose an accessible description while displaying only the number
- adjust the Copper Glow theme so serving copy turns black and meal plan surfaces adopt the deep burnished copper tone

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d36a5762d483259ad4a02e7453829d