### PR TITLE
Match reset and favorite buttons with neutral toggle styling

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -665,6 +665,18 @@ select {
   box-shadow: 0 0 0 3px var(--color-focus-ring);
 }
 
+.reset-button {
+  background: rgba(42, 52, 57, 0.12);
+  border-color: rgba(42, 52, 57, 0.55);
+  color: var(--color-gunmetal);
+}
+
+.reset-button:hover {
+  background: rgba(42, 52, 57, 0.18);
+  border-color: rgba(42, 52, 57, 0.7);
+  color: var(--color-gunmetal);
+}
+
 .pantry-only-filter {
   position: relative;
 }
@@ -1345,10 +1357,10 @@ textarea:focus {
 
 .meal-card__favorite-button {
   appearance: none;
-  border: 1px solid var(--color-accent-outline, rgba(244, 247, 229, 0.4));
+  border: 1px solid rgba(42, 52, 57, 0.55);
   border-radius: 999px;
-  background: var(--color-accent-softer, var(--color-accent-soft));
-  color: var(--color-accent-strong, var(--color-accent));
+  background: rgba(42, 52, 57, 0.12);
+  color: var(--color-gunmetal);
   padding: 0.3rem 0.8rem;
   font-size: 1.1rem;
   line-height: 1;
@@ -1365,6 +1377,8 @@ textarea:focus {
 .meal-card__favorite-button:hover {
   transform: translateY(-1px);
   box-shadow: 0 16px 32px -24px var(--color-accent-shadow, transparent);
+  background: rgba(42, 52, 57, 0.18);
+  border-color: rgba(42, 52, 57, 0.7);
 }
 
 .meal-card__favorite-button:focus-visible {


### PR DESCRIPTION
## Summary
- align the reset filter button styling with the pantry and substitution toggles by using the same translucent gray background and border colors
- update the meal card favorite button to share the neutral background treatment and hover state for visual consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db028d08a883258f573aa587e028de