### PR TITLE
Add floating navigation chip and kitchen equipment view

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,29 +10,40 @@
   <body>
     <div class="app-shell">
       <header class="app-header">
-        <div class="header-grid">
-          <div class="header-grid__secondary">
-            <div class="menu-column">
-              <div class="menu-column__row">
-                <div class="view-toggle">
-                  <button
-                    type="button"
-                    class="view-toggle__button view-toggle__button--active"
-                    data-view-target="meals"
-                  >
-                    Recipes
-                  </button>
-                  <button type="button" class="view-toggle__button" data-view-target="pantry">
-                    Pantry
-                  </button>
-                  <button type="button" class="view-toggle__button" data-view-target="meal-plan">
-                    Meal Plan
-                  </button>
-                </div>
-                <button type="button" class="family-button" id="family-button">
-                  Family
-                </button>
-                <details class="settings-panel" id="settings-panel">
+        <div class="app-header__inner">
+          <button
+            type="button"
+            class="nav-chip__toggle"
+            id="primary-nav-toggle"
+            aria-label="Toggle primary menu"
+            aria-expanded="false"
+            aria-controls="primary-nav"
+          >
+            <span class="nav-chip__toggle-icon" aria-hidden="true">☰</span>
+            <span class="nav-chip__toggle-label">Menu</span>
+          </button>
+          <nav class="nav-chip view-toggle" id="primary-nav" aria-label="Primary">
+            <button
+              type="button"
+              class="view-toggle__button view-toggle__button--active"
+              data-view-target="meals"
+            >
+              Recipes
+            </button>
+            <button type="button" class="view-toggle__button" data-view-target="kitchen">
+              Kitchen
+            </button>
+            <button type="button" class="view-toggle__button" data-view-target="pantry">
+              Pantry
+            </button>
+            <button type="button" class="view-toggle__button" data-view-target="meal-plan">
+              Meal Plan
+            </button>
+            <button type="button" class="view-toggle__button family-button" id="family-button">
+              Family
+            </button>
+          </nav>
+          <details class="settings-panel" id="settings-panel">
                   <summary
                     class="settings-panel__summary"
                     aria-label="Display and unit settings"
@@ -130,10 +141,7 @@
                       </div>
                     </div>
                   </div>
-                </details>
-              </div>
-            </div>
-          </div>
+          </details>
         </div>
       </header>
       <main class="layout" id="app-layout">
@@ -226,6 +234,19 @@
         </aside>
         <section class="content" id="meal-view">
           <div class="meal-grid" id="meal-grid"></div>
+        </section>
+        <section class="pantry-view kitchen-view" id="kitchen-view" hidden>
+          <header class="pantry-view__header">
+            <div>
+              <h2>Kitchen</h2>
+              <p>Keep track of cookware, appliances, and tools available in your kitchen.</p>
+            </div>
+            <div class="pantry-view__summary">
+              <span id="kitchen-count">0</span>
+              <p>items ready for cooking</p>
+            </div>
+          </header>
+          <div class="pantry-grid kitchen-grid" id="kitchen-grid"></div>
         </section>
         <section class="pantry-view" id="pantry-view" hidden>
           <header class="pantry-view__header">

