### PR TITLE
Update meal plan summary heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@
             <aside class="meal-plan-sidebar" id="meal-plan-sidebar">
               <section class="meal-plan-day" id="meal-plan-day-details"></section>
               <section class="meal-plan-summary" id="meal-plan-summary">
-                <h3 class="meal-plan-summary__title">Daily overview</h3>
+                <h3 class="meal-plan-summary__title" id="meal-plan-summary-title">Daily overview</h3>
                 <p class="meal-plan-summary__hint">
                   Manage your household in the Family menu, then toggle icons on each meal to track
                   attendance and guest counts.


### PR DESCRIPTION
## Summary
- show the meal planning summary heading as a formatted date with an ordinal day and meal count
- remove the redundant day header from the sidebar details section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e1bcdaec83259a4e6ec0e3637b00