### PR TITLE
Update meal plan styling and macro controls

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -25,6 +25,8 @@
   --color-layout-background: #d09c67;
   --color-burnished-copper: #4f2a1c;
   --color-burnished-copper-soft: #6a3a23;
+  --color-sepia-light: #f5ecdc;
+  --color-sepia-light-soft: rgba(245, 236, 220, 0.78);
   --gradient-burnished-copper: linear-gradient(
     140deg,
     var(--color-burnished-copper-soft),
@@ -61,8 +63,8 @@
   --meal-plan-type-drink: #0ea5e9;
   --meal-plan-type-snack: #7d9341;
   --meal-plan-type-text: var(--color-text-inverse);
-  --meal-plan-border: rgba(68, 83, 214, 0.14);
-  --meal-plan-surface: rgba(255, 255, 255, 0.9);
+  --meal-plan-border: rgba(79, 42, 28, 0.24);
+  --meal-plan-surface: var(--color-sepia-light);
 
   --view-toggle-inactive-gradient: linear-gradient(
     135deg,
@@ -663,7 +665,6 @@ select {
 }
 
 .input-group input:focus,
-.serving-controls input:focus,
 textarea:focus {
   outline: none;
   border-color: var(--color-accent);
@@ -969,9 +970,8 @@ textarea:focus {
 
 @media (orientation: landscape) {
   .meal-grid {
-    --meal-card-width: clamp(20rem, 35vw, 32rem);
-    --meal-grid-max-width: calc(2 * var(--meal-card-width) + var(--meal-grid-gap));
-    max-width: min(100%, var(--meal-grid-max-width));
+    --meal-card-width: clamp(20rem, 32vw, 34rem);
+    width: 100%;
     margin-inline: auto;
   }
 }
@@ -996,6 +996,7 @@ textarea:focus {
   --meal-section-background: var(--gradient-burnished-copper);
   --meal-section-border: var(--color-burnished-copper-border);
   --meal-section-shadow-color: var(--color-burnished-copper-shadow);
+  --serving-control-color: var(--color-accent-contrast, #ffffff);
 }
 
 .meal-card:hover {
@@ -1150,29 +1151,43 @@ textarea:focus {
 .serving-controls {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 0.35rem;
   min-width: 110px;
+  color: var(--serving-control-color, var(--color-accent-contrast, #ffffff));
 }
 
-.serving-controls span {
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
+.serving-controls__chevron {
+  appearance: none;
+  border: none;
+  background: none;
+  color: inherit;
+  font-size: 1.45rem;
+  line-height: 1;
+  padding: 0.1rem 0.45rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, color 0.2s ease;
 }
 
-.serving-controls input {
-  width: 100%;
-  border: 1px solid var(--color-neutral-200, var(--color-border));
-  border-radius: 12px;
-  padding: 0.45rem 0.5rem;
+.serving-controls__chevron:hover {
+  transform: scale(1.05);
+}
+
+.serving-controls__chevron:active {
+  transform: scale(0.95);
+}
+
+.serving-controls__chevron:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.serving-controls__display {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
   text-align: center;
-  background: var(--color-neutral-50, #ffffff);
-  color: var(--color-text-strong);
-}
-
-.base-serving {
-  margin: 0;
-  font-size: 0.8rem;
-  color: var(--color-text-soft);
 }
 
 .meal-card__section h4,
@@ -1568,8 +1583,9 @@ textarea:focus {
   align-items: stretch;
   padding: 0.6rem 0.75rem;
   border-radius: 14px;
-  background: rgba(68, 83, 214, 0.08);
-  border: 1px solid rgba(68, 83, 214, 0.12);
+  background: var(--color-sepia-light);
+  border: 1px solid var(--meal-plan-border, rgba(79, 42, 28, 0.24));
+  color: var(--color-burnished-copper);
 }
 
 .meal-plan-entry__main {
@@ -1616,18 +1632,18 @@ textarea:focus {
   margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--color-text-emphasis);
+  color: var(--color-burnished-copper);
 }
 
 .meal-plan-entry__meta {
   margin: 0;
-  color: var(--color-text-muted);
+  color: rgba(79, 42, 28, 0.75);
   font-size: 0.8rem;
 }
 
 .meal-plan-entry__time {
   margin: 0;
-  color: var(--color-text-muted);
+  color: rgba(79, 42, 28, 0.8);
   font-size: 0.85rem;
   font-weight: 500;
 }
@@ -2127,21 +2143,22 @@ textarea:focus {
   gap: 1rem;
   padding: 1.25rem 1rem 1rem;
   border-radius: 16px;
-  background: rgba(68, 83, 214, 0.08);
-  border: 1px solid rgba(68, 83, 214, 0.16);
+  background: var(--color-sepia-light);
+  border: 1px solid var(--meal-plan-border, rgba(79, 42, 28, 0.24));
+  color: var(--color-burnished-copper);
 }
 
 .meal-plan-summary__title {
   margin: 0;
   font-size: 1.15rem;
   font-weight: 600;
-  color: var(--color-text-emphasis);
+  color: var(--color-burnished-copper);
 }
 
 .meal-plan-summary__hint {
   margin: 0;
   font-size: 0.85rem;
-  color: var(--color-text-secondary);
+  color: rgba(79, 42, 28, 0.7);
 }
 
 .meal-plan-summary__macros {
@@ -2150,14 +2167,51 @@ textarea:focus {
   gap: 0.75rem;
 }
 
+.meal-plan-macro-icons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.meal-plan-macro-icons__button {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 0.35rem 0.65rem;
+  background: none;
+  color: var(--color-burnished-copper);
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.meal-plan-macro-icons__button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(79, 42, 28, 0.2);
+  background: rgba(79, 42, 28, 0.08);
+}
+
+.meal-plan-macro-icons__button:focus-visible {
+  outline: 2px solid rgba(79, 42, 28, 0.45);
+  outline-offset: 2px;
+}
+
+.meal-plan-macro-icons__button--active {
+  border-color: rgba(79, 42, 28, 0.35);
+  background: rgba(79, 42, 28, 0.16);
+  transform: none;
+}
+
 .meal-plan-summary__group {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   padding: 0.75rem;
   border-radius: 12px;
-  background: rgba(68, 83, 214, 0.12);
-  border: 1px solid rgba(68, 83, 214, 0.18);
+  background: var(--color-sepia-light-soft);
+  border: 1px solid rgba(79, 42, 28, 0.18);
 }
 
 .meal-plan-summary__group-icon {
@@ -2172,20 +2226,20 @@ textarea:focus {
   gap: 0.75rem;
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--color-text-emphasis);
+  color: var(--color-burnished-copper);
   margin: 0;
 }
 
 .meal-plan-summary__group-subtitle {
   margin: 0;
   font-size: 0.8rem;
-  color: var(--color-text-muted);
+  color: rgba(79, 42, 28, 0.68);
 }
 
 .meal-plan-summary__group-note {
   margin: 0;
   font-size: 0.75rem;
-  color: var(--color-text-muted);
+  color: rgba(79, 42, 28, 0.68);
 }
 
 .meal-plan-summary__stat-list {
@@ -2200,16 +2254,16 @@ textarea:focus {
   gap: 0.2rem;
   padding: 0.6rem 0.7rem;
   border-radius: 10px;
-  background: rgba(255, 255, 255, 0.82);
-  color: var(--color-text-strong);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  background: rgba(245, 236, 220, 0.92);
+  color: var(--color-burnished-copper);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
 .meal-plan-summary__stat dt {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--color-text-muted);
+  color: rgba(79, 42, 28, 0.7);
 }
 
 .meal-plan-summary__stat dd {
@@ -2224,21 +2278,21 @@ textarea:focus {
 .meal-plan-summary__empty {
   margin: 0;
   font-size: 0.9rem;
-  color: var(--color-text-muted);
+  color: rgba(79, 42, 28, 0.7);
 }
 
 .meal-plan-summary__stat-note {
   font-size: 0.75rem;
   font-weight: 500;
-  color: var(--color-text-muted);
+  color: rgba(79, 42, 28, 0.65);
 }
 
 .meal-plan-summary__target {
   grid-column: 1 / -1;
   padding: 0.6rem 0.7rem;
   border-radius: 10px;
-  background: rgba(68, 83, 214, 0.14);
-  color: var(--color-text-secondary);
+  background: rgba(79, 42, 28, 0.12);
+  color: var(--color-burnished-copper);
   font-size: 0.8rem;
   font-weight: 600;
 }
@@ -3815,8 +3869,7 @@ textarea:focus {
   box-shadow: var(--favorite-heart-shadow);
 }
 
-:root[data-mode='sepia'][data-theme='copper'] .serving-controls span,
-:root[data-mode='sepia'][data-theme='copper'] .base-serving {
+:root[data-mode='sepia'][data-theme='copper'] .serving-controls {
   color: #000000;
 }
 
@@ -3828,7 +3881,7 @@ textarea:focus {
   --color-text-tertiary: rgba(251, 230, 213, 0.78);
   --color-text-muted: rgba(251, 230, 213, 0.72);
   --color-text-soft: rgba(251, 230, 213, 0.64);
-  --meal-plan-border: rgba(251, 230, 213, 0.32);
+  --meal-plan-border: rgba(79, 42, 28, 0.32);
 }
 
 :root[data-mode='sepia'][data-theme='copper'] .meal-plan-view__navigator {


### PR DESCRIPTION
## Summary
- refresh the meal plan entry and summary styling with sepia surfaces and burnished copper accents
- add macro selection state with icon buttons so only the chosen person's nutrition totals are shown
- replace the recipe card serving input with chevron controls and loosen recipe grid width constraints

## Testing
- npm test *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d560174da48325a5533677eec73439