### PR TITLE
Add family filter toggles to meal plan view

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,6 +198,12 @@
                 </button>
               </div>
             </div>
+            <div
+              class="meal-plan-family-filter"
+              id="meal-plan-family-filter"
+              role="group"
+              aria-label="Filter meal plan by family member"
+            ></div>
             <div class="view-toggle meal-plan-view__mode-toggle" role="tablist">
               <button
                 type="button"

--- a/styles/app.css
+++ b/styles/app.css
@@ -1378,6 +1378,65 @@ textarea:focus {
   flex: 1 1 260px;
 }
 
+.meal-plan-family-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--meal-plan-surface, rgba(255, 255, 255, 0.68));
+  border: 1px solid var(--color-border-muted);
+  box-shadow: 0 16px 34px -26px var(--color-card-shadow-soft);
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.meal-plan-family-filter__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.meal-plan-family-filter__list {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.meal-plan-family-filter__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  font-size: 1.45rem;
+  line-height: 1;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.meal-plan-family-filter__button:hover {
+  background: var(--color-accent-softer, rgba(68, 83, 214, 0.12));
+}
+
+.meal-plan-family-filter__button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
+}
+
+.meal-plan-family-filter__button--active {
+  background: var(--color-accent-soft, rgba(68, 83, 214, 0.18));
+  border-color: var(--color-accent-outline, rgba(68, 83, 214, 0.32));
+  box-shadow: 0 10px 22px -18px var(--color-accent-shadow, rgba(68, 83, 214, 0.7));
+}
+
+.meal-plan-family-filter[data-filter-active='true'] .meal-plan-family-filter__label {
+  color: var(--color-text-emphasis);
+}
+
 .meal-plan-nav__label {
   font-weight: 600;
   color: var(--color-text-emphasis);
@@ -2433,6 +2492,12 @@ textarea:focus {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+.meal-plan-item--dimmed {
+  opacity: 0.32;
+  filter: saturate(0.5);
+  transition: opacity 0.2s ease, filter 0.2s ease;
 }
 
 .meal-plan-calendar__more {


### PR DESCRIPTION
## Summary
- add a family member filter control to the meal plan header and persist the selection in saved app state
- dim calendar and detail entries that do not include the selected members so it’s easy to focus on relevant meals
- style the new controls to match existing meal plan chrome and highlight the active filter state

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d55b1d25cc8325a44db8005c165bff