### PR TITLE
Add pantry favorites and substitution controls

### DIFF
--- a/data/ingredients.js
+++ b/data/ingredients.js
@@ -9,6 +9,7 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'pasta-macaroni', name: 'Macaroni', category: 'Pasta', tags: ['Contains Gluten', 'Vegetarian'] },
   { slug: 'pasta-egg-noodles', name: 'Egg Noodles', category: 'Pasta', tags: ['Contains Gluten', 'Contains Eggs', 'Vegetarian'] },
   { slug: 'pasta-rice-noodles', name: 'Rice Noodles', category: 'Pasta', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
+  { slug: 'pasta-chickpea', name: 'Chickpea Pasta', category: 'Pasta', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'pasta-soba-buckwheat', name: 'Soba (Buckwheat)', category: 'Pasta', tags: ['May Contain Gluten', 'Vegetarian'] }, // many soba blends include wheat
   { slug: 'pasta-gluten-free-blend', name: 'Gluten-Free Pasta (corn/rice/quinoa)', category: 'Pasta', tags: ['Gluten-Free', 'Vegetarian'] },
   { slug: 'pasta-farfalle', name: 'Farfalle', category: 'Pasta', tags: ['Contains Gluten', 'Vegetarian'] },
@@ -36,6 +37,56 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'dairy-cheese-feta', name: 'Feta Cheese', category: 'Dairy', tags: ['Contains Dairy', 'Vegetarian'] },
   { slug: 'dairy-cheese-monterey-jack', name: 'Monterey Jack Cheese', category: 'Dairy', tags: ['Contains Dairy', 'Vegetarian'] },
   { slug: 'dairy-cheese-queso-fresco', name: 'Queso Fresco', category: 'Dairy', tags: ['Contains Dairy', 'Vegetarian'] },
+
+  // Dairy Alternatives
+  {
+    slug: 'alt-milk-almond',
+    name: 'Almond Milk',
+    category: 'Dairy Alternative',
+    tags: ['Dairy-Free', 'Vegetarian', 'Vegan', 'Contains Nuts'],
+  },
+  {
+    slug: 'alt-milk-oat',
+    name: 'Oat Milk',
+    category: 'Dairy Alternative',
+    tags: ['Dairy-Free', 'Vegetarian', 'Vegan'],
+  },
+  {
+    slug: 'alt-milk-soy',
+    name: 'Soy Milk',
+    category: 'Dairy Alternative',
+    tags: ['Dairy-Free', 'Vegetarian', 'Vegan', 'Contains Soy'],
+  },
+  {
+    slug: 'alt-milk-pea',
+    name: 'Pea Milk',
+    category: 'Dairy Alternative',
+    tags: ['Dairy-Free', 'Vegetarian', 'Vegan'],
+  },
+  {
+    slug: 'alt-butter-vegan',
+    name: 'Vegan Butter',
+    category: 'Dairy Alternative',
+    tags: ['Dairy-Free', 'Vegetarian', 'Vegan'],
+  },
+  {
+    slug: 'alt-cheese-vegan',
+    name: 'Vegan Cheese Shreds',
+    category: 'Dairy Alternative',
+    tags: ['Dairy-Free', 'Vegetarian', 'Vegan'],
+  },
+  {
+    slug: 'alt-yogurt-coconut',
+    name: 'Coconut Yogurt',
+    category: 'Dairy Alternative',
+    tags: ['Dairy-Free', 'Vegetarian', 'Vegan'],
+  },
+  {
+    slug: 'alt-cream-cashew',
+    name: 'Cashew Cream',
+    category: 'Dairy Alternative',
+    tags: ['Dairy-Free', 'Vegetarian', 'Vegan', 'Contains Nuts'],
+  },
 
   // Meat (raw single-ingredient; suitability tags are general)
   { slug: 'meat-beef-ground-85', name: 'Ground Beef (85% Lean)', category: 'Meat', tags: ['Halal-Friendly', 'Kosher-Friendly', 'Paleo'] },
@@ -250,6 +301,50 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'baking-cocoa-powder', name: 'Cocoa Powder', category: 'Baking', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'baking-cornstarch', name: 'Cornstarch', category: 'Baking', tags: ['Gluten-Free', 'Vegetarian', 'Vegan', 'Low-FODMAP'] },
   { slug: 'baking-egg', name: 'Eggs', category: 'Baking', tags: ['Contains Eggs'] },
