### PR TITLE
Refine pantry controls and reorganize meal plan day view

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,16 +120,23 @@
               </button>
               <button
                 type="button"
-                class="pantry-only-filter"
+                class="pantry-only-filter filter-action-button"
                 id="pantry-only-toggle"
                 aria-pressed="false"
                 aria-label="Pantry filter off: include all recipes"
                 title="Pantry filter off: include all recipes"
               >
                 <span class="pantry-only-filter__icon" aria-hidden="true">🧺</span>
-                <span class="pantry-only-filter__label">Pantry</span>
               </button>
-              <button type="button" class="reset-button" id="reset-filters">Reset</button>
+              <button
+                type="button"
+                class="reset-button filter-action-button"
+                id="reset-filters"
+                aria-label="Reset filters"
+                title="Reset filters"
+              >
+                <span class="reset-button__icon" aria-hidden="true">↻</span>
+              </button>
             </div>
           </div>
           <div class="recipe-family-filter" id="recipe-family-filter" hidden aria-hidden="true"></div>
@@ -300,6 +307,31 @@
           <div class="family-panel__list" id="family-member-list"></div>
           <button type="button" class="family-panel__add" id="family-add-member">Add family member</button>
         </div>
+      </section>
+    </div>
+    <div class="meal-plan-day-modal" id="meal-plan-day-modal" hidden>
+      <div class="meal-plan-day-modal__backdrop" id="meal-plan-day-modal-backdrop" aria-hidden="true"></div>
+      <section
+        class="meal-plan-day-modal__content"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="meal-plan-day-modal-title"
+      >
+        <header class="meal-plan-day-modal__header">
+          <div class="meal-plan-day-modal__titles">
+            <h3 class="meal-plan-day-modal__title" id="meal-plan-day-modal-title"></h3>
+            <p class="meal-plan-day-modal__subtitle" id="meal-plan-day-modal-subtitle"></p>
+          </div>
+          <button
+            type="button"
+            class="meal-plan-day-modal__close"
+            id="meal-plan-day-modal-close"
+            aria-label="Close day overview"
+          >
+            ×
+          </button>
+        </header>
+        <div class="meal-plan-day-modal__body" id="meal-plan-day-modal-body"></div>
       </section>
     </div>
   </body>