--- a/styles/app.css
+++ b/styles/app.css
@@ -187,7 +187,7 @@ select {
 }
 
 .app-header {
-  padding: 0.625rem 1.5625rem;
+  padding: 4.25rem 1.5625rem 1.5rem;
   background: var(--color-header-background);
   color: var(
     --color-header-foreground,
@@ -200,63 +200,146 @@ select {
   z-index: 10;
 }
 
-.header-grid {
-  display: grid;
-  gap: 1.75rem;
-  padding: 0.625rem 1.5625rem;
-}
-
-.header-grid__primary {
+.app-header__inner {
   display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.header-grid__secondary {
-  display: flex;
-  justify-content: flex-start;
-}
-
-.menu-column {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  width: 100%;
-}
-
-.menu-column__row {
-  display: flex;
-  flex-wrap: wrap;
+  justify-content: flex-end;
   align-items: center;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
-.menu-column__row .view-toggle {
-  flex: 0 0 auto;
+.nav-chip {
+  position: fixed;
+  top: 1.5rem;
+  left: 1.5rem;
+  display: flex;
+  align-items: stretch;
+  background: var(--color-panel, rgba(255, 255, 255, 0.85));
+  border-radius: 999px;
+  box-shadow: 0 20px 42px -28px var(--color-card-shadow-soft);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  padding: 0.35rem;
+  gap: 0;
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+  z-index: 20;
+}
+
+.nav-chip__toggle {
+  position: fixed;
+  top: 1.5rem;
+  left: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  background: var(--color-panel, rgba(255, 255, 255, 0.9));
+  color: var(--color-text-strong);
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 18px 38px -26px var(--color-card-shadow-soft);
+  transition: transform 0.2s ease, box-shadow 0.2s ease,
+    background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  z-index: 21;
+}
+
+.nav-chip__toggle:hover,
+.nav-chip__toggle:focus-visible {
+  transform: translateY(-1px);
+  outline: none;
+  box-shadow: 0 20px 44px -26px var(--color-card-shadow-soft);
+  border-color: rgba(255, 255, 255, 0.85);
+}
+
+.nav-chip__toggle-icon {
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
+.nav-chip__toggle--active {
+  background: var(--gradient-accent);
+  color: var(--color-accent-contrast, #ffffff);
+  border-color: transparent;
+}
+
+.nav-chip .view-toggle__button {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.1rem;
+  background: transparent;
+  color: var(--color-text-strong);
+  box-shadow: none;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-chip .view-toggle__button + .view-toggle__button {
+  position: relative;
+}
+
+.nav-chip .view-toggle__button + .view-toggle__button::before {
+  content: '';
+  position: absolute;
+  top: 22%;
+  bottom: 22%;
+  left: 0;
+  width: 1px;
+  background: var(--color-border-muted, rgba(42, 52, 57, 0.14));
+}
+
+.nav-chip .view-toggle__button:hover,
+.nav-chip .view-toggle__button:focus-visible {
+  transform: none;
+  box-shadow: none;
+  outline: none;
+  background: rgba(42, 52, 57, 0.08);
+}
+
+.nav-chip .view-toggle__button--active {
+  background: var(--view-toggle-active-gradient, var(--gradient-accent));
+  color: var(--view-toggle-active-text, var(--color-accent-contrast));
+  box-shadow: none;
+}
+
+.nav-chip .view-toggle__button--active:hover,
+.nav-chip .view-toggle__button--active:focus-visible {
+  background: var(--view-toggle-active-gradient, var(--gradient-accent));
+  color: var(--view-toggle-active-text, var(--color-accent-contrast));
+}
+
+.nav-chip .family-button {
+  font-weight: 600;
 }
 
 .family-button {
-  flex: 0 0 auto;
-  padding: 0.55rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid var(
-      --view-toggle-inactive-border,
-      rgba(125, 147, 65, 0.45)
-    );
-  background: var(--view-toggle-inactive-gradient);
-  color: var(--view-toggle-inactive-text, #f4f7e5);
-  font-weight: 600;
+  border: none;
+  background: transparent;
+  color: inherit;
   cursor: pointer;
-  box-shadow: 0 10px 24px -20px var(--color-card-shadow);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
-    color 0.2s ease;
 }
 
-.family-button:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--view-toggle-hover-glow, 0 0 16px rgba(233, 204, 138, 0.45));
-  background: var(--view-toggle-inactive-gradient);
-  color: var(--view-toggle-inactive-text, #f4f7e5);
+.family-button:hover,
+.family-button:focus-visible {
+  outline: none;
+}
+
+@media (max-width: 62.5rem) {
+  .nav-chip {
+    display: none;
+  }
+
+  .nav-chip.nav-chip--open {
+    display: flex;
+  }
+}
+
+@media (min-width: 62.5625rem) {
+  .nav-chip__toggle {
+    display: none;
+  }
 }
 
 .family-button:focus-visible {
@@ -611,7 +694,8 @@ select {
 }
 
 .filter-panel,
-.pantry-view {
+.pantry-view,
+.kitchen-view {
   border: 1px solid var(--color-accent-outline, var(--color-border-muted));
   border-radius: 18px;
   box-shadow: 0 24px 48px -28px var(--color-card-shadow);
@@ -642,7 +726,8 @@ select {
   --filter-section-shadow: rgba(20, 33, 61, 0.24);
 }
 
-.pantry-view {
+.pantry-view,
+.kitchen-view {
   background: var(--surface-panel-gradient);
 }
 
@@ -1669,7 +1754,8 @@ textarea:focus {
   color: var(--color-text-strong);
 }
 
-.pantry-view {
+.pantry-view,
+.kitchen-view {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -3172,6 +3258,17 @@ textarea:focus {
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.kitchen-card {
+  gap: 0.5rem;
+  padding: 1rem 1.1rem;
+}
+
+.kitchen-card__usage {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
 .pantry-card:focus-within {
   border-color: var(--color-accent-border);
   box-shadow: 0 12px 28px -20px var(--color-card-shadow-soft);
@@ -3323,6 +3420,7 @@ textarea:focus {
   }
 
   .pantry-view,
+  .kitchen-view,
   .meal-plan-view {
     position: sticky;
     top: 5.5rem;
@@ -3336,6 +3434,7 @@ textarea:focus {
 
   .filter-panel,
   .pantry-view,
+  .kitchen-view,
   .meal-plan-view {
     position: static;
     max-height: none;


### PR DESCRIPTION
## Summary
- redesign the header navigation into a floating segmented chip with a collapsible toggle for small screens
- add a dedicated Kitchen view that aggregates recipe equipment into a browsable inventory with search
- update filter panel behavior and styling to support the new view and shared layouts

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dffeb60d9883258b219cbbff30ebbb