### PR TITLE
Add holiday theme override controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,38 @@
                         <span class="theme-toolbar__label">Palette</span>
                         <div class="theme-toolbar__options theme-toolbar__options--themes" id="theme-options"></div>
                       </div>
+                      <div class="theme-toolbar__group theme-toolbar__group--holiday">
+                        <div class="theme-toolbar__holiday-row">
+                          <label class="holiday-theme-toggle" for="holiday-theme-toggle">
+                            <input type="checkbox" id="holiday-theme-toggle" />
+                            <span>Holiday Themes</span>
+                          </label>
+                          <button
+                            type="button"
+                            class="holiday-theme-settings"
+                            id="holiday-theme-settings"
+                            aria-label="Choose holidays for automatic themes"
+                            aria-haspopup="dialog"
+                            aria-controls="holiday-theme-dialog"
+                            title="Choose holidays for automatic themes"
+                          >
+                            <span class="holiday-theme-settings__icon" aria-hidden="true">
+                              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.3.136.855.142 1.205-.108l.737-.527a1.125 1.125 0 0 1 1.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.11v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.397-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 0 1-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.78.929l-.15.894c-.09.543-.56.94-1.11.94h-1.094c-.55 0-1.019-.397-1.11-.94l-.148-.894c-.071-.424-.384-.764-.78-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 0 1-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.11v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.107-1.204l-.527-.738a1.125 1.125 0 0 1 .12-1.45l.773-.773a1.125 1.125 0 0 1 1.45-.12l.737.527c.35.25.806.272 1.204.107.397-.165.71-.505.78-.929l.149-.894z"
+                                ></path>
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"></path>
+                              </svg>
+                            </span>
+                          </button>
+                        </div>
+                        <p class="holiday-theme-toggle__description">
+                          Automatically switch palettes on selected holidays.
+                        </p>
+                        <p class="holiday-theme-toggle__status" id="holiday-theme-status" hidden aria-live="polite"></p>
+                      </div>
                       <div class="theme-toolbar__group">
                         <span class="theme-toolbar__label">Units</span>
                         <div class="theme-toolbar__options" id="measurement-toggle">

--- a/styles/app.css
+++ b/styles/app.css
@@ -453,6 +453,84 @@ select {
   flex-wrap: wrap;
 }
 
+.theme-toolbar__group--holiday {
+  padding-top: 0.25rem;
+  border-top: 1px solid var(--color-border-soft, var(--color-border));
+}
+
+.theme-toolbar__holiday-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.holiday-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-weight: 600;
+  color: var(--color-text-emphasis);
+  cursor: pointer;
+  user-select: none;
+}
+
+.holiday-theme-toggle input[type='checkbox'] {
+  width: 1.2rem;
+  height: 1.2rem;
+  accent-color: var(--color-accent, currentColor);
+  cursor: pointer;
+}
+
+.holiday-theme-settings {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.holiday-theme-settings:hover {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px -18px var(--color-card-shadow);
+}
+
+.holiday-theme-settings:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.holiday-theme-settings__icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.holiday-theme-toggle__description {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.holiday-theme-toggle__status {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--color-text-secondary);
+}
+
+.holiday-theme-toggle__status[data-holiday-active='true'] {
+  color: var(--color-accent-strong, var(--color-accent));
+  font-weight: 600;
+}
+
 .mode-toggle__button {
   border: 1px solid var(--color-border);
   border-radius: 999px;
@@ -4442,6 +4520,151 @@ textarea:focus {
 :root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__week-header-date,
 :root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__date-number {
   color: var(--color-gunmetal);
+}
+
+.holiday-theme-dialog {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 60;
+}
+
+.holiday-theme-dialog[hidden] {
+  display: none;
+}
+
+.holiday-theme-dialog[data-open='true'] {
+  display: flex;
+}
+
+.holiday-theme-dialog__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.38);
+  backdrop-filter: blur(2px);
+}
+
+.holiday-theme-dialog__panel {
+  position: relative;
+  width: min(420px, 90vw);
+  max-height: min(80vh, 560px);
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: 0 32px 48px -26px var(--color-card-shadow);
+  padding: 1.4rem 1.6rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  z-index: 1;
+}
+
+.holiday-theme-dialog__title {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--color-text-emphasis);
+}
+
+.holiday-theme-dialog__description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.holiday-theme-dialog__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0 0.25rem 0 0;
+  overflow-y: auto;
+  max-height: 320px;
+}
+
+.holiday-theme-dialog__item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: var(--color-surface-soft);
+  transition: border-color 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.holiday-theme-dialog__item[data-checked='true'] {
+  border-color: var(--color-accent);
+  background: var(--color-surface-highlight, var(--color-surface-soft));
+}
+
+.holiday-theme-dialog__checkbox {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex-shrink: 0;
+  accent-color: var(--color-accent);
+}
+
+.holiday-theme-dialog__item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-weight: 600;
+  color: var(--color-text-emphasis);
+}
+
+.holiday-theme-dialog__item-name {
+  font-size: 0.95rem;
+}
+
+.holiday-theme-dialog__item-date {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.holiday-theme-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: auto;
+}
+
+.holiday-theme-dialog__button {
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  padding: 0.55rem 1.35rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.holiday-theme-dialog__button:hover {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px -20px var(--color-card-shadow);
+}
+
+.holiday-theme-dialog__button--primary {
+  background: var(--gradient-accent);
+  color: var(--color-accent-contrast);
+  border-color: transparent;
+}
+
+.holiday-theme-dialog__button--primary:hover {
+  color: var(--color-accent-contrast);
+  box-shadow: 0 18px 32px -22px var(--color-accent-shadow-strong);
+}
+
+.holiday-theme-dialog__button:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 :root[data-mode='sepia'][data-theme='umber'] {


### PR DESCRIPTION
## Summary
- add a Holiday Themes toggle under the palette selector and surface its current status
- enable holiday-aware theme overrides with persistent allow lists and a configurable selection dialog
- style the new controls and dialog to match the existing settings aesthetic

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfe7ceb7fc8325ae8fcfbdaff99ad4