### PR TITLE
Update pantry toggle styling and simplify meal plan sidebar

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -4550,6 +4550,7 @@
       showMeta = true,
       showHeader = true,
       headingId,
+      showEntries = true,
     } = options;
     const entries = sortMealPlanEntries(getMealPlanEntries(selectedIso));
     const wrapper = document.createElement('div');
@@ -4575,10 +4576,16 @@
       wrapper.appendChild(header);
     }
     if (!entries.length) {
+      if (!showEntries) {
+        return { container: wrapper, titleText, subtitleText, entryCount: entries.length };
+      }
       const empty = document.createElement('p');
       empty.className = 'meal-plan-empty';
       empty.textContent = 'Add meals, drinks, or snacks to fill this day.';
       wrapper.appendChild(empty);
+      return { container: wrapper, titleText, subtitleText, entryCount: entries.length };
+    }
+    if (!showEntries) {
       return { container: wrapper, titleText, subtitleText, entryCount: entries.length };
     }
     const list = document.createElement('div');
@@ -4617,10 +4624,11 @@
     const container = elements.mealPlanDayDetails;
     container.innerHTML = '';
     const { container: content } = createMealPlanDayDetailsContent(selectedDate, selectedIso, {
-      allowAttendance: true,
-      allowRemoval: true,
-      showMeta: true,
+      allowAttendance: false,
+      allowRemoval: false,
+      showMeta: false,
       showHeader: true,
+      showEntries: false,
     });
     container.appendChild(content);
   };

--- a/styles/app.css
+++ b/styles/app.css
@@ -616,7 +616,7 @@ select {
   font-size: 1.1rem;
   line-height: 1;
   color: currentColor;
-  transition: color 0.2s ease;
+  transition: color 0.2s ease, filter 0.2s ease, opacity 0.2s ease;
 }
 
 .favorite-filter:hover {
@@ -669,11 +669,25 @@ select {
   position: relative;
 }
 
+.pantry-only-filter:not(.pantry-only-filter--active):not([aria-pressed='true']) {
+  color: var(--color-gunmetal);
+  border-color: rgba(42, 52, 57, 0.45);
+  background: rgba(42, 52, 57, 0.08);
+}
+
+.pantry-only-filter:not(.pantry-only-filter--active):not([aria-pressed='true']):hover {
+  color: var(--color-gunmetal);
+  border-color: rgba(42, 52, 57, 0.6);
+  background: rgba(42, 52, 57, 0.12);
+}
+
 .pantry-only-filter__icon {
   font-size: 1.2rem;
   line-height: 1;
   color: currentColor;
-  transition: color 0.2s ease;
+  filter: grayscale(100%);
+  opacity: 0.8;
+  transition: color 0.2s ease, filter 0.2s ease, opacity 0.2s ease;
 }
 
 .pantry-only-filter.pantry-only-filter--active,
@@ -688,6 +702,8 @@ select {
 .pantry-only-filter.pantry-only-filter--active .pantry-only-filter__icon,
 .pantry-only-filter[aria-pressed='true'] .pantry-only-filter__icon {
   color: var(--color-accent-secondary-contrast);
+  filter: none;
+  opacity: 1;
 }
 
 .reset-button__icon {
@@ -2460,6 +2476,7 @@ textarea:focus {
   background: var(--color-sepia-light);
   border: 1px solid var(--meal-plan-border, rgba(79, 42, 28, 0.24));
   color: var(--color-burnished-copper);
+  flex: 1 1 auto;
 }
 
 .meal-plan-summary__title {


### PR DESCRIPTION
## Summary
- restyle the pantry-only filter button so the inactive state uses gunmetal accents and a grayscale basket icon while the active state remains vibrant
- let the meal plan sidebar reuse the day header without rendering individual entries, giving more room to the summary panel and allowing it to expand

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6cece636c8325a075c0aa88fa1e8d