+
+  // Baking Alternatives
+  {
+    slug: 'alt-egg-flax',
+    name: 'Flax Egg (1 tbsp ground flax + water)',
+    category: 'Baking Alternative',
+    tags: ['Egg-Free', 'Vegetarian', 'Vegan'],
+  },
+  {
+    slug: 'alt-egg-chia',
+    name: 'Chia Egg',
+    category: 'Baking Alternative',
+    tags: ['Egg-Free', 'Vegetarian', 'Vegan'],
+  },
+  {
+    slug: 'alt-egg-applesauce',
+    name: 'Unsweetened Applesauce (Egg Substitute)',
+    category: 'Baking Alternative',
+    tags: ['Egg-Free', 'Vegetarian', 'Vegan'],
+  },
+  {
+    slug: 'alt-egg-aquafaba',
+    name: 'Aquafaba (Whipped Chickpea Brine)',
+    category: 'Baking Alternative',
+    tags: ['Egg-Free', 'Vegetarian', 'Vegan', 'Legume'],
+  },
+  {
+    slug: 'alt-flour-almond',
+    name: 'Almond Flour',
+    category: 'Baking Alternative',
+    tags: ['Gluten-Free', 'Vegetarian', 'Vegan', 'Contains Nuts'],
+  },
+  {
+    slug: 'alt-flour-coconut',
+    name: 'Coconut Flour',
+    category: 'Baking Alternative',
+    tags: ['Gluten-Free', 'Vegetarian', 'Vegan'],
+  },
+  {
+    slug: 'alt-flour-cassava',
+    name: 'Cassava Flour',
+    category: 'Baking Alternative',
+    tags: ['Gluten-Free', 'Vegetarian', 'Vegan'],
+  },
   { slug: 'baking-yeast-active-dry', name: 'Yeast (Active Dry)', category: 'Baking', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'baking-vanilla-extract', name: 'Vanilla Extract', category: 'Baking', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'baking-chocolate-chips', name: 'Chocolate Chips', category: 'Baking', tags: ['Contains Dairy', 'Vegetarian'] }, // many contain dairy
@@ -268,6 +363,12 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'condiment-dijon-mustard', name: 'Dijon Mustard', category: 'Condiment/Sauce', tags: ['Gluten-Free*', 'Vegetarian', 'Vegan'] },
   { slug: 'condiment-ketchup', name: 'Ketchup', category: 'Condiment/Sauce', tags: ['Gluten-Free*', 'Vegetarian', 'Vegan'] },
   { slug: 'condiment-mayonnaise', name: 'Mayonnaise', category: 'Condiment/Sauce', tags: ['Contains Eggs', 'Gluten-Free*', 'Vegetarian'] },
+  {
+    slug: 'condiment-coconut-aminos',
+    name: 'Coconut Aminos',
+    category: 'Condiment/Sauce',
+    tags: ['Gluten-Free', 'Soy-Free', 'Vegetarian', 'Vegan'],
+  },
   { slug: 'condiment-soy-sauce', name: 'Soy Sauce', category: 'Condiment/Sauce', tags: ['Contains Soy', 'Contains Gluten', 'Vegetarian', 'Vegan'] },
   { slug: 'condiment-tamari-gf', name: 'Tamari (GF)', category: 'Condiment/Sauce', tags: ['Gluten-Free', 'Contains Soy', 'Vegetarian', 'Vegan'] },
   { slug: 'condiment-sriracha', name: 'Sriracha', category: 'Condiment/Sauce', tags: ['Gluten-Free*', 'Vegetarian', 'Vegan', 'Nightshade'] },
