### PR TITLE
Update filter panel controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,26 +113,23 @@
                 class="favorite-filter"
                 id="favorite-filter"
                 aria-pressed="false"
+                aria-label="Filter by favorite recipes"
+                title="Filter by favorite recipes"
               >
                 <span class="favorite-filter__icon" aria-hidden="true">♥</span>
-                <span class="favorite-filter__label">Favorites</span>
               </button>
               <button
                 type="button"
                 class="pantry-only-filter"
                 id="pantry-only-toggle"
                 aria-pressed="false"
+                aria-label="Pantry filter off: include all recipes"
+                title="Pantry filter off: include all recipes"
               >
                 <span class="pantry-only-filter__icon" aria-hidden="true">🧺</span>
-                <span class="pantry-only-filter__label">Pantry Ready</span>
+                <span class="pantry-only-filter__label">Pantry</span>
               </button>
               <button type="button" class="reset-button" id="reset-filters">Reset</button>
-              <span
-                class="filter-panel__count"
-                id="meal-count"
-                aria-live="polite"
-                aria-label="0 recipes match your filters."
-              >0</span>
             </div>
           </div>
           <div class="recipe-family-filter" id="recipe-family-filter" hidden aria-hidden="true"></div>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -3176,7 +3176,6 @@
     elements.mealPlanPrevButton = document.getElementById('meal-plan-prev');
     elements.mealPlanNextButton = document.getElementById('meal-plan-next');
     elements.mealGrid = document.getElementById('meal-grid');
-    elements.mealCount = document.getElementById('meal-count');
     elements.pantryGrid = document.getElementById('pantry-grid');
     elements.pantryCount = document.getElementById('pantry-count');
     elements.filterSearch = document.getElementById('filter-search');
@@ -3565,10 +3564,6 @@
     } else {
       delete container.dataset.filterActive;
     }
-    const label = document.createElement('span');
-    label.className = 'recipe-family-filter__label';
-    label.textContent = 'Family';
-    container.appendChild(label);
     const list = document.createElement('div');
     list.className = 'recipe-family-filter__list';
     list.setAttribute('role', 'group');
@@ -3728,19 +3723,7 @@
       const favoritesOnly = isMealsView && Boolean(filters.favoritesOnly);
       elements.favoriteFilterToggle.setAttribute('aria-pressed', favoritesOnly ? 'true' : 'false');
       elements.favoriteFilterToggle.classList.toggle('favorite-filter--active', favoritesOnly);
-      const labelEl = elements.favoriteFilterToggle.querySelector('.favorite-filter__label');
       const favoriteCount = state.favoriteRecipes.size;
-      if (labelEl) {
-        if (favoritesOnly) {
-          labelEl.textContent = favoriteCount
-            ? `${favoriteCount} favorite${favoriteCount === 1 ? '' : 's'}`
-            : 'No favorites';
-        } else if (favoriteCount) {
-          labelEl.textContent = `Favorites (${favoriteCount})`;
-        } else {
-          labelEl.textContent = 'Favorites';
-        }
-      }
       const titleText = favoritesOnly
         ? favoriteCount
           ? `Showing ${favoriteCount} favorite${favoriteCount === 1 ? '' : 's'}`
@@ -3760,11 +3743,11 @@
         elements.pantryOnlyToggle.setAttribute('aria-pressed', pantryOnly ? 'true' : 'false');
         const label = elements.pantryOnlyToggle.querySelector('.pantry-only-filter__label');
         if (label) {
-          label.textContent = pantryOnly ? 'Pantry Ready Only' : 'Pantry Ready';
+          label.textContent = 'Pantry';
         }
         const title = pantryOnly
