### PR TITLE
Remove meal plan summary hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,10 +251,6 @@
               <section class="meal-plan-day" id="meal-plan-day-details"></section>
               <section class="meal-plan-summary" id="meal-plan-summary">
                 <h3 class="meal-plan-summary__title" id="meal-plan-summary-title">Daily overview</h3>
-                <p class="meal-plan-summary__hint">
-                  Manage your household in the Family menu, then toggle icons on each meal to track
-                  attendance and guest counts.
-                </p>
                 <div class="meal-plan-summary__macros" id="meal-plan-macros" aria-live="polite"></div>
               </section>
             </aside>


### PR DESCRIPTION
## Summary
- remove the descriptive hint from the meal plan summary sidebar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e997b55c8325bb09a10d6f5e2861