### PR TITLE
Adjust meal plan calendar row sizing

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -1411,6 +1411,13 @@ textarea:focus {
   background: var(--surface-section-gradient);
   border: 1px solid var(--meal-plan-border, var(--color-border-muted));
   box-shadow: 0 18px 32px -24px var(--color-card-shadow-soft);
+  display: flex;
+  flex-direction: column;
+}
+
+.meal-plan-calendar > * {
+  flex: 1;
+  min-height: 0;
 }
 
 .meal-plan-sidebar {
@@ -1725,7 +1732,16 @@ textarea:focus {
   align-items: stretch;
 }
 
+.meal-plan-calendar__month {
+  display: grid;
+  grid-template-rows: auto;
+  grid-auto-rows: minmax(0, 1fr);
+  gap: 0.75rem;
+  min-height: 0;
+}
+
 .meal-plan-calendar__week {
+  min-height: 0;
   grid-auto-rows: minmax(0, 1fr);
 }
 


### PR DESCRIPTION
## Summary
- make the meal plan calendar container flex so embedded views stretch to the full height
- update the month grid so each week row shares equal space regardless of content
- ensure individual week rows can shrink properly while maintaining full-height cells

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d49e9ff09c83259bb2414e88e755e5