@@ -546,5 +647,13 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'veg-kabocha', name: 'Kabocha Squash', category: 'Vegetable', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'veg-celeriac', name: 'Celery Root', category: 'Vegetable', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'veg-jicama', name: 'Jicama', category: 'Vegetable', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
+  { slug: 'veg-hearts-of-palm', name: 'Hearts of Palm', category: 'Vegetable', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
+  { slug: 'veg-cauliflower-rice', name: 'Riced Cauliflower', category: 'Vegetable', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'veg-mustard-greens', name: 'Mustard Greens', category: 'Vegetable', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
+  {
+    slug: 'fruit-jackfruit-young',
+    name: 'Young Jackfruit (Canned)',
+    category: 'Fruit',
+    tags: ['Gluten-Free', 'Vegetarian', 'Vegan'],
+  },
 ];

--- a/index.html
+++ b/index.html
@@ -130,6 +130,25 @@
               </button>
               <button
                 type="button"
+                class="substitution-toggle filter-action-button"
+                id="substitution-toggle"
+                aria-pressed="false"
+                aria-label="Substitutions off: recipes must match pantry exactly"
+                title="Substitutions off: recipes must match pantry exactly"
+              >
+                <span class="substitution-toggle__icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <path d="M4 8h14" stroke-linecap="round"></path>
+                    <path d="M18 8l-3-3" stroke-linecap="round" stroke-linejoin="round"></path>
+                    <path d="M18 8l-3 3" stroke-linecap="round" stroke-linejoin="round"></path>
+                    <path d="M20 16H6" stroke-linecap="round"></path>
+                    <path d="M6 16l3-3" stroke-linecap="round" stroke-linejoin="round"></path>
+                    <path d="M6 16l3 3" stroke-linecap="round" stroke-linejoin="round"></path>
+                  </svg>
+                </span>
+              </button>
+              <button
+                type="button"
                 class="reset-button filter-action-button"
                 id="reset-filters"
                 aria-label="Reset filters"

--- a/styles/app.css
+++ b/styles/app.css
@@ -669,16 +669,18 @@ select {
   position: relative;
 }
 
-.pantry-only-filter:not(.pantry-only-filter--active):not([aria-pressed='true']) {
+.pantry-only-filter:not(.pantry-only-filter--active):not([aria-pressed='true']),
+.substitution-toggle:not(.substitution-toggle--active):not([aria-pressed='true']) {
   color: var(--color-gunmetal);
-  border-color: rgba(42, 52, 57, 0.45);
-  background: rgba(42, 52, 57, 0.08);
+  border-color: rgba(42, 52, 57, 0.55);
+  background: rgba(42, 52, 57, 0.12);
 }
 
-.pantry-only-filter:not(.pantry-only-filter--active):not([aria-pressed='true']):hover {
+.pantry-only-filter:not(.pantry-only-filter--active):not([aria-pressed='true']):hover,
+.substitution-toggle:not(.substitution-toggle--active):not([aria-pressed='true']):hover {
   color: var(--color-gunmetal);
-  border-color: rgba(42, 52, 57, 0.6);
-  background: rgba(42, 52, 57, 0.12);
+  border-color: rgba(42, 52, 57, 0.7);
+  background: rgba(42, 52, 57, 0.18);
 }
 
 .pantry-only-filter__icon {
@@ -688,6 +690,26 @@ select {
   filter: grayscale(100%);
   opacity: 0.8;
   transition: color 0.2s ease, filter 0.2s ease, opacity 0.2s ease;
+}
+
+.substitution-toggle {
+  position: relative;
+}
+
+.substitution-toggle__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  color: currentColor;
+  opacity: 0.85;
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.substitution-toggle__icon svg {
+  width: 100%;
+  height: 100%;
 }
 
 .pantry-only-filter.pantry-only-filter--active,
@@ -703,6 +725,21 @@ select {
 .pantry-only-filter[aria-pressed='true'] .pantry-only-filter__icon {
   color: var(--color-accent-secondary-contrast);
   filter: none;
+  opacity: 1;
+}
+
+.substitution-toggle.substitution-toggle--active,
+.substitution-toggle[aria-pressed='true'] {
+  background: var(--color-accent-secondary);
+  color: var(--color-accent-secondary-contrast);
+  border-color: var(--color-accent-secondary);
+  box-shadow: 0 12px 25px -18px
+    var(--color-accent-secondary-shadow, var(--color-card-shadow-soft));
+}
+
+.substitution-toggle.substitution-toggle--active .substitution-toggle__icon,
+.substitution-toggle[aria-pressed='true'] .substitution-toggle__icon {
+  color: var(--color-accent-secondary-contrast);
   opacity: 1;
 }
 
@@ -1348,6 +1385,38 @@ textarea:focus {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.meal-card__substitution-notice {
+  margin: 0.35rem 0 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  background: var(--color-accent-softer, rgba(217, 75, 165, 0.12));
+  color: var(--color-text-strong);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.meal-card__substitution-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.meal-card__substitution-list {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.meal-card__substitution-list li {
+  list-style: disc;
 }
 
 .meal-card__description {
@@ -3000,8 +3069,58 @@ textarea:focus {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  margin-left: auto;
   flex: 0 0 auto;
+}
+
+.pantry-card__header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: auto;
+  flex-wrap: nowrap;
+}
+
+.pantry-card__favorite-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-gunmetal);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.pantry-card__favorite-button span {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.pantry-card__favorite-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px -18px var(--color-card-shadow-soft);
+}
+
+.pantry-card__favorite-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
+}
+
+.pantry-card__favorite-button--active,
+.pantry-card__favorite-button[aria-pressed='true'] {
+  background: var(--gradient-accent);
+  color: var(--color-accent-contrast, #ffffff);
+  border-color: transparent;
+  box-shadow: 0 16px 32px -20px var(--color-accent-shadow);
+}
+
+.pantry-card--favorite {
+  border-color: var(--color-accent-border);
+  box-shadow: 0 18px 36px -26px var(--color-accent-shadow, rgba(217, 75, 165, 0.3));
 }
 
 .pantry-card__inline-input {


### PR DESCRIPTION
## Summary
- add pantry ingredient favorites with a dedicated heart control, styling, and persistence
- introduce an ingredient substitution system with a toggle, directional substitution families, and in-card guidance
- expand the ingredient catalog with common allergen-friendly alternatives and refresh related filter button styles

## Testing
- Manual smoke test in browser

------
https://chatgpt.com/codex/tasks/task_e_68daf5200c0c83258f21f77910443b66