### PR TITLE
Expand bean and nut ingredients and update plant protein filter

### DIFF
--- a/data/ingredients.js
+++ b/data/ingredients.js
@@ -176,6 +176,9 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'nut-walnut', name: 'Walnuts', category: 'Nut/Seed', tags: ['Contains Nuts', 'Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'nut-pecan', name: 'Pecans', category: 'Nut/Seed', tags: ['Contains Nuts', 'Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'nut-hazelnut', name: 'Hazelnuts', category: 'Nut/Seed', tags: ['Contains Nuts', 'Gluten-Free', 'Vegetarian', 'Vegan'] },
+  { slug: 'nut-macadamia', name: 'Macadamia Nuts', category: 'Nut/Seed', tags: ['Contains Nuts', 'Gluten-Free', 'Vegetarian', 'Vegan'] },
+  { slug: 'nut-brazil', name: 'Brazil Nuts', category: 'Nut/Seed', tags: ['Contains Nuts', 'Gluten-Free', 'Vegetarian', 'Vegan'] },
+  { slug: 'seed-pine-nut', name: 'Pine Nuts', category: 'Nut/Seed', tags: ['Contains Nuts', 'Gluten-Free', 'Vegetarian', 'Vegan'] },
 
   // Grains & Cereals
   { slug: 'grain-barley', name: 'Barley', category: 'Grain', tags: ['Contains Gluten', 'Vegetarian', 'Vegan'] },
@@ -194,7 +197,7 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'grain-granola', name: 'Granola', category: 'Grain', tags: ['Contains Gluten', 'Vegetarian', 'Vegan'] },
   { slug: 'grain-tortilla-strips', name: 'Tortilla Strips', category: 'Grain', tags: ['Gluten-Free*', 'Vegetarian', 'Vegan'] },
 
-  // Legumes
+  // Legumes & Plant Proteins
   { slug: 'legume-black-beans', name: 'Black Beans', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'legume-chickpea', name: 'Chickpeas', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'legume-edamame', name: 'Edamame', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan', 'Contains Soy'] },
@@ -208,10 +211,14 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'legume-great-northern-beans', name: 'Great Northern Beans', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'legume-black-eyed-peas', name: 'Black-Eyed Peas', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'legume-lentil-red', name: 'Lentils (Red)', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
-  { slug: 'legume-tofu-extra-firm', name: 'Tofu (Extra-Firm)', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan', 'Contains Soy'] },
-  { slug: 'legume-tempeh', name: 'Tempeh', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan', 'Contains Soy'] },
-  { slug: 'legume-textured-vegetable-protein', name: 'Textured Vegetable Protein (TVP)', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan', 'Contains Soy'] },
-  { slug: 'legume-chickpea-flour', name: 'Chickpea Flour', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
+  { slug: 'legume-lima-beans', name: 'Lima Beans', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
+  { slug: 'legume-butter-beans', name: 'Butter Beans', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
+  { slug: 'legume-refried-beans', name: 'Refried Beans', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
+  { slug: 'legume-adzuki-beans', name: 'Adzuki Beans', category: 'Legume', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
+  { slug: 'legume-tofu-extra-firm', name: 'Tofu (Extra-Firm)', category: 'Plant Protein', tags: ['Gluten-Free', 'Vegetarian', 'Vegan', 'Contains Soy'] },
+  { slug: 'legume-tempeh', name: 'Tempeh', category: 'Plant Protein', tags: ['Gluten-Free', 'Vegetarian', 'Vegan', 'Contains Soy'] },
+  { slug: 'legume-textured-vegetable-protein', name: 'Textured Vegetable Protein (TVP)', category: 'Plant Protein', tags: ['Gluten-Free', 'Vegetarian', 'Vegan', 'Contains Soy'] },
+  { slug: 'legume-chickpea-flour', name: 'Chickpea Flour', category: 'Plant Protein', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
 
   // Oils & Fats
   { slug: 'oil-avocado', name: 'Avocado Oil', category: 'Oil/Fat', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1609,7 +1609,7 @@
 
   const INGREDIENT_FILTER_GROUPS = [
     { id: 'protein', label: 'Protein', categories: ['Meat', 'Seafood'] },
-    { id: 'legumes', label: 'Legumes & Plant Proteins', categories: ['Legume'] },
+    { id: 'legumes', label: 'Legumes and Plant Proteins', categories: ['Legume', 'Plant Protein'] },
     { id: 'vegetables', label: 'Vegetables', categories: ['Vegetable'] },
     { id: 'fruits', label: 'Fruits', categories: ['Fruit'] },
     { id: 'pasta-grains', label: 'Pasta & Grains', categories: ['Pasta', 'Grain'] },


### PR DESCRIPTION
## Summary
- add more bean varieties and plant-based protein staples to the ingredient dataset
- extend nut coverage with additional popular nuts and seeds
- update the Legumes and Plant Proteins filter to surface the new category entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5c2b010a48325809fba5329ca8459