-          ? 'Showing only recipes that match your pantry inventory'
-          : 'Limit recipes to only those you can make from your pantry';
+          ? 'Pantry filter on: showing only recipes you can make from your pantry'
+          : 'Pantry filter off: include all recipes';
         elements.pantryOnlyToggle.setAttribute('title', title);
         elements.pantryOnlyToggle.setAttribute('aria-label', title);
       } else {
@@ -5019,16 +5002,6 @@
   const renderMeals = () => {
     const filters = state.mealFilters;
     const filteredRecipes = recipes.filter((recipe) => matchesMealFilters(recipe));
-    const matchLabel = filters.favoritesOnly
-      ? filteredRecipes.length === 1
-        ? 'favorite recipe matches'
-        : 'favorite recipes match'
-      : filteredRecipes.length === 1
-        ? 'recipe matches'
-        : 'recipes match';
-    const matchesText = `${filteredRecipes.length} ${matchLabel} your filters.`;
-    elements.mealCount.textContent = String(filteredRecipes.length);
-    elements.mealCount.setAttribute('aria-label', matchesText);
     elements.mealGrid.innerHTML = '';
     if (filteredRecipes.length) {
       filteredRecipes.forEach((recipe) => {

--- a/styles/app.css
+++ b/styles/app.css
@@ -580,38 +580,28 @@ select {
   color: var(--color-text-emphasis);
 }
 
-.filter-panel__count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 2.25rem;
-  margin: 0;
-  font-size: 1.425rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-}
-
 .favorite-filter {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.45rem;
-  padding: 0.55rem 0.9rem;
-  border-radius: 999px;
+  width: 2.55rem;
+  height: 2.55rem;
+  padding: 0;
+  border-radius: 50%;
   border: 1px solid var(--color-accent-border, rgba(244, 247, 229, 0.45));
   background: var(--color-background);
   color: var(--color-accent-secondary-strong, var(--color-accent-strong));
   font-weight: 600;
-  font-size: 0.92rem;
+  font-size: 1rem;
   cursor: pointer;
   transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease,
     border-color 0.2s ease, transform 0.2s ease;
 }
 
 .favorite-filter__icon {
-  font-size: 1.05rem;
+  font-size: 1.1rem;
   line-height: 1;
-  color: #d94ba5;
+  color: currentColor;
   transition: color 0.2s ease;
 }
 
@@ -637,12 +627,12 @@ select {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.45rem;
-  padding: 0.55rem 0.9rem;
+  gap: 0.4rem;
+  padding: 0.55rem 1rem;
   border-radius: 999px;
-  border: 1px solid var(--color-accent-secondary, rgba(107, 194, 125, 0.6));
-  background: var(--color-background);
-  color: var(--color-accent-secondary, #3fbd89);
+  border: 1px solid var(--color-border-muted, rgba(148, 163, 184, 0.28));
+  background: var(--color-panel, rgba(255, 255, 255, 0.8));
+  color: var(--color-text-muted);
   font-weight: 600;
   font-size: 0.92rem;
   cursor: pointer;
@@ -660,6 +650,7 @@ select {
 .pantry-only-filter:hover {
   transform: translateY(-1px);
   box-shadow: 0 16px 32px -24px var(--color-card-shadow-soft);
+  color: var(--color-text-emphasis);
 }
 
 .pantry-only-filter:focus-visible {
@@ -699,8 +690,8 @@ select {
 .recipe-family-filter {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 0.75rem;
+  gap: 0.35rem;
+  padding: 0.4rem 0.55rem;
   margin: 0.35rem 0 0.65rem;
   border-radius: 999px;
   border: 1px solid var(--color-border-muted);
@@ -713,16 +704,6 @@ select {
 .recipe-family-filter[data-filter-active='true'] {
   border-color: var(--color-accent-outline, rgba(68, 83, 214, 0.32));
   box-shadow: 0 20px 40px -28px var(--color-accent-shadow, rgba(68, 83, 214, 0.32));
-}
-
-.recipe-family-filter__label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-}
-
-.recipe-family-filter[data-filter-active='true'] .recipe-family-filter__label {
-  color: var(--color-text-emphasis);
 }
 
 .recipe-family-filter__list {
@@ -3843,10 +3824,6 @@ textarea:focus {
   --filter-section-shadow: rgba(28, 14, 10, 0.65);
   --filter-panel-group-foreground: #2a3439;
   --filter-panel-group-muted: rgba(42, 52, 57, 0.72);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .filter-panel__count {
-  color: rgba(251, 230, 213, 0.78);
 }
 
 :root[data-mode='sepia'][data-theme='copper'] .filter-section {


### PR DESCRIPTION
## Summary
- remove the visible "Favorites" label and filter count from the recipe filter toolbar while keeping accessible labelling
- rename the pantry toggle to "Pantry" with clearer on/off messaging and refresh the styling for the icon buttons
- simplify the family recipe filter so only the member icons remain

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d5f4d276e48325948663d22ea8d891