### PR TITLE
Expand family icons and adjust meal plan layout

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -155,6 +155,73 @@
     '👦',
     '👶',
     '🐾',
+    'A',
+    'B',
+    'C',
+    'D',
+    'E',
+    'F',
+    'G',
+    'H',
+    'I',
+    'J',
+    'K',
+    'L',
+    'M',
+    'N',
+    'O',
+    'P',
+    'Q',
+    'R',
+    'S',
+    'T',
+    'U',
+    'V',
+    'W',
+    'X',
+    'Y',
+    'Z',
+    '0',
+    '1',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    '🔴',
+    '🟠',
+    '🟡',
+    '🟢',
+    '🔵',
+    '🟣',
+    '🟤',
+    '⚫',
+    '⚪',
+    '🐶',
+    '🐱',
+    '🐭',
+    '🐹',
+    '🐰',
+    '🦊',
+    '🐻',
+    '🐼',
+    '🐨',
+    '🐯',
+    '🦁',
+    '🐮',
+    '🐷',
+    '🐸',
+    '🐵',
+    '🐤',
+    '🐧',
+    '🐦',
+    '🦄',
+    '🐢',
+    '🦕',
+    '🦖',
   ];
 
   const FAMILY_DIET_OPTIONS = [
@@ -3082,11 +3149,13 @@
     const typeLabel = mealPlanEntryTypeLookup.get(normalizedType) || 'Meal';
     const article = document.createElement('article');
     article.className = 'meal-plan-entry';
+    const main = document.createElement('div');
+    main.className = 'meal-plan-entry__main';
     const badge = document.createElement('span');
     badge.className = `meal-plan-entry__type meal-plan-entry__type--${normalizedType}`;
     badge.textContent = typeLabel.charAt(0).toUpperCase();
     badge.title = typeLabel;
-    article.appendChild(badge);
+    main.appendChild(badge);
     const content = document.createElement('div');
     content.className = 'meal-plan-entry__content';
     const title = document.createElement('p');
@@ -3106,7 +3175,8 @@
       meta.textContent = typeLabel;
       content.appendChild(meta);
     }
-    article.appendChild(content);
+    main.appendChild(content);
+    article.appendChild(main);
     if (showRemove && dateKey) {
       const removeButton = document.createElement('button');
       removeButton.type = 'button';
@@ -3114,7 +3184,7 @@
       removeButton.dataset.removeEntry = entry.id;
       removeButton.dataset.entryDate = dateKey;
       removeButton.textContent = 'Remove';
-      article.appendChild(removeButton);
+      main.appendChild(removeButton);
     }
     return article;
   };

--- a/styles/app.css
+++ b/styles/app.css
@@ -1504,12 +1504,20 @@ textarea:focus {
 
 .meal-plan-entry {
   display: flex;
+  flex-direction: column;
   gap: 0.75rem;
-  align-items: center;
+  align-items: stretch;
   padding: 0.6rem 0.75rem;
   border-radius: 14px;
   background: rgba(68, 83, 214, 0.08);
   border: 1px solid rgba(68, 83, 214, 0.12);
+}
+
+.meal-plan-entry__main {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
 }
 
 .meal-plan-entry__type {
@@ -2178,17 +2186,20 @@ textarea:focus {
 
 
 .meal-plan-entry__attendance {
-  margin-top: 0.75rem;
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
   align-items: center;
+  justify-content: flex-start;
+  width: 100%;
 }
 
 .meal-plan-entry__members {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .meal-plan-entry__member {
@@ -2219,6 +2230,7 @@ textarea:focus {
   margin: 0;
   font-size: 0.8rem;
   color: var(--color-text-muted);
+  flex: 1 1 auto;
 }
 
 .meal-plan-entry__guest-field {
@@ -2227,6 +2239,7 @@ textarea:focus {
   gap: 0.4rem;
   font-size: 0.8rem;
   color: var(--color-text-secondary);
+  margin-left: auto;
 }
 
 .meal-plan-entry__guest-label {


### PR DESCRIPTION
## Summary
- expand the family icon options with letters, numbers, colorful badges, and playful animal selections for more personalization
- restructure meal plan entry markup and layout so member icons and guest controls live on a dedicated bottom row for better clarity

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5571ed9208325870126d1ff8cadfa