--- a/styles/app.css
+++ b/styles/app.css
@@ -167,6 +167,18 @@ button,
 select {
   font: inherit;
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
 .app-shell {
   min-height: 100vh;
   display: flex;
@@ -510,7 +522,7 @@ select {
   display: grid;
   grid-template-columns: minmax(240px, 320px) 1fr;
   gap: 1.75rem;
-  padding: 2rem 3rem 3rem;
+  padding: 2rem 3rem 3rem 0;
   align-items: flex-start;
   background: var(--color-layout-background);
   border-radius: 0;
@@ -534,6 +546,8 @@ select {
   padding: 1.5rem;
   background: var(--view-toggle-inactive-gradient);
   border-color: rgba(244, 247, 229, 0.35);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
   color: var(--view-toggle-inactive-text, #f4f7e5);
   --color-text-emphasis: var(--view-toggle-inactive-text, #f4f7e5);
   --color-text-tertiary: rgba(244, 247, 229, 0.78);
@@ -623,68 +637,62 @@ select {
   box-shadow: 0 18px 36px -24px rgba(217, 75, 165, 0.6);
 }
 
-.pantry-only-filter {
+.filter-action-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.4rem;
-  padding: 0.55rem 1rem;
-  border-radius: 999px;
-  border: 1px solid var(--color-border-muted, rgba(148, 163, 184, 0.28));
-  background: var(--color-panel, rgba(255, 255, 255, 0.8));
-  color: var(--color-text-muted);
-  font-weight: 600;
-  font-size: 0.92rem;
+  width: 2.55rem;
+  height: 2.55rem;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid var(--color-accent-secondary);
+  background: var(--color-neutral-50, transparent);
+  color: var(--color-accent-secondary);
+  line-height: 1;
   cursor: pointer;
-  transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease,
-    border-color 0.2s ease, transform 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
+    color 0.2s ease, border-color 0.2s ease;
+}
+
+.filter-action-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px -18px
+    var(--color-accent-secondary-shadow, var(--color-card-shadow-soft));
+}
+
+.filter-action-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
+}
+
+.pantry-only-filter {
+  position: relative;
 }
 
 .pantry-only-filter__icon {
-  font-size: 1.05rem;
+  font-size: 1.2rem;
   line-height: 1;
   color: currentColor;
   transition: color 0.2s ease;
 }
 
-.pantry-only-filter:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 16px 32px -24px var(--color-card-shadow-soft);
-  color: var(--color-text-emphasis);
-}
-
-.pantry-only-filter:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--color-focus-ring);
-}
-
 .pantry-only-filter.pantry-only-filter--active,
 .pantry-only-filter[aria-pressed='true'] {
-  background: linear-gradient(135deg, #3ca370 0%, #6dd195 50%, #3fbd89 100%);
-  color: #ffffff;
-  border-color: transparent;
-  box-shadow: 0 18px 36px -24px rgba(63, 189, 137, 0.45);
+  background: var(--color-accent-secondary);
+  color: var(--color-accent-secondary-contrast);
+  border-color: var(--color-accent-secondary);
+  box-shadow: 0 12px 25px -18px
+    var(--color-accent-secondary-shadow, var(--color-card-shadow-soft));
 }
 
 .pantry-only-filter.pantry-only-filter--active .pantry-only-filter__icon,
 .pantry-only-filter[aria-pressed='true'] .pantry-only-filter__icon {
-  color: #ffffff;
+  color: var(--color-accent-secondary-contrast);
 }
 
-.reset-button {
-  background: var(--color-neutral-50, transparent);
-  border: 1px solid var(--color-accent-secondary);
-  border-radius: 999px;
-  padding: 0.35rem 0.85rem;
-  color: var(--color-accent-secondary);
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.reset-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 25px -18px
-    var(--color-accent-secondary-shadow, var(--color-card-shadow-soft));
+.reset-button__icon {
+  font-size: 1.1rem;
+  line-height: 1;
 }
 
 .recipe-family-filter {
@@ -2188,6 +2196,100 @@ textarea:focus {
   box-shadow: 0 0 0 3px var(--color-focus-ring);
 }
 
+.meal-plan-day-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.meal-plan-day-modal[hidden] {
+  display: none;
+}
+
+.meal-plan-day-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(4px);
+}
+
+.meal-plan-day-modal__content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: min(720px, 100%);
+  max-height: 85vh;
+  padding: 1.5rem 1.75rem 1.75rem;
+  border-radius: 22px;
+  background: var(--meal-plan-surface, var(--color-surface));
+  border: 1px solid var(--meal-plan-border, rgba(79, 42, 28, 0.24));
+  box-shadow: 0 32px 60px -28px var(--color-card-shadow-soft);
+}
+
+.meal-plan-day-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.meal-plan-day-modal__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.meal-plan-day-modal__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--color-text-emphasis);
+}
+
+.meal-plan-day-modal__subtitle {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.meal-plan-day-modal__close {
+  appearance: none;
+  border: none;
+  background: none;
+  color: var(--color-text-muted);
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.25rem;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.meal-plan-day-modal__close:hover {
+  color: var(--color-text-emphasis);
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.meal-plan-day-modal__close:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.meal-plan-day-modal__body {
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.meal-plan-day-modal__body .meal-plan-day {
+  padding-right: 0.25rem;
+}
+
 .family-member-card {
   background: rgba(255, 255, 255, 0.98);
   border: 1px solid rgba(68, 83, 214, 0.18);
@@ -2790,31 +2892,26 @@ textarea:focus {
 }
 
 .meal-plan-calendar__day {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  display: flex;
+  justify-content: center;
+  padding: 1rem;
 }
 
-.meal-plan-calendar__day-column {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-  padding: 1rem;
-  border-radius: 16px;
+.meal-plan-calendar__day .meal-plan-day {
+  width: min(100%, 640px);
+  padding: 1.25rem;
+  border-radius: 18px;
   border: 1px solid rgba(68, 83, 214, 0.16);
   background: rgba(255, 255, 255, 0.92);
   box-shadow: 0 18px 32px -26px var(--color-card-shadow-soft);
 }
 
-.meal-plan-calendar__day-title {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 700;
-  color: var(--color-text-emphasis);
-}
-
-.meal-plan-calendar__day-column .meal-plan-empty {
-  margin-top: 0.35rem;
+.meal-plan-day-modal__body .meal-plan-day {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 18px;
+  border: 1px solid rgba(68, 83, 214, 0.16);
+  padding: 1.25rem;
+  box-shadow: 0 18px 32px -26px var(--color-card-shadow-soft);
 }
 
 .pantry-category__title {
@@ -2986,7 +3083,7 @@ textarea:focus {
   }
 
   .layout {
-    padding: 1.5rem;
+    padding: 1.5rem 1.5rem 1.5rem 0;
   }
 
   .meal-plan-view__header {
@@ -4155,7 +4252,6 @@ textarea:focus {
 :root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__entry,
 :root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__entry-title,
 :root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__more,
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__day-title,
 :root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__week-header-date,
 :root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__date-number {
   color: var(--color-gunmetal);


### PR DESCRIPTION
## Summary
- restyle the pantry-only and reset filter buttons with icon-focused controls that align with the reset button theme
- remove the left gutter from the filter column and adjust styling to sit flush with the viewport
- reorganize the meal planner day experience with a chronological single-column view and a reusable day-details modal for week/month selections

## Testing
- node tests/ingredient-matching.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6b0fe332483258256412a6e23cc86