### PR TITLE
Allow custom theme palettes with dynamic color tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-mode="light" data-theme="serene">
+<html lang="en" data-mode="light">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
@@ -66,14 +66,90 @@
                           <button type="button" class="mode-toggle__button" data-mode="dark" aria-pressed="false">
                             Dark
                           </button>
-                          <button type="button" class="mode-toggle__button" data-mode="sepia" aria-pressed="false">
-                            Sepia
-                          </button>
                         </div>
                       </div>
                       <div class="theme-toolbar__group">
                         <span class="theme-toolbar__label">Palette</span>
-                        <div class="theme-toolbar__options theme-toolbar__options--themes" id="theme-options"></div>
+                        <div class="theme-toolbar__palette" id="theme-palette">
+                          <div class="theme-color-control">
+                            <span class="theme-color-control__label" id="theme-color-label-background"
+                              >Background</span
+                            >
+                            <div class="theme-color-control__inputs">
+                              <input
+                                type="color"
+                                class="theme-color-control__picker"
+                                data-color-role="background"
+                                aria-labelledby="theme-color-label-background"
+                              />
+                              <input
+                                type="text"
+                                class="theme-color-control__value"
+                                data-color-role="background"
+                                aria-labelledby="theme-color-label-background"
+                                placeholder="#RRGGBB"
+                                spellcheck="false"
+                                autocapitalize="off"
+                                autocomplete="off"
+                                inputmode="text"
+                                maxlength="7"
+                                pattern="^#?[0-9A-Fa-f]{3,6}$"
+                              />
+                            </div>
+                          </div>
+                          <div class="theme-color-control">
+                            <span class="theme-color-control__label" id="theme-color-label-primary"
+                              >Primary</span
+                            >
+                            <div class="theme-color-control__inputs">
+                              <input
+                                type="color"
+                                class="theme-color-control__picker"
+                                data-color-role="main"
+                                aria-labelledby="theme-color-label-primary"
+                              />
+                              <input
+                                type="text"
+                                class="theme-color-control__value"
+                                data-color-role="main"
+                                aria-labelledby="theme-color-label-primary"
+                                placeholder="#RRGGBB"
+                                spellcheck="false"
+                                autocapitalize="off"
+                                autocomplete="off"
+                                inputmode="text"
+                                maxlength="7"
+                                pattern="^#?[0-9A-Fa-f]{3,6}$"
+                              />
+                            </div>
+                          </div>
+                          <div class="theme-color-control">
+                            <span class="theme-color-control__label" id="theme-color-label-accent"
+                              >Accent</span
+                            >
+                            <div class="theme-color-control__inputs">
+                              <input
+                                type="color"
+                                class="theme-color-control__picker"
+                                data-color-role="accent"
+                                aria-labelledby="theme-color-label-accent"
+                              />
+                              <input
+                                type="text"
+                                class="theme-color-control__value"
+                                data-color-role="accent"
+                                aria-labelledby="theme-color-label-accent"
+                                placeholder="#RRGGBB"
+                                spellcheck="false"
+                                autocapitalize="off"
+                                autocomplete="off"
+                                inputmode="text"
+                                maxlength="7"
+                                pattern="^#?[0-9A-Fa-f]{3,6}$"
+                              />
+                            </div>
+                          </div>
+                        </div>
                       </div>
                       <div class="theme-toolbar__group theme-toolbar__group--holiday">
                         <div class="theme-toolbar__holiday-row">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1332,98 +1332,202 @@
   const THEME_STORAGE_KEY = 'blissful-theme';
   const HOLIDAY_THEME_STORAGE_KEY = 'blissful-holiday-themes';
   let lastPersistedHolidayThemes = null;
-  const THEME_OPTIONS = {
-    light: [
-      {
-        id: 'serene',
-        label: 'Serene',
-        preview: 'linear-gradient(135deg, #4453d6, #f59e0b)',
-      },
-      {
-        id: 'sunrise',
-        label: 'Sunrise',
-        preview: 'linear-gradient(135deg, #f97316, #0ea5e9)',
-      },
-      {
-        id: 'meadow',
-        label: 'Meadow',
-        preview: 'linear-gradient(135deg, #2f855a, #6366f1)',
-      },
-      {
-        id: 'mist',
-        label: 'Misty Morning',
-        preview: 'linear-gradient(135deg, #38bdf8, #a855f7)',
-      },
-      {
-        id: 'blossom',
-        label: 'Blossom',
-        preview: 'linear-gradient(135deg, #ec4899, #22d3ee)',
-      },
-      {
-        id: 'citrine',
-        label: 'Citrine Glow',
-        preview: 'linear-gradient(135deg, #facc15, #3b82f6)',
-      },
-    ],
-    dark: [
-      {
-        id: 'midnight',
-        label: 'Midnight',
-        preview: 'linear-gradient(135deg, #2f6df0, #f472b6)',
-      },
-      {
-        id: 'nebula',
-        label: 'Nebula',
-        preview: 'linear-gradient(135deg, #a855f7, #22d3ee)',
-      },
-      {
-        id: 'forest',
-        label: 'Forest',
-        preview: 'linear-gradient(135deg, #34d399, #fbbf24)',
-      },
-      {
-        id: 'ember',
-        label: 'Ember',
-        preview: 'linear-gradient(135deg, #f97316, #2563eb)',
-      },
-      {
-        id: 'abyss',
-        label: 'Abyss',
-        preview: 'linear-gradient(135deg, #14b8a6, #8b5cf6)',
-      },
-      {
-        id: 'velvet',
-        label: 'Velvet Night',
-        preview: 'linear-gradient(135deg, #f472b6, #14b8a6)',
-      },
-    ],
-    sepia: [
-      {
-        id: 'classic',
-        label: 'Classic Sepia',
-        preview: 'linear-gradient(135deg, #b7791f, #2f855a)',
-      },
-      {
-        id: 'copper',
-        label: 'Copper Glow',
-        preview: 'linear-gradient(135deg, #c26a3d, #0f766e)',
-      },
-      {
-        id: 'umber',
-        label: 'Deep Umber',
-        preview: 'linear-gradient(135deg, #8a4b2a, #3b82f6)',
-      },
-    ],
-  };
-
-  const DEFAULT_THEME_SELECTIONS = {
-    light: 'serene',
-    dark: 'midnight',
-    sepia: 'classic',
+  const DEFAULT_THEME_PALETTES = {
+    light: {
+      background: '#F5F8FF',
+      main: '#3B82F6',
+      accent: '#22D3EE',
+    },
+    dark: {
+      background: '#0F172A',
+      main: '#60A5FA',
+      accent: '#38BDF8',
+    },
   };
 
   const DEFAULT_MODE = 'light';
-  const AVAILABLE_MODES = Object.keys(THEME_OPTIONS);
+  const AVAILABLE_MODES = Object.keys(DEFAULT_THEME_PALETTES);
+  let lastPersistedTheme = null;
+
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+  const clamp01 = (value) => clamp(value, 0, 1);
+
+  const normalizeHexColor = (value) => {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    let hex = value.trim();
+    if (!hex) {
+      return null;
+    }
+    if (!hex.startsWith('#')) {
+      hex = `#${hex}`;
+    }
+    const match = hex.match(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
+    if (!match) {
+      return null;
+    }
+    if (hex.length === 4) {
+      hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+    }
+    return hex.toUpperCase();
+  };
+
+  const componentToHex = (component) => Math.round(clamp(component, 0, 255)).toString(16).padStart(2, '0');
+
+  const rgbToHex = ({ r, g, b }) => `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`.toUpperCase();
+
+  const hexToRgb = (value) => {
+    const normalized = normalizeHexColor(value);
+    if (!normalized) {
+      return null;
+    }
+    const r = parseInt(normalized.slice(1, 3), 16);
+    const g = parseInt(normalized.slice(3, 5), 16);
+    const b = parseInt(normalized.slice(5, 7), 16);
+    return { r, g, b, hex: normalized };
+  };
+
+  const rgbToHsl = ({ r, g, b }) => {
+    const rNorm = r / 255;
+    const gNorm = g / 255;
+    const bNorm = b / 255;
+    const max = Math.max(rNorm, gNorm, bNorm);
+    const min = Math.min(rNorm, gNorm, bNorm);
+    let h = 0;
+    let s = 0;
+    const l = (max + min) / 2;
+    if (max !== min) {
+      const delta = max - min;
+      s = l > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+      switch (max) {
+        case rNorm:
+          h = (gNorm - bNorm) / delta + (gNorm < bNorm ? 6 : 0);
+          break;
+        case gNorm:
+          h = (bNorm - rNorm) / delta + 2;
+          break;
+        default:
+          h = (rNorm - gNorm) / delta + 4;
+          break;
+      }
+      h /= 6;
+    }
+    return { h, s, l };
+  };
+
+  const hueToRgb = (p, q, t) => {
+    let tt = t;
+    if (tt < 0) tt += 1;
+    if (tt > 1) tt -= 1;
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+    if (tt < 1 / 2) return q;
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+    return p;
+  };
+
+  const hslToRgb = ({ h, s, l }) => {
+    const saturation = clamp01(s);
+    const lightness = clamp01(l);
+    if (saturation === 0) {
+      const value = Math.round(lightness * 255);
+      return { r: value, g: value, b: value };
+    }
+    const q = lightness < 0.5 ? lightness * (1 + saturation) : lightness + saturation - lightness * saturation;
+    const p = 2 * lightness - q;
+    const r = Math.round(hueToRgb(p, q, h + 1 / 3) * 255);
+    const g = Math.round(hueToRgb(p, q, h) * 255);
+    const b = Math.round(hueToRgb(p, q, h - 1 / 3) * 255);
+    return { r, g, b };
+  };
+
+  const adjustLightness = (rgb, amount) => {
+    const hsl = rgbToHsl(rgb);
+    return hslToRgb({ h: hsl.h, s: hsl.s, l: clamp01(hsl.l + amount) });
+  };
+
+  const adjustSaturation = (rgb, amount) => {
+    const hsl = rgbToHsl(rgb);
+    return hslToRgb({ h: hsl.h, s: clamp01(hsl.s + amount), l: hsl.l });
+  };
+
+  const mixColors = (a, b, amount) => {
+    const t = clamp01(amount);
+    return {
+      r: Math.round(a.r + (b.r - a.r) * t),
+      g: Math.round(a.g + (b.g - a.g) * t),
+      b: Math.round(a.b + (b.b - a.b) * t),
+    };
+  };
+
+  const toRgba = (rgb, alpha) => `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${Math.round(clamp01(alpha) * 1000) / 1000})`;
+
+  const relativeLuminance = ({ r, g, b }) => {
+    const transform = (channel) => {
+      const value = channel / 255;
+      return value <= 0.03928 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4);
+    };
+    const rLin = transform(r);
+    const gLin = transform(g);
+    const bLin = transform(b);
+    return 0.2126 * rLin + 0.7152 * gLin + 0.0722 * bLin;
+  };
+
+  const contrastRatio = (foreground, background) => {
+    const lumA = relativeLuminance(foreground);
+    const lumB = relativeLuminance(background);
+    const light = Math.max(lumA, lumB);
+    const dark = Math.min(lumA, lumB);
+    return (light + 0.05) / (dark + 0.05);
+  };
+
+  const getReadableTextColor = (background, candidates) => {
+    const palette = Array.isArray(candidates)
+      ? candidates
+      : ['#0F172A', '#111827', '#F8FAFC', '#F1F5F9'];
+    let best = palette[0];
+    let bestContrast = -Infinity;
+    palette.forEach((candidate) => {
+      const candidateRgb = hexToRgb(candidate);
+      if (!candidateRgb) {
+        return;
+      }
+      const contrast = contrastRatio(candidateRgb, background);
+      if (contrast > bestContrast) {
+        bestContrast = contrast;
+        best = candidateRgb.hex;
+      }
+    });
+    return best;
+  };
+
+  const alphaColor = (hex, alpha) => {
+    const rgb = hexToRgb(hex);
+    if (!rgb) {
+      return `rgba(0, 0, 0, ${clamp01(alpha)})`;
+    }
+    return toRgba(rgb, alpha);
+  };
+
+  const sanitizeThemePalette = (palette, mode) => {
+    const defaults = DEFAULT_THEME_PALETTES[mode] || DEFAULT_THEME_PALETTES.light;
+    return {
+      background: normalizeHexColor(palette?.background) || defaults.background,
+      main: normalizeHexColor(palette?.main) || defaults.main,
+      accent: normalizeHexColor(palette?.accent) || defaults.accent,
+    };
+  };
+
+  const sanitizeThemePalettes = (palettes) => {
+    const result = {};
+    AVAILABLE_MODES.forEach((mode) => {
+      result[mode] = sanitizeThemePalette(palettes?.[mode], mode);
+    });
+    return result;
+  };
+
+  const WHITE_RGB = hexToRgb('#FFFFFF');
+  const BLACK_RGB = hexToRgb('#020617');
 
   const MEASUREMENT_STORAGE_KEY = 'blissful-measurement';
   const MEASUREMENT_SYSTEMS = ['imperial', 'metric'];
@@ -1595,28 +1699,26 @@
 
   const loadThemePreferences = () => {
     const fallbackMode = resolveFallbackMode();
-    const fallback = { mode: fallbackMode, selections: { ...DEFAULT_THEME_SELECTIONS } };
+    const fallbackPalettes = sanitizeThemePalettes(DEFAULT_THEME_PALETTES);
+    const fallback = { mode: fallbackMode, palettes: fallbackPalettes };
     try {
-      const stored = JSON.parse(localStorage.getItem(THEME_STORAGE_KEY));
+      const storedRaw = localStorage.getItem(THEME_STORAGE_KEY);
+      if (!storedRaw) {
+        lastPersistedTheme = null;
+        return fallback;
+      }
+      const stored = JSON.parse(storedRaw);
       if (!stored || typeof stored !== 'object') {
+        lastPersistedTheme = null;
         return fallback;
       }
       const mode = AVAILABLE_MODES.includes(stored.mode) ? stored.mode : fallbackMode;
-      const selections = { ...DEFAULT_THEME_SELECTIONS, ...(stored.selections || {}) };
-      AVAILABLE_MODES.forEach((key) => {
-        const options = Array.isArray(THEME_OPTIONS[key]) ? THEME_OPTIONS[key] : [];
-        if (!options.length) return;
-        if (!options.some((option) => option.id === selections[key])) {
-          const fallbackSelection =
-            DEFAULT_THEME_SELECTIONS[key] || (options[0] ? options[0].id : undefined);
-          if (fallbackSelection) {
-            selections[key] = fallbackSelection;
-          }
-        }
-      });
-      return { mode, selections };
+      const palettes = sanitizeThemePalettes(stored.palettes);
+      lastPersistedTheme = JSON.stringify({ mode, palettes });
+      return { mode, palettes };
     } catch (error) {
       console.warn('Unable to read saved theme preferences.', error);
+      lastPersistedTheme = null;
       return fallback;
     }
   };
@@ -1788,22 +1890,53 @@
 
   const holidayThemePreferences = loadHolidayThemePreferences();
 
+  const SHARED_THEME_PRESETS = {
+    calm: {
+      light: DEFAULT_THEME_PALETTES.light,
+      dark: DEFAULT_THEME_PALETTES.dark,
+    },
+    sunset: {
+      light: {
+        background: '#FFF7ED',
+        main: '#F97316',
+        accent: '#EC4899',
+      },
+      dark: {
+        background: '#1C1917',
+        main: '#FB923C',
+        accent: '#F472B6',
+      },
+    },
+    forest: {
+      light: {
+        background: '#F0FDF4',
+        main: '#22C55E',
+        accent: '#0EA5E9',
+      },
+      dark: {
+        background: '#022C22',
+        main: '#34D399',
+        accent: '#FACC15',
+      },
+    },
+  };
+
   const HOLIDAY_THEME_OVERRIDES = {
-    'new-years-day': { light: 'citrine', dark: 'nebula', sepia: 'copper' },
-    'martin-luther-king-jr-day': { light: 'mist', dark: 'midnight', sepia: 'classic' },
-    'valentines-day': { light: 'blossom', dark: 'velvet', sepia: 'copper' },
-    'presidents-day': { light: 'serene', dark: 'midnight', sepia: 'classic' },
-    'st-patricks-day': { light: 'meadow', dark: 'forest', sepia: 'umber' },
-    'mothers-day': { light: 'blossom', dark: 'velvet', sepia: 'classic' },
-    'memorial-day': { light: 'sunrise', dark: 'ember', sepia: 'copper' },
-    'juneteenth': { light: 'sunrise', dark: 'ember', sepia: 'copper' },
-    'independence-day': { light: 'citrine', dark: 'nebula', sepia: 'copper' },
-    'labor-day': { light: 'meadow', dark: 'forest', sepia: 'classic' },
-    'halloween': { light: 'sunrise', dark: 'abyss', sepia: 'umber' },
-    'thanksgiving-day': { light: 'meadow', dark: 'forest', sepia: 'umber' },
-    'christmas-eve': { light: 'mist', dark: 'abyss', sepia: 'classic' },
-    'christmas-day': { light: 'mist', dark: 'abyss', sepia: 'classic' },
-    'new-years-eve': { light: 'citrine', dark: 'nebula', sepia: 'copper' },
+    'new-years-day': 'calm',
+    'martin-luther-king-jr-day': 'calm',
+    'valentines-day': 'sunset',
+    'presidents-day': 'calm',
+    'st-patricks-day': 'forest',
+    'mothers-day': 'sunset',
+    'memorial-day': 'calm',
+    'juneteenth': 'sunset',
+    'independence-day': 'calm',
+    'labor-day': 'forest',
+    halloween: 'sunset',
+    'thanksgiving-day': 'forest',
+    'christmas-eve': 'calm',
+    'christmas-day': 'calm',
+    'new-years-eve': 'calm',
   };
 
   const holidayCache = new Map();
@@ -2648,7 +2781,7 @@
     pantryInventory: sanitizePantryInventory(storedAppState.pantryInventory),
     familyMembers: sanitizedFamilyMembers,
     themeMode: themePreferences.mode,
-    themeSelections: { ...themePreferences.selections },
+    themePalettes: sanitizeThemePalettes(themePreferences.palettes),
     holidayThemesEnabled: holidayThemePreferences.enabled,
     holidayThemeAllowList: new Set(holidayThemePreferences.holidays),
     measurementSystem: measurementPreference,
@@ -4082,17 +4215,11 @@
   const getActiveFilters = () =>
     state.activeView === 'meals' ? ensureMealFilters() : state.pantryFilters;
 
-  const setDocumentThemeAttributes = (mode, theme) => {
+  const setDocumentThemeAttributes = (mode) => {
     if (document.documentElement.dataset.mode !== mode) {
       document.documentElement.dataset.mode = mode;
     }
-    if (theme) {
-      if (document.documentElement.dataset.theme !== theme) {
-        document.documentElement.dataset.theme = theme;
-      }
-    } else {
-      delete document.documentElement.dataset.theme;
-    }
+    delete document.documentElement.dataset.theme;
   };
 
   const ensureHolidayThemeAllowList = () => {
@@ -4107,25 +4234,29 @@
     return list;
   };
 
-  const resolveHolidayThemeId = (holidayId, mode) => {
+  const resolveHolidayPalette = (holidayId, mode) => {
     const override = HOLIDAY_THEME_OVERRIDES[holidayId];
-    if (override) {
-      if (typeof override === 'string') {
-        return override;
-      }
+    if (!override) {
+      return null;
+    }
+    if (typeof override === 'object' && !Array.isArray(override)) {
       if (override[mode]) {
-        return override[mode];
+        return sanitizeThemePalette(override[mode], mode);
       }
       if (override.default) {
-        return override.default;
+        return sanitizeThemePalette(override.default, mode);
       }
     }
-    const fallback = DEFAULT_THEME_SELECTIONS[mode];
-    if (fallback) {
-      return fallback;
+    if (typeof override === 'string') {
+      const preset = SHARED_THEME_PRESETS[override];
+      if (preset) {
+        const palette = preset[mode] || preset.default;
+        if (palette) {
+          return sanitizeThemePalette(palette, mode);
+        }
+      }
     }
-    const options = Array.isArray(THEME_OPTIONS[mode]) ? THEME_OPTIONS[mode] : [];
-    return options.length ? options[0].id : null;
+    return null;
   };
 
   const getActiveHolidayThemeOverride = (date = new Date()) => {
@@ -4144,11 +4275,11 @@
     if (!activeHoliday) {
       return null;
     }
-    const themeId = resolveHolidayThemeId(activeHoliday.id, state.themeMode);
-    if (!themeId) {
+    const palette = resolveHolidayPalette(activeHoliday.id, state.themeMode);
+    if (!palette) {
       return null;
     }
-    return { id: activeHoliday.id, label: activeHoliday.label, theme: themeId };
+    return { id: activeHoliday.id, label: activeHoliday.label, palette };
   };
 
   const applyHolidayThemeDataset = (override) => {
@@ -4176,7 +4307,7 @@
       if (override) {
         status.hidden = false;
         status.dataset.holidayActive = 'true';
-        status.textContent = `${override.label} palette is active today.`;
+        status.textContent = `${override.label} colors are active today.`;
         return;
       }
       delete status.dataset.holidayActive;
@@ -4488,7 +4619,6 @@
     });
   };
 
-  let lastPersistedTheme = null;
   let lastPersistedMeasurement = null;
   let lastPersistedFavorites = JSON.stringify(favoriteRecipeIds);
   let lastPersistedPantryFavorites = JSON.stringify(favoritePantrySlugs);
@@ -4642,26 +4772,262 @@
     }
   };
 
-  const applyColorTheme = (shouldPersist = true) => {
-    const mode = state.themeMode;
-    const options = THEME_OPTIONS[mode] || [];
-    const fallback = DEFAULT_THEME_SELECTIONS[mode] || (options[0] ? options[0].id : undefined);
-    const currentSelection = state.themeSelections[mode];
-    const activeTheme = options.some((option) => option.id === currentSelection)
-      ? currentSelection
-      : fallback;
-    const selectionChanged = activeTheme !== currentSelection;
-    if (selectionChanged) {
-      state.themeSelections[mode] = activeTheme;
+  const getThemePaletteForMode = (mode) => {
+    const resolvedMode = AVAILABLE_MODES.includes(mode) ? mode : resolveFallbackMode();
+    if (!state.themePalettes || typeof state.themePalettes !== 'object') {
+      state.themePalettes = {};
     }
+    const existing = state.themePalettes[resolvedMode];
+    const sanitized = sanitizeThemePalette(existing, resolvedMode);
+    state.themePalettes[resolvedMode] = sanitized;
+    return sanitized;
+  };
+
+  const generateThemeTokens = (mode, palette) => {
+    const sanitized = sanitizeThemePalette(palette, mode);
+    const fallback = DEFAULT_THEME_PALETTES[mode] || DEFAULT_THEME_PALETTES.light;
+    const background = hexToRgb(sanitized.background) || hexToRgb(fallback.background);
+    const main = hexToRgb(sanitized.main) || hexToRgb(fallback.main);
+    const accent = hexToRgb(sanitized.accent) || hexToRgb(fallback.accent);
+    const white = WHITE_RGB || hexToRgb('#FFFFFF');
+    const black = BLACK_RGB || hexToRgb('#020617');
+
+    const backgroundHex = background.hex;
+    const mainHex = main.hex;
+    const accentHex = accent.hex;
+
+    const textPrimaryHex = getReadableTextColor(background, [
+      '#0F172A',
+      '#111827',
+      '#020617',
+      '#F8FAFC',
+    ]);
+    const textPrimary = hexToRgb(textPrimaryHex);
+    const textStrongHex = textPrimaryHex;
+    const textSecondaryHex = rgbToHex(
+      mixColors(textPrimary, background, mode === 'light' ? 0.35 : 0.32),
+    );
+    const textTertiaryHex = rgbToHex(
+      mixColors(textPrimary, background, mode === 'light' ? 0.55 : 0.48),
+    );
+    const textMutedColor = mixColors(textPrimary, background, mode === 'light' ? 0.45 : 0.5);
+    const textSoftColor = mixColors(textPrimary, background, mode === 'light' ? 0.6 : 0.58);
+    const textBadgeHex = rgbToHex(
+      mixColors(textPrimary, background, mode === 'light' ? 0.2 : 0.28),
+    );
+    const textInstructionHex = rgbToHex(
+      mixColors(textPrimary, background, mode === 'light' ? 0.24 : 0.3),
+    );
+
+    const surface = mixColors(background, white, mode === 'light' ? 0.9 : 0.18);
+    const surfaceElevated = mixColors(background, white, mode === 'light' ? 0.96 : 0.28);
+    const surfaceHex = rgbToHex(surface);
+    const surfaceElevatedHex = rgbToHex(surfaceElevated);
+    const layoutBackgroundHex = rgbToHex(
+      mixColors(background, white, mode === 'light' ? 0.75 : 0.22),
+    );
+    const surfaceTextHex = getReadableTextColor(surfaceElevated, [
+      '#0F172A',
+      '#111827',
+      '#F8FAFC',
+      '#F1F5F9',
+    ]);
+
+    const gradientStartHex = rgbToHex(
+      mixColors(background, white, mode === 'light' ? 0.12 : 0.2),
+    );
+    const gradientMidHex = rgbToHex(
+      mixColors(background, white, mode === 'light' ? 0.3 : 0.12),
+    );
+    const gradientEndHex = rgbToHex(
+      mixColors(background, mode === 'light' ? white : black, mode === 'light' ? 0.55 : 0.4),
+    );
+
+    const accentStrong = adjustLightness(adjustSaturation(main, 0.05), mode === 'light' ? -0.18 : -0.08);
+    const accentStrongHex = rgbToHex(accentStrong);
+    const accentSecondaryStrong = adjustLightness(adjustSaturation(accent, 0.05), mode === 'light' ? -0.16 : -0.08);
+    const accentSecondaryStrongHex = rgbToHex(accentSecondaryStrong);
+    const accentInverseHex = getReadableTextColor(accent, [
+      '#F8FAFC',
+      '#F1F5F9',
+      '#0F172A',
+      '#020617',
+    ]);
+    const accentContrastHex = getReadableTextColor(main, [
+      '#F8FAFC',
+      '#F1F5F9',
+      '#0F172A',
+      '#020617',
+    ]);
+
+    const borderColor = mixColors(main, background, mode === 'light' ? 0.45 : 0.3);
+    const borderStrongColor = mixColors(main, textPrimary, mode === 'light' ? 0.4 : 0.35);
+    const borderMutedColor = mixColors(background, white, mode === 'light' ? 0.68 : 0.35);
+
+    const headerShadowColor = mixColors(textPrimary, black, mode === 'light' ? 0.45 : 0.2);
+    const cardShadowColor = mixColors(main, black, mode === 'light' ? 0.25 : 0.55);
+    const cardShadowMutedColor = mixColors(main, black, mode === 'light' ? 0.18 : 0.48);
+    const cardShadowSoftColor = mixColors(accent, main, 0.4);
+
+    const neutral50Hex = rgbToHex(mixColors(background, textPrimary, mode === 'light' ? 0.08 : 0.16));
+    const neutral100Hex = rgbToHex(mixColors(background, textPrimary, mode === 'light' ? 0.14 : 0.22));
+    const neutral200Hex = rgbToHex(mixColors(background, textPrimary, mode === 'light' ? 0.24 : 0.28));
+    const neutral400Hex = rgbToHex(mixColors(background, textPrimary, mode === 'light' ? 0.4 : 0.42));
+    const neutral600Hex = rgbToHex(mixColors(background, textPrimary, mode === 'light' ? 0.55 : 0.55));
+
+    const codeBackgroundHex = rgbToHex(
+      mixColors(surfaceElevated, textPrimary, mode === 'light' ? 0.08 : 0.35),
+    );
+    const mealPlanSnackHex = rgbToHex(mixColors(main, accent, 0.5));
+    const mealPlanSurfaceValue = mode === 'light' ? '#FFFFFF' : toRgba(surfaceElevated, 0.92);
+
+    const inactiveBlend = mixColors(main, accent, 0.5);
+    const inactiveGradient = `linear-gradient(135deg, ${alphaColor(mainHex, mode === 'light' ? 0.65 : 0.58)}, ${alphaColor(accentHex, mode === 'light' ? 0.65 : 0.6)})`;
+    const activeGradient = `linear-gradient(135deg, ${mainHex}, ${accentHex})`;
+    const inactiveTextHex = getReadableTextColor(inactiveBlend, [
+      '#F8FAFC',
+      '#F1F5F9',
+      '#0F172A',
+    ]);
+    const activeTextHex = getReadableTextColor(inactiveBlend, [
+      '#F8FAFC',
+      '#F1F5F9',
+      '#0F172A',
+    ]);
+
+    const elevatedGradient = `linear-gradient(158deg, ${alphaColor(accentHex, mode === 'light' ? 0.16 : 0.22)}, ${surfaceElevatedHex})`;
+    const sectionGradient = `linear-gradient(155deg, ${alphaColor(mainHex, mode === 'light' ? 0.12 : 0.2)}, ${alphaColor(accentHex, mode === 'light' ? 0.16 : 0.24)})`;
+
+    return {
+      '--theme-background': backgroundHex,
+      '--theme-main': mainHex,
+      '--theme-accent': accentHex,
+      '--color-background': backgroundHex,
+      '--body-gradient-start': gradientStartHex,
+      '--body-gradient-mid': gradientMidHex,
+      '--body-gradient-end': gradientEndHex,
+      '--color-layout-background': layoutBackgroundHex,
+      '--color-header-background': toRgba(surfaceElevated, mode === 'light' ? 0.92 : 0.88),
+      '--color-header-shadow': alphaColor(rgbToHex(headerShadowColor), mode === 'light' ? 0.25 : 0.65),
+      '--color-surface': surfaceHex,
+      '--color-surface-elevated': surfaceElevatedHex,
+      '--color-surface-soft': alphaColor(mainHex, mode === 'light' ? 0.12 : 0.2),
+      '--color-surface-highlight': alphaColor(accentHex, mode === 'light' ? 0.18 : 0.26),
+      '--color-card-shadow': alphaColor(rgbToHex(cardShadowColor), mode === 'light' ? 0.24 : 0.6),
+      '--color-card-shadow-muted': alphaColor(rgbToHex(cardShadowMutedColor), mode === 'light' ? 0.18 : 0.5),
+      '--color-card-shadow-soft': alphaColor(rgbToHex(cardShadowSoftColor), mode === 'light' ? 0.2 : 0.34),
+      '--color-border': alphaColor(rgbToHex(borderColor), mode === 'light' ? 0.45 : 0.38),
+      '--color-border-strong': alphaColor(
+        rgbToHex(borderStrongColor),
+        mode === 'light' ? 0.55 : 0.6,
+      ),
+      '--color-border-muted': alphaColor(rgbToHex(borderMutedColor), mode === 'light' ? 0.68 : 0.55),
+      '--color-inline-tag-background': alphaColor(accentHex, mode === 'light' ? 0.2 : 0.26),
+      '--color-inline-tag-text': accentInverseHex,
+      '--color-code-background': codeBackgroundHex,
+      '--color-neutral-50': neutral50Hex,
+      '--color-neutral-100': neutral100Hex,
+      '--color-neutral-200': neutral200Hex,
+      '--color-neutral-400': neutral400Hex,
+      '--color-neutral-600': neutral600Hex,
+      '--color-neutral-soft': alphaColor(textPrimaryHex, mode === 'light' ? 0.08 : 0.24),
+      '--color-text-primary': textPrimaryHex,
+      '--color-text-strong': textStrongHex,
+      '--color-text-secondary': textSecondaryHex,
+      '--color-text-tertiary': textTertiaryHex,
+      '--color-text-muted': toRgba(textMutedColor, mode === 'light' ? 0.85 : 0.78),
+      '--color-text-badge': textBadgeHex,
+      '--color-text-soft': toRgba(textSoftColor, mode === 'light' ? 0.7 : 0.68),
+      '--color-text-instruction': textInstructionHex,
+      '--color-text-inline': mainHex,
+      '--color-tag-text': mainHex,
+      '--color-text-inverse': accentContrastHex,
+      '--color-gunmetal': textStrongHex,
+      '--color-text-emphasis': textPrimaryHex,
+      '--color-accent': mainHex,
+      '--color-accent-strong': accentStrongHex,
+      '--color-accent-soft': alphaColor(mainHex, mode === 'light' ? 0.18 : 0.28),
+      '--color-accent-softer': alphaColor(mainHex, mode === 'light' ? 0.12 : 0.22),
+      '--color-accent-outline': alphaColor(mainHex, mode === 'light' ? 0.3 : 0.45),
+      '--color-accent-border': alphaColor(mainHex, mode === 'light' ? 0.38 : 0.5),
+      '--color-accent-shadow': alphaColor(
+        rgbToHex(mixColors(main, black, mode === 'light' ? 0.4 : 0.35)),
+        mode === 'light' ? 0.32 : 0.45,
+      ),
+      '--color-accent-shadow-strong': alphaColor(mainHex, mode === 'light' ? 0.42 : 0.5),
+      '--color-accent-contrast': accentContrastHex,
+      '--color-accent-secondary': accentHex,
+      '--color-accent-secondary-strong': accentSecondaryStrongHex,
+      '--color-accent-secondary-soft': alphaColor(accentHex, mode === 'light' ? 0.22 : 0.32),
+      '--color-accent-secondary-outline': alphaColor(accentHex, mode === 'light' ? 0.3 : 0.45),
+      '--color-accent-secondary-contrast': accentInverseHex,
+      '--color-accent-secondary-shadow': alphaColor(
+        rgbToHex(mixColors(accent, black, mode === 'light' ? 0.35 : 0.3)),
+        mode === 'light' ? 0.32 : 0.42,
+      ),
+      '--color-burnished-copper': mainHex,
+      '--color-burnished-copper-soft': accentStrongHex,
+      '--color-burnished-copper-border': alphaColor(mainHex, mode === 'light' ? 0.25 : 0.38),
+      '--color-burnished-copper-shadow': alphaColor(
+        rgbToHex(cardShadowColor),
+        mode === 'light' ? 0.35 : 0.5,
+      ),
+      '--gradient-accent': `linear-gradient(135deg, ${mainHex}, ${accentStrongHex})`,
+      '--gradient-accent-secondary': `linear-gradient(135deg, ${accentHex}, ${accentSecondaryStrongHex})`,
+      '--gradient-burnished-copper': `linear-gradient(140deg, ${accentStrongHex}, ${mainHex})`,
+      '--meal-plan-type-meal': mainHex,
+      '--meal-plan-type-drink': accentHex,
+      '--meal-plan-type-snack': mealPlanSnackHex,
+      '--meal-plan-type-text': surfaceTextHex,
+      '--meal-plan-border': alphaColor(mainHex, mode === 'light' ? 0.24 : 0.32),
+      '--meal-plan-surface': mealPlanSurfaceValue,
+      '--view-toggle-inactive-gradient': inactiveGradient,
+      '--view-toggle-inactive-border': alphaColor(mainHex, mode === 'light' ? 0.5 : 0.45),
+      '--view-toggle-inactive-text': inactiveTextHex,
+      '--view-toggle-hover-glow': `0 0 16px ${alphaColor(accentHex, mode === 'light' ? 0.35 : 0.45)}`,
+      '--view-toggle-active-gradient': activeGradient,
+      '--view-toggle-active-text': activeTextHex,
+      '--surface-elevated-gradient': elevatedGradient,
+      '--surface-panel-gradient': elevatedGradient,
+      '--surface-section-gradient': sectionGradient,
+      '--surface-card-gradient': elevatedGradient,
+      '--color-focus-ring': alphaColor(mainHex, mode === 'light' ? 0.28 : 0.4),
+      '--color-header-foreground': surfaceTextHex,
+    };
+  };
+
+  const applyThemeTokens = (tokens) => {
+    const root = document.documentElement;
+    Object.entries(tokens).forEach(([property, value]) => {
+      root.style.setProperty(property, value);
+    });
+  };
+
+  const getSerializedThemeState = () =>
+    JSON.stringify({ mode: state.themeMode, palettes: sanitizeThemePalettes(state.themePalettes) });
+
+  const applyColorTheme = (shouldPersist = true) => {
+    const mode = AVAILABLE_MODES.includes(state.themeMode) ? state.themeMode : resolveFallbackMode();
+    if (state.themeMode !== mode) {
+      state.themeMode = mode;
+    }
+    const basePalette = getThemePaletteForMode(mode);
     const holidayOverride = getActiveHolidayThemeOverride();
-    const themeToApply = holidayOverride?.theme || activeTheme;
-    setDocumentThemeAttributes(mode, themeToApply);
+    const paletteToApply = holidayOverride?.palette
+      ? sanitizeThemePalette(holidayOverride.palette, mode)
+      : basePalette;
+    const tokens = generateThemeTokens(mode, paletteToApply);
+    applyThemeTokens(tokens);
+    setDocumentThemeAttributes(mode);
     applyHolidayThemeDataset(holidayOverride);
     renderHolidayThemeStatus();
-    if (!shouldPersist && !selectionChanged) return;
-    const serialized = JSON.stringify({ mode, selections: { ...state.themeSelections } });
-    if (serialized === lastPersistedTheme) return;
+    if (!shouldPersist) {
+      return;
+    }
+    const serialized = getSerializedThemeState();
+    if (serialized === lastPersistedTheme) {
+      return;
+    }
     try {
       localStorage.setItem(THEME_STORAGE_KEY, serialized);
       lastPersistedTheme = serialized;
@@ -4680,56 +5046,61 @@
     });
   };
 
-  const renderThemeOptions = () => {
-    if (!elements.themeOptions) return;
-    const currentMode = state.themeMode;
-    const options = THEME_OPTIONS[currentMode] || [];
-    const activeTheme = state.themeSelections[currentMode];
-    elements.themeOptions.innerHTML = '';
-    options.forEach((option) => {
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'theme-option';
-      button.style.setProperty('--theme-preview-color', option.preview);
-      const isActive = option.id === activeTheme;
-      if (isActive) {
-        button.classList.add('theme-option--active');
-        button.setAttribute('aria-pressed', 'true');
-      } else {
-        button.setAttribute('aria-pressed', 'false');
+  const renderThemePaletteControls = () => {
+    if (!elements.themePaletteControls) {
+      return;
+    }
+    const palette = getThemePaletteForMode(state.themeMode);
+    const assignValue = (input) => {
+      if (!(input instanceof HTMLInputElement)) {
+        return;
       }
-      button.dataset.themeOption = option.id;
-      button.textContent = option.label;
-      button.addEventListener('click', () => {
-        if (state.themeSelections[currentMode] === option.id) return;
-        state.themeSelections[currentMode] = option.id;
-        applyColorTheme();
-        renderThemeOptions();
-      });
-      elements.themeOptions.appendChild(button);
-    });
+      const role = input.dataset.colorRole;
+      if (!role || !(role in palette)) {
+        return;
+      }
+      if (input.type === 'color') {
+        input.value = palette[role];
+      } else {
+        input.value = palette[role];
+      }
+    };
+    if (Array.isArray(elements.themePaletteColorInputs)) {
+      elements.themePaletteColorInputs.forEach(assignValue);
+    }
+    if (Array.isArray(elements.themePaletteTextInputs)) {
+      elements.themePaletteTextInputs.forEach(assignValue);
+    }
+  };
+
+  const updateThemePaletteValue = (role, value) => {
+    if (!role) {
+      return false;
+    }
+    const normalized = normalizeHexColor(value);
+    if (!normalized) {
+      return false;
+    }
+    const current = getThemePaletteForMode(state.themeMode);
+    if (current[role] === normalized) {
+      return false;
+    }
+    state.themePalettes[state.themeMode] = { ...current, [role]: normalized };
+    return true;
   };
 
   const setThemeMode = (mode) => {
-    const options = Array.isArray(THEME_OPTIONS[mode]) ? THEME_OPTIONS[mode] : [];
-    if (!options.length || state.themeMode === mode) return;
+    if (!AVAILABLE_MODES.includes(mode) || state.themeMode === mode) return;
     state.themeMode = mode;
-    if (!options.some((option) => option.id === state.themeSelections[mode])) {
-      const fallbackSelection =
-        DEFAULT_THEME_SELECTIONS[mode] || (options[0] ? options[0].id : undefined);
-      if (fallbackSelection) {
-        state.themeSelections[mode] = fallbackSelection;
-      }
-    }
+    renderThemePaletteControls();
     applyColorTheme();
     updateModeButtons();
-    renderThemeOptions();
   };
 
   const initThemeControls = () => {
-    applyColorTheme();
+    renderThemePaletteControls();
+    applyColorTheme(false);
     updateModeButtons();
-    renderThemeOptions();
     updateHolidayThemeToggle();
   };
 
@@ -5166,7 +5537,13 @@
     elements.tagOptions = document.getElementById('tag-options');
     elements.allergyOptions = document.getElementById('allergy-options');
     elements.equipmentOptions = document.getElementById('equipment-options');
-    elements.themeOptions = document.getElementById('theme-options');
+    elements.themePaletteControls = document.getElementById('theme-palette');
+    elements.themePaletteColorInputs = Array.from(
+      document.querySelectorAll('#theme-palette .theme-color-control__picker'),
+    );
+    elements.themePaletteTextInputs = Array.from(
+      document.querySelectorAll('#theme-palette .theme-color-control__value'),
+    );
     elements.holidayThemeToggle = document.getElementById('holiday-theme-toggle');
     elements.holidayThemeSettings = document.getElementById('holiday-theme-settings');
     elements.holidayThemeStatus = document.getElementById('holiday-theme-status');
@@ -7896,6 +8273,46 @@
           if (mode) {
             setThemeMode(mode);
           }
+        });
+      });
+    }
+
+    if (Array.isArray(elements.themePaletteColorInputs)) {
+      elements.themePaletteColorInputs.forEach((input) => {
+        input.addEventListener('input', (event) => {
+          const target = event.target;
+          if (!(target instanceof HTMLInputElement)) {
+            return;
+          }
+          const role = target.dataset.colorRole;
+          if (!role) {
+            return;
+          }
+          const changed = updateThemePaletteValue(role, target.value);
+          if (changed) {
+            applyColorTheme();
+          }
+          renderThemePaletteControls();
+        });
+      });
+    }
+
+    if (Array.isArray(elements.themePaletteTextInputs)) {
+      elements.themePaletteTextInputs.forEach((input) => {
+        input.addEventListener('change', (event) => {
+          const target = event.target;
+          if (!(target instanceof HTMLInputElement)) {
+            return;
+          }
+          const role = target.dataset.colorRole;
+          if (!role) {
+            return;
+          }
+          const changed = updateThemePaletteValue(role, target.value);
+          if (changed) {
+            applyColorTheme();
+          }
+          renderThemePaletteControls();
         });
       });
     }

--- a/styles/app.css
+++ b/styles/app.css
@@ -3,128 +3,130 @@
 }
 
 :root {
-  --color-background: #f2dec7;
-  --body-gradient-start: #f9e8d7;
-  --body-gradient-mid: #e3b889;
-  --body-gradient-end: #c98246;
+  color-scheme: light;
+  --color-background: #f5f8ff;
+  --body-gradient-start: #f5f8ff;
+  --body-gradient-mid: #dbeafe;
+  --body-gradient-end: #bfdbfe;
 
   --color-text-primary: #0f172a;
   --color-text-strong: #0b1120;
-  --color-text-secondary: #2e3a59;
-  --color-text-tertiary: #3a4666;
-  --color-text-muted: #4b5674;
-  --color-text-badge: #243256;
-  --color-text-soft: #36425f;
-  --color-text-instruction: #283756;
-  --color-text-inline: #2a3a5a;
-  --color-tag-text: #1c2a6d;
-  --color-text-inverse: #ffffff;
-  --color-gunmetal: #2a3439;
-  --color-text-emphasis: #1b2848;
+  --color-text-secondary: #1f2937;
+  --color-text-tertiary: #334155;
+  --color-text-muted: rgba(51, 65, 85, 0.85);
+  --color-text-badge: #1f2937;
+  --color-text-soft: rgba(71, 85, 105, 0.7);
+  --color-text-instruction: #1f2937;
+  --color-text-inline: #1d4ed8;
+  --color-tag-text: #1d4ed8;
+  --color-text-inverse: #f8fafc;
+  --color-gunmetal: #1f2937;
+  --color-text-emphasis: #111827;
 
-  --color-layout-background: #d09c67;
-  --color-burnished-copper: #4f2a1c;
-  --color-burnished-copper-soft: #6a3a23;
-  --color-sepia-light: #f5ecdc;
-  --color-sepia-light-soft: rgba(245, 236, 220, 0.78);
-  --gradient-burnished-copper: linear-gradient(
-    140deg,
-    var(--color-burnished-copper-soft),
-    var(--color-burnished-copper)
-  );
-  --color-burnished-copper-border: rgba(255, 240, 224, 0.18);
-  --color-burnished-copper-shadow: rgba(15, 10, 6, 0.55);
+  --color-layout-background: #e2e8f0;
 
-  --color-accent: #4453d6;
-  --color-accent-strong: #6f63ff;
-  --color-accent-soft: rgba(68, 83, 214, 0.18);
-  --color-accent-softer: rgba(68, 83, 214, 0.12);
-  --color-accent-outline: rgba(68, 83, 214, 0.2);
-  --color-accent-border: #a2b0f8;
-  --color-accent-shadow: rgba(68, 83, 214, 0.75);
-  --color-accent-shadow-strong: rgba(68, 83, 214, 0.85);
-  --color-accent-contrast: #ffffff;
+  --theme-background: #f5f8ff;
+  --theme-main: #3b82f6;
+  --theme-accent: #22d3ee;
+
+  --color-surface: #ffffff;
+  --color-surface-elevated: #ffffff;
+  --color-surface-soft: rgba(59, 130, 246, 0.08);
+  --color-surface-highlight: rgba(34, 211, 238, 0.18);
+  --color-header-background: rgba(255, 255, 255, 0.92);
+
+  --color-header-shadow: rgba(15, 23, 42, 0.25);
+  --color-card-shadow: rgba(15, 23, 42, 0.12);
+  --color-card-shadow-muted: rgba(15, 23, 42, 0.08);
+  --color-card-shadow-soft: rgba(59, 130, 246, 0.16);
+
+  --color-border: rgba(148, 163, 184, 0.6);
+  --color-border-strong: rgba(71, 85, 105, 0.5);
+  --color-border-muted: rgba(203, 213, 225, 0.65);
+  --color-code-background: #e2e8f0;
+  --color-inline-tag-background: rgba(148, 163, 184, 0.3);
+  --color-inline-tag-text: #1f2937;
+
+  --color-neutral-50: #eef2ff;
+  --color-neutral-100: #e0e7ff;
+  --color-neutral-200: #c7d2fe;
+  --color-neutral-400: #818cf8;
+  --color-neutral-600: #4f46e5;
+  --color-neutral-soft: rgba(15, 23, 42, 0.08);
+
+  --color-accent: #3b82f6;
+  --color-accent-strong: #1d4ed8;
+  --color-accent-soft: rgba(59, 130, 246, 0.18);
+  --color-accent-softer: rgba(59, 130, 246, 0.12);
+  --color-accent-outline: rgba(59, 130, 246, 0.24);
+  --color-accent-border: rgba(59, 130, 246, 0.35);
+  --color-accent-shadow: rgba(15, 23, 42, 0.24);
+  --color-accent-shadow-strong: rgba(59, 130, 246, 0.38);
+  --color-accent-contrast: #f8fafc;
+
+  --color-accent-secondary: #22d3ee;
+  --color-accent-secondary-strong: #0ea5e9;
+  --color-accent-secondary-soft: rgba(34, 211, 238, 0.2);
+  --color-accent-secondary-outline: rgba(34, 211, 238, 0.3);
+  --color-accent-secondary-contrast: #083344;
+  --color-accent-secondary-shadow: rgba(8, 145, 178, 0.28);
 
   --gradient-accent: linear-gradient(135deg, var(--color-accent), var(--color-accent-strong));
-
-  --color-accent-secondary: #f59e0b;
-  --color-accent-secondary-strong: #d97706;
-  --color-accent-secondary-soft: rgba(245, 158, 11, 0.18);
-  --color-accent-secondary-outline: rgba(245, 158, 11, 0.32);
-  --color-accent-secondary-contrast: #2b1a0f;
-  --color-accent-secondary-shadow: rgba(245, 158, 11, 0.35);
   --gradient-accent-secondary: linear-gradient(
     135deg,
     var(--color-accent-secondary),
     var(--color-accent-secondary-strong)
   );
 
+  --color-burnished-copper: var(--color-accent);
+  --color-burnished-copper-soft: var(--color-accent-strong);
+  --gradient-burnished-copper: linear-gradient(
+    140deg,
+    var(--color-accent-strong),
+    var(--color-accent)
+  );
+  --color-burnished-copper-border: rgba(59, 130, 246, 0.25);
+  --color-burnished-copper-shadow: rgba(15, 23, 42, 0.35);
+
   --meal-plan-type-meal: var(--color-accent);
-  --meal-plan-type-drink: #0ea5e9;
-  --meal-plan-type-snack: #7d9341;
+  --meal-plan-type-drink: var(--color-accent-secondary);
+  --meal-plan-type-snack: #10b981;
   --meal-plan-type-text: var(--color-text-inverse);
-  --meal-plan-border: rgba(79, 42, 28, 0.24);
-  --meal-plan-surface: var(--color-sepia-light);
+  --meal-plan-border: rgba(59, 130, 246, 0.2);
+  --meal-plan-surface: #ffffff;
 
   --view-toggle-inactive-gradient: linear-gradient(
     135deg,
-    #4c5f24 0%,
-    #7d9341 45%,
-    #556b27 100%
+    rgba(59, 130, 246, 0.65),
+    rgba(22, 163, 74, 0.65)
   );
-  --view-toggle-inactive-border: rgba(125, 147, 65, 0.45);
-  --view-toggle-inactive-text: #f4f7e5;
-  --view-toggle-hover-glow: 0 0 16px rgba(233, 204, 138, 0.45);
+  --view-toggle-inactive-border: rgba(59, 130, 246, 0.5);
+  --view-toggle-inactive-text: #f0f9ff;
+  --view-toggle-hover-glow: 0 0 16px rgba(34, 211, 238, 0.35);
   --view-toggle-active-gradient: linear-gradient(
     135deg,
-    #d07a3b 0%,
-    #f3bf88 48%,
-    #b85d2e 100%
+    var(--color-accent),
+    var(--color-accent-secondary)
   );
-  --view-toggle-active-text: #34190c;
+  --view-toggle-active-text: var(--color-text-inverse);
 
-  --color-surface-elevated: #ffffff;
   --surface-elevated-gradient: linear-gradient(
     158deg,
-    var(--color-accent-secondary-soft, var(--color-accent-soft)),
+    rgba(34, 211, 238, 0.16),
     var(--color-surface-elevated)
   );
   --surface-panel-gradient: var(--surface-elevated-gradient);
   --surface-section-gradient: linear-gradient(
     155deg,
-    var(--color-accent-softer, var(--color-accent-soft)),
+    rgba(59, 130, 246, 0.12),
     var(--color-surface-soft)
   );
   --surface-card-gradient: var(--surface-elevated-gradient);
 
-  --color-neutral-50: #f6f8ff;
-  --color-neutral-100: #e5eafe;
-  --color-neutral-200: #d2dcfb;
-  --color-neutral-400: #a6b5ec;
-  --color-neutral-600: #5d6ca6;
+  --color-danger: #ef4444;
+  --color-danger-soft: rgba(239, 68, 68, 0.16);
 
-  --color-border: #b8c4e3;
-  --color-border-strong: #9caad3;
-  --color-border-muted: #d3daf1;
-  --color-code-background: #e8ecf8;
-  --color-inline-tag-background: #e0e6ff;
-  --color-inline-tag-text: #1c2a6d;
-
-  --color-neutral-soft: rgba(15, 23, 42, 0.08);
-  --color-surface: #ffffff;
-  --color-surface-soft: rgba(15, 23, 42, 0.05);
-  --color-surface-highlight: rgba(68, 83, 214, 0.12);
-  --color-header-background: rgba(255, 255, 255, 0.92);
-
-  --color-header-shadow: rgba(20, 33, 61, 0.45);
-  --color-card-shadow: rgba(20, 33, 61, 0.35);
-  --color-card-shadow-muted: rgba(20, 33, 61, 0.2);
-  --color-card-shadow-soft: rgba(68, 83, 214, 0.38);
-
-  --color-danger: #b91c1c;
-  --color-danger-soft: rgba(185, 28, 28, 0.14);
-
-  --color-focus-ring: rgba(68, 83, 214, 0.28);
+  --color-focus-ring: rgba(59, 130, 246, 0.28);
 
   font-family: 'Inter', 'Segoe UI', sans-serif;
   line-height: 1.6;
@@ -554,46 +556,79 @@ select {
   box-shadow: 0 18px 32px -20px var(--color-accent-shadow-strong);
 }
 
-.theme-option {
-  position: relative;
-  border: 1px solid var(--color-border);
-  border-radius: 14px;
+.theme-toolbar__palette {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.theme-color-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.85rem;
+  border: 1px solid var(--color-border-muted);
+  border-radius: 16px;
   background: var(--color-surface);
-  color: var(--color-text-secondary);
-  padding: 0.45rem 0.85rem 0.45rem 2.3rem;
-  min-width: 140px;
+  box-shadow: 0 16px 30px -26px var(--color-card-shadow);
+}
+
+.theme-color-control__label {
+  font-size: 0.75rem;
   font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.theme-color-control__inputs {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.theme-color-control__picker {
+  width: 2.75rem;
+  height: 2.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: var(--color-surface);
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, color 0.2s ease;
+  padding: 0;
 }
 
-.theme-option::before {
-  content: '';
-  position: absolute;
-  width: 1rem;
-  height: 1rem;
-  border-radius: 999px;
-  left: 0.75rem;
-  top: 50%;
-  transform: translateY(-50%);
-  background: var(--theme-preview-color, var(--color-accent));
-  box-shadow: 0 0 0 2px var(--color-surface);
+.theme-color-control__picker::-webkit-color-swatch,
+.theme-color-control__picker::-webkit-color-swatch-wrapper {
+  border: none;
+  border-radius: 10px;
+  padding: 0;
 }
 
-.theme-option:hover {
-  transform: translateY(-1px);
-  border-color: var(--color-accent);
-  box-shadow: 0 12px 24px -18px var(--color-card-shadow);
+.theme-color-control__picker::-moz-color-swatch {
+  border: none;
+  border-radius: 10px;
 }
 
-.theme-option--active {
-  border-color: var(--color-accent);
-  color: var(--color-text-emphasis);
-  box-shadow: 0 18px 32px -20px var(--color-card-shadow-soft);
+.theme-color-control__picker:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
 }
 
-.theme-option--active::before {
-  box-shadow: 0 0 0 2px var(--color-surface), 0 0 0 4px var(--color-accent);
+.theme-color-control__value {
+  flex: 1 1 auto;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.85rem;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-strong);
+  text-transform: uppercase;
+}
+
+.theme-color-control__value:focus {
+  outline: none;
+  border-color: var(--color-accent-border, var(--color-border));
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
 }
 
 .layout {
@@ -1984,9 +2019,9 @@ textarea:focus {
   align-items: stretch;
   padding: 0.6rem 0.75rem;
   border-radius: 14px;
-  background: var(--color-sepia-light);
-  border: 1px solid var(--meal-plan-border, rgba(79, 42, 28, 0.24));
-  color: var(--color-burnished-copper);
+  background: var(--meal-plan-surface, var(--color-surface));
+  border: 1px solid var(--meal-plan-border, rgba(59, 130, 246, 0.18));
+  color: var(--color-text-secondary);
 }
 
 .meal-plan-entry__main {
@@ -2033,18 +2068,18 @@ textarea:focus {
   margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--color-burnished-copper);
+  color: var(--color-text-emphasis);
 }
 
 .meal-plan-entry__meta {
   margin: 0;
-  color: rgba(79, 42, 28, 0.75);
+  color: var(--color-text-soft);
   font-size: 0.8rem;
 }
 
 .meal-plan-entry__time {
   margin: 0;
-  color: rgba(79, 42, 28, 0.8);
+  color: var(--color-text-secondary);
   font-size: 0.85rem;
   font-weight: 500;
 }
@@ -2409,7 +2444,7 @@ textarea:focus {
   padding: 1.5rem 1.75rem 1.75rem;
   border-radius: 22px;
   background: var(--meal-plan-surface, var(--color-surface));
-  border: 1px solid var(--meal-plan-border, rgba(79, 42, 28, 0.24));
+  border: 1px solid var(--meal-plan-border, rgba(59, 130, 246, 0.18));
   box-shadow: 0 32px 60px -28px var(--color-card-shadow-soft);
 }
 
@@ -2638,9 +2673,9 @@ textarea:focus {
   gap: 1rem;
   padding: 1.25rem 1rem 1rem;
   border-radius: 16px;
-  background: var(--color-sepia-light);
-  border: 1px solid var(--meal-plan-border, rgba(79, 42, 28, 0.24));
-  color: var(--color-burnished-copper);
+  background: var(--meal-plan-surface, var(--color-surface));
+  border: 1px solid var(--meal-plan-border, rgba(59, 130, 246, 0.18));
+  color: var(--color-text-secondary);
   flex: 1 1 auto;
 }
 
@@ -2648,13 +2683,13 @@ textarea:focus {
   margin: 0;
   font-size: 1.15rem;
   font-weight: 600;
-  color: var(--color-burnished-copper);
+  color: var(--color-text-emphasis);
 }
 
 .meal-plan-summary__hint {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(79, 42, 28, 0.7);
+  color: var(--color-text-soft);
 }
 
 .meal-plan-summary__macros {
@@ -2685,18 +2720,18 @@ textarea:focus {
 
 .meal-plan-macro-icons__button:hover {
   transform: translateY(-1px);
-  border-color: rgba(79, 42, 28, 0.2);
-  background: rgba(79, 42, 28, 0.08);
+  border-color: var(--color-accent);
+  background: var(--color-accent-softer);
 }
 
 .meal-plan-macro-icons__button:focus-visible {
-  outline: 2px solid rgba(79, 42, 28, 0.45);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
 
 .meal-plan-macro-icons__button--active {
-  border-color: rgba(79, 42, 28, 0.35);
-  background: rgba(79, 42, 28, 0.16);
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
   transform: none;
 }
 
@@ -2706,8 +2741,8 @@ textarea:focus {
   gap: 0.5rem;
   padding: 0.75rem;
   border-radius: 12px;
-  background: var(--color-sepia-light-soft);
-  border: 1px solid rgba(79, 42, 28, 0.18);
+  background: var(--color-surface-soft);
+  border: 1px solid var(--meal-plan-border, rgba(59, 130, 246, 0.18));
 }
 
 .meal-plan-summary__group-icon {
@@ -2722,20 +2757,20 @@ textarea:focus {
   gap: 0.75rem;
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--color-burnished-copper);
+  color: var(--color-text-emphasis);
   margin: 0;
 }
 
 .meal-plan-summary__group-subtitle {
   margin: 0;
   font-size: 0.8rem;
-  color: rgba(79, 42, 28, 0.68);
+  color: var(--color-text-soft);
 }
 
 .meal-plan-summary__group-note {
   margin: 0;
   font-size: 0.75rem;
-  color: rgba(79, 42, 28, 0.68);
+  color: var(--color-text-soft);
 }
 
 .meal-plan-summary__stat-list {
@@ -2750,16 +2785,16 @@ textarea:focus {
   gap: 0.2rem;
   padding: 0.6rem 0.7rem;
   border-radius: 10px;
-  background: rgba(245, 236, 220, 0.92);
-  color: var(--color-burnished-copper);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  background: var(--color-surface-highlight, var(--color-surface-soft));
+  color: var(--color-text-secondary);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2);
 }
 
 .meal-plan-summary__stat dt {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: rgba(79, 42, 28, 0.7);
+  color: var(--color-text-soft);
 }
 
 .meal-plan-summary__stat dd {
@@ -2774,21 +2809,21 @@ textarea:focus {
 .meal-plan-summary__empty {
   margin: 0;
   font-size: 0.9rem;
-  color: rgba(79, 42, 28, 0.7);
+  color: var(--color-text-soft);
 }
 
 .meal-plan-summary__stat-note {
   font-size: 0.75rem;
   font-weight: 500;
-  color: rgba(79, 42, 28, 0.65);
+  color: var(--color-text-soft);
 }
 
 .meal-plan-summary__target {
   grid-column: 1 / -1;
   padding: 0.6rem 0.7rem;
   border-radius: 10px;
-  background: rgba(79, 42, 28, 0.12);
-  color: var(--color-burnished-copper);
+  background: var(--color-accent-softer);
+  color: var(--color-accent);
   font-size: 0.8rem;
   font-weight: 600;
 }
@@ -3389,9 +3424,13 @@ textarea:focus {
   }
 
   .theme-toolbar__group,
-  .theme-toolbar__options--themes,
-  .theme-option {
+  .theme-toolbar__palette,
+  .theme-color-control {
     width: 100%;
+  }
+
+  .theme-toolbar__palette {
+    grid-template-columns: 1fr;
   }
 }
 .view-toggle {
@@ -3445,1099 +3484,63 @@ textarea:focus {
 .view-toggle__button--active {
   background: var(--view-toggle-active-gradient, var(--gradient-accent));
   color: var(--view-toggle-active-text, var(--color-accent-contrast));
-  border-color: rgba(212, 129, 69, 0.65);
-  box-shadow: 0 18px 32px -22px rgba(184, 93, 46, 0.65);
+  border-color: var(--color-accent);
+  box-shadow: 0 18px 32px -22px var(--color-accent-shadow-strong);
 }
 
 .view-toggle__button--active:hover {
   box-shadow:
     var(--view-toggle-hover-glow, 0 0 16px rgba(233, 204, 138, 0.45)),
-    0 18px 35px -20px var(--color-accent-shadow-strong, rgba(184, 93, 46, 0.75));
+    0 18px 35px -20px var(--color-accent-shadow-strong);
 }
 
-:root[data-mode='light'][data-theme='sunrise'] {
-  --color-background: #fff4ed;
-  --body-gradient-start: #fff9f4;
-  --body-gradient-mid: #ffe2d0;
-  --body-gradient-end: #ffcba4;
-
-  --color-header-background: rgba(255, 244, 236, 0.94);
-
-  --color-accent: #f97316;
-  --color-accent-strong: #f43f5e;
-  --color-accent-soft: rgba(249, 115, 22, 0.22);
-  --color-accent-softer: rgba(249, 115, 22, 0.16);
-  --color-accent-outline: rgba(249, 115, 22, 0.26);
-  --color-accent-border: #fca15d;
-  --color-accent-shadow: rgba(249, 115, 22, 0.48);
-  --color-accent-shadow-strong: rgba(244, 63, 94, 0.52);
-
-  --color-accent-secondary: #0ea5e9;
-  --color-accent-secondary-strong: #0284c7;
-  --color-accent-secondary-soft: rgba(14, 165, 233, 0.22);
-  --color-accent-secondary-outline: rgba(14, 165, 233, 0.32);
-  --color-accent-secondary-contrast: #012a3a;
-  --color-accent-secondary-shadow: rgba(14, 165, 233, 0.3);
-
-  --color-neutral-50: #fff6ef;
-  --color-neutral-100: #ffe4d6;
-  --color-neutral-200: #fdd2be;
-  --color-neutral-400: #f4b391;
-  --color-neutral-600: #c26a3d;
-
-  --color-inline-tag-background: rgba(254, 215, 170, 0.42);
-  --color-inline-tag-text: #7c2d12;
-
-  --color-neutral-soft: rgba(120, 53, 15, 0.12);
-  --color-surface-soft: rgba(249, 115, 22, 0.08);
-  --color-surface-highlight: rgba(249, 115, 22, 0.18);
-
-  --color-border: #f4b791;
-  --color-border-strong: #ea8e58;
-  --color-border-muted: #fbd6b6;
-  --color-code-background: #ffeadd;
-
-  --color-card-shadow: rgba(191, 90, 29, 0.32);
-  --color-card-shadow-muted: rgba(249, 115, 22, 0.24);
-  --color-card-shadow-soft: rgba(249, 115, 22, 0.34);
-
-  --color-focus-ring: rgba(249, 115, 22, 0.32);
-}
-
-:root[data-mode='light'][data-theme='meadow'] {
-  --color-background: #effdf3;
-  --body-gradient-start: #ffffff;
-  --body-gradient-mid: #dcfce7;
-  --body-gradient-end: #bbf7d0;
-
-  --color-header-background: rgba(239, 253, 243, 0.94);
-
-  --color-accent: #2f855a;
-  --color-accent-strong: #38a169;
-  --color-accent-soft: rgba(47, 133, 90, 0.22);
-  --color-accent-softer: rgba(47, 133, 90, 0.16);
-  --color-accent-outline: rgba(47, 133, 90, 0.24);
-  --color-accent-border: #8cd9a8;
-  --color-accent-shadow: rgba(47, 133, 90, 0.45);
-  --color-accent-shadow-strong: rgba(56, 189, 148, 0.48);
-
-  --color-accent-secondary: #6366f1;
-  --color-accent-secondary-strong: #4f46e5;
-  --color-accent-secondary-soft: rgba(99, 102, 241, 0.22);
-  --color-accent-secondary-outline: rgba(99, 102, 241, 0.32);
-  --color-accent-secondary-contrast: #f5f3ff;
-  --color-accent-secondary-shadow: rgba(99, 102, 241, 0.34);
-
-  --color-neutral-50: #f1fcf3;
-  --color-neutral-100: #dff7e6;
-  --color-neutral-200: #c9eed6;
-  --color-neutral-400: #9ddbb1;
-  --color-neutral-600: #3f8a6b;
-
-  --color-inline-tag-background: rgba(134, 239, 172, 0.38);
-  --color-inline-tag-text: #064e3b;
-
-  --color-neutral-soft: rgba(15, 118, 110, 0.12);
-  --color-surface-soft: rgba(15, 118, 110, 0.08);
-  --color-surface-highlight: rgba(34, 197, 94, 0.18);
-
-  --color-border: #9ddbb1;
-  --color-border-strong: #7fcf9c;
-  --color-border-muted: #ccecd7;
-  --color-code-background: #e3f9ec;
-
-  --color-card-shadow: rgba(15, 118, 110, 0.32);
-  --color-card-shadow-muted: rgba(47, 133, 90, 0.24);
-  --color-card-shadow-soft: rgba(52, 211, 153, 0.36);
-
-  --color-focus-ring: rgba(56, 161, 105, 0.3);
-}
-
-:root[data-mode='light'][data-theme='mist'] {
-  --color-background: #f2f9ff;
-  --body-gradient-start: #ffffff;
-  --body-gradient-mid: #e0f2fe;
-  --body-gradient-end: #bae6fd;
-
-  --color-header-background: rgba(242, 249, 255, 0.94);
-
-  --color-accent: #38bdf8;
-  --color-accent-strong: #0ea5e9;
-  --color-accent-soft: rgba(56, 189, 248, 0.24);
-  --color-accent-softer: rgba(14, 165, 233, 0.16);
-  --color-accent-outline: rgba(56, 189, 248, 0.26);
-  --color-accent-border: #8ecdf5;
-  --color-accent-shadow: rgba(56, 189, 248, 0.36);
-  --color-accent-shadow-strong: rgba(14, 165, 233, 0.44);
-
-  --color-accent-secondary: #a855f7;
-  --color-accent-secondary-strong: #7c3aed;
-  --color-accent-secondary-soft: rgba(168, 85, 247, 0.24);
-  --color-accent-secondary-outline: rgba(168, 85, 247, 0.34);
-  --color-accent-secondary-contrast: #f9f5ff;
-  --color-accent-secondary-shadow: rgba(168, 85, 247, 0.3);
-
-  --color-neutral-50: #f3f8ff;
-  --color-neutral-100: #e3f1ff;
-  --color-neutral-200: #d1e6fb;
-  --color-neutral-400: #a8c5e6;
-  --color-neutral-600: #4d7098;
-
-  --color-inline-tag-background: rgba(59, 130, 246, 0.26);
-  --color-inline-tag-text: #0b3d5c;
-
-  --color-neutral-soft: rgba(12, 74, 110, 0.16);
-  --color-surface-soft: rgba(56, 189, 248, 0.1);
-  --color-surface-highlight: rgba(56, 189, 248, 0.2);
-
-  --color-border: #b0cff5;
-  --color-border-strong: #90bdf0;
-  --color-border-muted: #dbeafb;
-  --color-code-background: #e6f4ff;
-
-  --color-card-shadow: rgba(12, 74, 110, 0.22);
-  --color-card-shadow-muted: rgba(14, 165, 233, 0.2);
-  --color-card-shadow-soft: rgba(56, 189, 248, 0.32);
-
-  --color-focus-ring: rgba(56, 189, 248, 0.32);
-}
-
-:root[data-mode='light'][data-theme='blossom'] {
-  --color-background: #fff5fa;
-  --body-gradient-start: #ffffff;
-  --body-gradient-mid: #fde4f2;
-  --body-gradient-end: #fbcfe8;
-
-  --color-header-background: rgba(255, 245, 250, 0.94);
-
-  --color-accent: #ec4899;
-  --color-accent-strong: #db2777;
-  --color-accent-soft: rgba(236, 72, 153, 0.24);
-  --color-accent-softer: rgba(236, 72, 153, 0.16);
-  --color-accent-outline: rgba(236, 72, 153, 0.28);
-  --color-accent-border: #f472b6;
-  --color-accent-shadow: rgba(190, 24, 93, 0.36);
-  --color-accent-shadow-strong: rgba(236, 72, 153, 0.4);
-
-  --color-accent-secondary: #22d3ee;
-  --color-accent-secondary-strong: #0ea5e9;
-  --color-accent-secondary-soft: rgba(34, 211, 238, 0.24);
-  --color-accent-secondary-outline: rgba(34, 211, 238, 0.32);
-  --color-accent-secondary-contrast: #062c35;
-  --color-accent-secondary-shadow: rgba(34, 211, 238, 0.32);
-
-  --color-neutral-50: #fff6fb;
-  --color-neutral-100: #ffe3f2;
-  --color-neutral-200: #fbd1e7;
-  --color-neutral-400: #f3a6cb;
-  --color-neutral-600: #b75283;
-
-  --color-inline-tag-background: rgba(244, 114, 182, 0.32);
-  --color-inline-tag-text: #831843;
-
-  --color-neutral-soft: rgba(190, 24, 93, 0.14);
-  --color-surface-soft: rgba(236, 72, 153, 0.1);
-  --color-surface-highlight: rgba(244, 114, 182, 0.22);
-
-  --color-border: #f5b4d3;
-  --color-border-strong: #ee8bb8;
-  --color-border-muted: #fbd9e9;
-  --color-code-background: #ffeaf4;
-
-  --color-card-shadow: rgba(190, 24, 93, 0.26);
-  --color-card-shadow-muted: rgba(236, 72, 153, 0.2);
-  --color-card-shadow-soft: rgba(236, 72, 153, 0.36);
-
-  --color-focus-ring: rgba(236, 72, 153, 0.32);
-}
-
-:root[data-mode='light'][data-theme='citrine'] {
-  --color-background: #fffbea;
-  --body-gradient-start: #ffffff;
-  --body-gradient-mid: #fef3c7;
-  --body-gradient-end: #fde68a;
-
-  --color-header-background: rgba(255, 251, 234, 0.95);
-
-  --color-accent: #facc15;
-  --color-accent-strong: #f59e0b;
-  --color-accent-soft: rgba(250, 204, 21, 0.24);
-  --color-accent-softer: rgba(250, 204, 21, 0.16);
-  --color-accent-outline: rgba(234, 179, 8, 0.3);
-  --color-accent-border: #f5c54d;
-  --color-accent-shadow: rgba(234, 179, 8, 0.34);
-  --color-accent-shadow-strong: rgba(250, 204, 21, 0.4);
-
-  --color-accent-secondary: #3b82f6;
-  --color-accent-secondary-strong: #2563eb;
-  --color-accent-secondary-soft: rgba(59, 130, 246, 0.24);
-  --color-accent-secondary-outline: rgba(59, 130, 246, 0.32);
-  --color-accent-secondary-contrast: #0b1f3a;
-  --color-accent-secondary-shadow: rgba(37, 99, 235, 0.35);
-
-  --color-neutral-50: #fff9e6;
-  --color-neutral-100: #fff1cc;
-  --color-neutral-200: #fde7af;
-  --color-neutral-400: #f0c86b;
-  --color-neutral-600: #b68a2c;
-
-  --color-inline-tag-background: rgba(250, 204, 21, 0.32);
-  --color-inline-tag-text: #7c2d12;
-
-  --color-neutral-soft: rgba(180, 83, 9, 0.14);
-  --color-surface-soft: rgba(250, 204, 21, 0.1);
-  --color-surface-highlight: rgba(250, 204, 21, 0.22);
-
-  --color-border: #f0c86b;
-  --color-border-strong: #e2a93a;
-  --color-border-muted: #f7e3a1;
-  --color-code-background: #fff3c4;
-
-  --color-card-shadow: rgba(146, 64, 14, 0.24);
-  --color-card-shadow-muted: rgba(217, 119, 6, 0.22);
-  --color-card-shadow-soft: rgba(250, 204, 21, 0.34);
-
-  --color-focus-ring: rgba(250, 204, 21, 0.34);
-}
 
 :root[data-mode='dark'] {
-  --color-background: #020617;
-  --body-gradient-start: #0b1733;
-  --body-gradient-mid: #061228;
-  --body-gradient-end: #010816;
+  color-scheme: dark;
+  --color-layout-background: #0b1220;
 
-  --color-layout-background: #1f232d;
-
-  --color-text-primary: #f1f5ff;
+  --color-text-primary: #f8fafc;
   --color-text-strong: #f8fafc;
-  --color-text-secondary: #d5defa;
-  --color-text-tertiary: #b8c4ff;
-  --color-text-muted: #a5b4d6;
-  --color-text-badge: #e2ecff;
-  --color-text-soft: #a5b4d6;
-  --color-text-instruction: #d5defa;
-  --color-text-inline: #e2ecff;
-  --color-tag-text: #e0e7ff;
-  --color-text-emphasis: #f4f7ff;
+  --color-text-secondary: #cbd5f5;
+  --color-text-tertiary: rgba(203, 213, 225, 0.86);
+  --color-text-muted: rgba(148, 163, 184, 0.78);
+  --color-text-badge: #e2e8f0;
+  --color-text-soft: rgba(148, 163, 184, 0.68);
+  --color-text-instruction: rgba(203, 213, 225, 0.85);
+  --color-text-inline: #cbd5f5;
+  --color-tag-text: #cbd5f5;
+  --color-text-emphasis: #f8fafc;
 
-  --color-surface: #0f172a;
-  --color-surface-elevated: #223049;
-  --color-surface-soft: rgba(47, 109, 240, 0.18);
-  --color-surface-highlight: rgba(96, 165, 250, 0.24);
-  --color-header-background: rgba(15, 23, 42, 0.94);
-  --color-header-shadow: rgba(2, 6, 23, 0.78);
+  --color-surface: #111827;
+  --color-surface-elevated: #1f2937;
+  --color-surface-soft: rgba(148, 163, 184, 0.12);
+  --color-surface-highlight: rgba(148, 163, 184, 0.18);
+  --color-header-background: rgba(17, 24, 39, 0.9);
+  --color-header-shadow: rgba(2, 6, 23, 0.7);
 
-  --color-border: rgba(148, 163, 184, 0.48);
-  --color-border-strong: rgba(191, 219, 254, 0.62);
-  --color-border-muted: rgba(148, 163, 184, 0.32);
-  --color-code-background: rgba(30, 41, 59, 0.86);
-  --color-inline-tag-background: rgba(96, 165, 250, 0.32);
-  --color-inline-tag-text: #e2ecff;
-  --color-neutral-soft: rgba(148, 163, 184, 0.28);
+  --color-border: rgba(148, 163, 184, 0.4);
+  --color-border-strong: rgba(148, 163, 184, 0.6);
+  --color-border-muted: rgba(51, 65, 85, 0.55);
+  --color-inline-tag-background: rgba(148, 163, 184, 0.2);
+  --color-inline-tag-text: #f8fafc;
+  --color-code-background: rgba(30, 41, 59, 0.85);
+  --color-neutral-50: rgba(148, 163, 184, 0.14);
+  --color-neutral-100: rgba(148, 163, 184, 0.2);
+  --color-neutral-200: rgba(148, 163, 184, 0.28);
+  --color-neutral-400: rgba(148, 163, 184, 0.4);
+  --color-neutral-600: rgba(148, 163, 184, 0.55);
+  --color-neutral-soft: rgba(148, 163, 184, 0.25);
 
-  --color-card-shadow: rgba(2, 6, 23, 0.72);
-  --color-card-shadow-muted: rgba(2, 6, 23, 0.52);
-  --color-card-shadow-soft: rgba(59, 130, 246, 0.36);
+  --color-card-shadow: rgba(2, 6, 23, 0.65);
+  --color-card-shadow-muted: rgba(2, 6, 23, 0.5);
+  --color-card-shadow-soft: rgba(148, 163, 184, 0.3);
 
   --color-danger: #f87171;
-  --color-danger-soft: rgba(248, 113, 113, 0.28);
-
-  --color-focus-ring: rgba(96, 165, 250, 0.46);
-
-  --color-accent: #2f6df0;
-  --color-accent-strong: #60a5fa;
-  --color-accent-soft: rgba(47, 109, 240, 0.28);
-  --color-accent-softer: rgba(59, 130, 246, 0.2);
-  --color-accent-outline: rgba(96, 165, 250, 0.42);
-  --color-accent-border: rgba(125, 181, 255, 0.65);
-  --color-accent-shadow: rgba(47, 109, 240, 0.55);
-  --color-accent-shadow-strong: rgba(59, 130, 246, 0.58);
-
-  --color-accent-secondary: #f472b6;
-  --color-accent-secondary-strong: #db2777;
-  --color-accent-secondary-soft: rgba(244, 114, 182, 0.24);
-  --color-accent-secondary-outline: rgba(244, 114, 182, 0.34);
-  --color-accent-secondary-contrast: #fdf2f8;
-  --color-accent-secondary-shadow: rgba(244, 114, 182, 0.45);
-
-  --color-neutral-50: rgba(148, 163, 184, 0.1);
-  --color-neutral-100: rgba(148, 163, 184, 0.16);
-  --color-neutral-200: rgba(148, 163, 184, 0.24);
-  --color-neutral-400: rgba(96, 165, 250, 0.28);
-  --color-neutral-600: rgba(96, 165, 250, 0.42);
-}
-
-:root[data-mode='dark'][data-theme='nebula'] {
-  --color-background: #0c0a1a;
-  --body-gradient-start: #1a0f3f;
-  --body-gradient-mid: #120a2d;
-  --body-gradient-end: #050311;
-
-  --color-surface: #1f1936;
-  --color-surface-elevated: #2b2452;
-  --color-surface-soft: rgba(168, 85, 247, 0.2);
-  --color-header-background: rgba(31, 25, 54, 0.95);
-  --color-header-shadow: rgba(9, 6, 25, 0.72);
-
-  --color-accent: #a855f7;
-  --color-accent-strong: #6366f1;
-  --color-accent-soft: rgba(168, 85, 247, 0.32);
-  --color-accent-softer: rgba(99, 102, 241, 0.24);
-  --color-accent-outline: rgba(129, 140, 248, 0.45);
-  --color-accent-border: rgba(209, 196, 255, 0.7);
-  --color-accent-shadow: rgba(129, 140, 248, 0.52);
-  --color-accent-shadow-strong: rgba(168, 85, 247, 0.58);
-
-  --color-accent-secondary: #22d3ee;
-  --color-accent-secondary-strong: #0ea5e9;
-  --color-accent-secondary-soft: rgba(34, 211, 238, 0.34);
-  --color-accent-secondary-outline: rgba(34, 211, 238, 0.48);
-  --color-accent-secondary-contrast: #022c3a;
-  --color-accent-secondary-shadow: rgba(34, 211, 238, 0.36);
-
-  --color-neutral-50: rgba(196, 181, 253, 0.12);
-  --color-neutral-100: rgba(196, 181, 253, 0.18);
-  --color-neutral-200: rgba(167, 139, 250, 0.24);
-  --color-neutral-400: rgba(129, 140, 248, 0.32);
-  --color-neutral-600: rgba(99, 102, 241, 0.45);
-
-  --color-inline-tag-background: rgba(168, 85, 247, 0.36);
-  --color-inline-tag-text: #f4f3ff;
-  --color-tag-text: #f4f3ff;
-  --color-text-emphasis: #f5f3ff;
-  --color-surface-highlight: rgba(139, 92, 246, 0.28);
-
-  --color-border: rgba(196, 181, 253, 0.5);
-  --color-border-strong: rgba(209, 196, 255, 0.65);
-  --color-border-muted: rgba(196, 181, 253, 0.36);
-  --color-neutral-soft: rgba(196, 181, 253, 0.24);
-  --color-card-shadow: rgba(9, 6, 25, 0.72);
-  --color-card-shadow-muted: rgba(9, 6, 25, 0.54);
-  --color-card-shadow-soft: rgba(168, 85, 247, 0.36);
-
-  --color-focus-ring: rgba(168, 85, 247, 0.46);
-  --color-code-background: rgba(44, 28, 72, 0.86);
-}
-
-:root[data-mode='dark'][data-theme='forest'] {
-  --color-background: #021512;
-  --body-gradient-start: #05201b;
-  --body-gradient-mid: #0b2b24;
-  --body-gradient-end: #010f0c;
-
-  --color-surface: #0f1f1a;
-  --color-surface-elevated: #1c2f27;
-  --color-surface-soft: rgba(45, 212, 191, 0.2);
-  --color-header-background: rgba(15, 31, 26, 0.95);
-  --color-header-shadow: rgba(1, 15, 12, 0.7);
-
-  --color-accent: #34d399;
-  --color-accent-strong: #10b981;
-  --color-accent-soft: rgba(52, 211, 153, 0.32);
-  --color-accent-softer: rgba(16, 185, 129, 0.24);
-  --color-accent-outline: rgba(52, 211, 153, 0.4);
-  --color-accent-border: rgba(134, 239, 172, 0.65);
-  --color-accent-shadow: rgba(16, 185, 129, 0.55);
-  --color-accent-shadow-strong: rgba(45, 212, 191, 0.6);
-
-  --color-accent-secondary: #fbbf24;
-  --color-accent-secondary-strong: #f59e0b;
-  --color-accent-secondary-soft: rgba(251, 191, 36, 0.32);
-  --color-accent-secondary-outline: rgba(251, 191, 36, 0.46);
-  --color-accent-secondary-contrast: #2b1900;
-  --color-accent-secondary-shadow: rgba(251, 191, 36, 0.38);
-
-  --color-neutral-50: rgba(45, 212, 191, 0.12);
-  --color-neutral-100: rgba(45, 212, 191, 0.18);
-  --color-neutral-200: rgba(20, 184, 166, 0.22);
-  --color-neutral-400: rgba(20, 156, 148, 0.3);
-  --color-neutral-600: rgba(13, 148, 136, 0.42);
-
-  --color-inline-tag-background: rgba(45, 212, 191, 0.36);
-  --color-inline-tag-text: #e0fdf6;
-  --color-tag-text: #e0fdf6;
-  --color-text-emphasis: #dcfce7;
-  --color-surface-highlight: rgba(45, 212, 191, 0.28);
-
-  --color-border: rgba(134, 239, 172, 0.45);
-  --color-border-strong: rgba(167, 243, 208, 0.6);
-  --color-border-muted: rgba(110, 231, 183, 0.34);
-  --color-neutral-soft: rgba(15, 118, 110, 0.24);
-  --color-card-shadow: rgba(1, 15, 12, 0.72);
-  --color-card-shadow-muted: rgba(1, 15, 12, 0.52);
-  --color-card-shadow-soft: rgba(45, 212, 191, 0.36);
-
-  --color-focus-ring: rgba(45, 212, 191, 0.48);
-  --color-code-background: rgba(15, 52, 40, 0.82);
-}
-
-:root[data-mode='dark'][data-theme='ember'] {
-  --color-background: #130b06;
-  --body-gradient-start: #1f130c;
-  --body-gradient-mid: #140a05;
-  --body-gradient-end: #080402;
-
-  --color-surface: #1e130a;
-  --color-surface-elevated: #2d1c11;
-  --color-surface-soft: rgba(249, 115, 22, 0.22);
-  --color-header-background: linear-gradient(
-    135deg,
-    rgba(58, 32, 18, 0.95) 0%,
-    rgba(40, 22, 12, 0.95) 45%,
-    rgba(24, 12, 6, 0.95) 100%
-  );
-  --color-header-shadow: rgba(8, 4, 2, 0.76);
-
-  --color-accent: #f97316;
-  --color-accent-strong: #fb923c;
-  --color-accent-soft: rgba(249, 115, 22, 0.34);
-  --color-accent-softer: rgba(249, 115, 22, 0.24);
-  --color-accent-outline: rgba(251, 146, 60, 0.48);
-  --color-accent-border: rgba(251, 146, 60, 0.68);
-  --color-accent-shadow: rgba(249, 115, 22, 0.58);
-  --color-accent-shadow-strong: rgba(249, 115, 22, 0.64);
-
-  --color-accent-secondary: #2563eb;
-  --color-accent-secondary-strong: #1d4ed8;
-  --color-accent-secondary-soft: rgba(37, 99, 235, 0.32);
-  --color-accent-secondary-outline: rgba(37, 99, 235, 0.48);
-  --color-accent-secondary-contrast: #e2ecff;
-  --color-accent-secondary-shadow: rgba(37, 99, 235, 0.38);
-
-  --color-neutral-50: rgba(248, 113, 113, 0.14);
-  --color-neutral-100: rgba(251, 146, 60, 0.18);
-  --color-neutral-200: rgba(249, 115, 22, 0.22);
-  --color-neutral-400: rgba(217, 119, 6, 0.32);
-  --color-neutral-600: rgba(180, 83, 9, 0.45);
-
-  --color-inline-tag-background: rgba(249, 115, 22, 0.32);
-  --color-inline-tag-text: #ffedd5;
-  --color-tag-text: #ffedd5;
-  --color-text-emphasis: #ffe7d6;
-  --color-surface-highlight: rgba(251, 146, 60, 0.36);
-
-  --color-border: rgba(251, 146, 60, 0.4);
-  --color-border-strong: rgba(251, 146, 60, 0.55);
-  --color-border-muted: rgba(251, 146, 60, 0.32);
-  --color-neutral-soft: rgba(249, 115, 22, 0.26);
-  --color-card-shadow: rgba(8, 4, 2, 0.8);
-  --color-card-shadow-muted: rgba(8, 4, 2, 0.6);
-  --color-card-shadow-soft: rgba(249, 115, 22, 0.4);
-
-  --color-focus-ring: rgba(251, 146, 60, 0.48);
-  --color-code-background: rgba(60, 32, 18, 0.84);
-}
-
-:root[data-mode='dark'][data-theme='ember'] .view-toggle__button {
-  background: linear-gradient(135deg, #2f6f63, #1f4740);
-  border-color: rgba(47, 111, 99, 0.65);
-  color: #e8f6f0;
-}
-
-:root[data-mode='dark'][data-theme='ember'] .view-toggle__button:hover {
-  box-shadow: 0 14px 28px -20px rgba(47, 111, 99, 0.6);
-}
-
-:root[data-mode='dark'][data-theme='ember'] .view-toggle__button--active {
-  background: linear-gradient(135deg, #ffe0b5 0%, #f5a262 45%, #c56a28 100%);
-  border-color: rgba(245, 162, 98, 0.75);
-  color: #2b1307;
-  box-shadow: 0 20px 36px -18px rgba(197, 106, 40, 0.55);
-}
-
-:root[data-mode='dark'][data-theme='ember'] .view-toggle__button--active:hover {
-  box-shadow: 0 22px 40px -18px rgba(216, 124, 51, 0.6);
-}
-
-:root[data-mode='dark'][data-theme='abyss'] {
-  --color-background: #020f17;
-  --body-gradient-start: #021b25;
-  --body-gradient-mid: #031520;
-  --body-gradient-end: #01070b;
-
-  --color-surface: #0b1f24;
-  --color-surface-elevated: #12303a;
-  --color-surface-soft: rgba(14, 165, 233, 0.22);
-  --color-header-background: rgba(11, 31, 36, 0.95);
-  --color-header-shadow: rgba(1, 7, 11, 0.72);
-
-  --color-accent: #14b8a6;
-  --color-accent-strong: #38bdf8;
-  --color-accent-soft: rgba(20, 184, 166, 0.36);
-  --color-accent-softer: rgba(14, 165, 233, 0.26);
-  --color-accent-outline: rgba(20, 184, 166, 0.48);
-  --color-accent-border: rgba(94, 234, 212, 0.65);
-  --color-accent-shadow: rgba(14, 116, 144, 0.58);
-  --color-accent-shadow-strong: rgba(56, 189, 248, 0.58);
-
-  --color-accent-secondary: #8b5cf6;
-  --color-accent-secondary-strong: #7c3aed;
-  --color-accent-secondary-soft: rgba(139, 92, 246, 0.3);
-  --color-accent-secondary-outline: rgba(139, 92, 246, 0.44);
-  --color-accent-secondary-contrast: #f5f3ff;
-  --color-accent-secondary-shadow: rgba(139, 92, 246, 0.36);
-
-  --color-neutral-50: rgba(13, 148, 136, 0.14);
-  --color-neutral-100: rgba(14, 165, 233, 0.18);
-  --color-neutral-200: rgba(13, 148, 136, 0.22);
-  --color-neutral-400: rgba(14, 165, 233, 0.3);
-  --color-neutral-600: rgba(12, 105, 128, 0.45);
-
-  --color-inline-tag-background: rgba(13, 148, 136, 0.32);
-  --color-inline-tag-text: #d5fef9;
-  --color-tag-text: #d5fef9;
-  --color-text-emphasis: #d6f7ff;
-  --color-surface-highlight: rgba(14, 165, 233, 0.3);
-
-  --color-border: rgba(14, 165, 233, 0.38);
-  --color-border-strong: rgba(56, 189, 248, 0.52);
-  --color-border-muted: rgba(20, 184, 166, 0.3);
-  --color-neutral-soft: rgba(45, 212, 191, 0.32);
-  --color-card-shadow: rgba(1, 7, 11, 0.78);
-  --color-card-shadow-muted: rgba(1, 7, 11, 0.58);
-  --color-card-shadow-soft: rgba(14, 165, 233, 0.4);
-
-  --color-focus-ring: rgba(56, 189, 248, 0.5);
-  --color-code-background: rgba(10, 35, 41, 0.88);
-}
-
-:root[data-mode='dark'][data-theme='velvet'] {
-  --color-background: #150313;
-  --body-gradient-start: #2a0826;
-  --body-gradient-mid: #1b0418;
-  --body-gradient-end: #08010a;
-
-  --color-surface: #240b20;
-  --color-surface-elevated: #34142f;
-  --color-surface-soft: rgba(236, 72, 153, 0.22);
-  --color-header-background: rgba(36, 11, 32, 0.95);
-  --color-header-shadow: rgba(8, 1, 10, 0.74);
-
-  --color-accent: #f472b6;
-  --color-accent-strong: #db2777;
-  --color-accent-soft: rgba(244, 114, 182, 0.34);
-  --color-accent-softer: rgba(219, 39, 119, 0.26);
-  --color-accent-outline: rgba(236, 72, 153, 0.48);
-  --color-accent-border: rgba(244, 114, 182, 0.6);
-  --color-accent-shadow: rgba(131, 24, 67, 0.54);
-  --color-accent-shadow-strong: rgba(236, 72, 153, 0.56);
-
-  --color-accent-secondary: #14b8a6;
-  --color-accent-secondary-strong: #0d9488;
-  --color-accent-secondary-soft: rgba(20, 184, 166, 0.3);
-  --color-accent-secondary-outline: rgba(20, 184, 166, 0.46);
-  --color-accent-secondary-contrast: #012725;
-  --color-accent-secondary-shadow: rgba(20, 184, 166, 0.36);
-
-  --color-neutral-50: rgba(236, 72, 153, 0.16);
-  --color-neutral-100: rgba(236, 72, 153, 0.22);
-  --color-neutral-200: rgba(219, 39, 119, 0.28);
-  --color-neutral-400: rgba(190, 24, 93, 0.36);
-  --color-neutral-600: rgba(190, 24, 93, 0.48);
-
-  --color-inline-tag-background: rgba(236, 72, 153, 0.34);
-  --color-inline-tag-text: #fde8f3;
-  --color-tag-text: #fde8f3;
-  --color-text-emphasis: #fde6f2;
-  --color-surface-highlight: rgba(236, 72, 153, 0.34);
-
-  --color-border: rgba(236, 72, 153, 0.38);
-  --color-border-strong: rgba(236, 72, 153, 0.52);
-  --color-border-muted: rgba(236, 72, 153, 0.3);
-  --color-neutral-soft: rgba(236, 72, 153, 0.32);
-  --color-card-shadow: rgba(8, 1, 10, 0.76);
-  --color-card-shadow-muted: rgba(8, 1, 10, 0.56);
-  --color-card-shadow-soft: rgba(236, 72, 153, 0.4);
-
-  --color-focus-ring: rgba(236, 72, 153, 0.46);
-  --color-code-background: rgba(44, 10, 36, 0.86);
-}
-
-:root[data-mode='sepia'] {
-  --color-layout-background: #ead7ba;
-
-  --color-text-primary: #2b1a11;
-  --color-text-strong: #1e120b;
-  --color-text-secondary: #4a3121;
-  --color-text-tertiary: #5b3a27;
-  --color-text-muted: #704a33;
-  --color-text-badge: #3c2619;
-  --color-text-soft: #704a33;
-  --color-text-instruction: #5a3a25;
-  --color-text-inline: #5b331c;
-  --color-tag-text: #4a2517;
-  --color-text-inverse: #fdf4e7;
-  --color-text-emphasis: #1e120b;
-
-  --color-surface: #fff6e6;
-  --color-surface-elevated: #fff1dd;
-  --color-surface-soft: rgba(112, 74, 51, 0.1);
-  --color-surface-highlight: rgba(193, 140, 98, 0.2);
-  --color-header-background: rgba(255, 247, 236, 0.94);
-  --color-header-shadow: rgba(68, 49, 37, 0.36);
-
-  --color-border: rgba(193, 140, 98, 0.48);
-  --color-border-strong: rgba(193, 140, 98, 0.62);
-  --color-border-muted: rgba(193, 140, 98, 0.28);
-  --color-code-background: rgba(255, 241, 215, 0.95);
-  --color-inline-tag-background: rgba(193, 140, 98, 0.26);
-  --color-inline-tag-text: #452916;
-  --color-neutral-soft: rgba(126, 87, 57, 0.26);
-
-  --color-card-shadow: rgba(68, 49, 37, 0.26);
-  --color-card-shadow-muted: rgba(68, 49, 37, 0.18);
-  --color-card-shadow-soft: rgba(193, 140, 98, 0.3);
-
-  --color-accent-secondary: #2f855a;
-  --color-accent-secondary-strong: #276749;
-  --color-accent-secondary-soft: rgba(47, 133, 90, 0.2);
-  --color-accent-secondary-outline: rgba(47, 133, 90, 0.3);
-  --color-accent-secondary-contrast: #08281a;
-  --color-accent-secondary-shadow: rgba(47, 133, 90, 0.28);
-
-  --color-neutral-50: #f9f2e8;
-  --color-neutral-100: #ecdcc6;
-  --color-neutral-200: #dfc7a9;
-  --color-neutral-400: #c7a075;
-  --color-neutral-600: #8d6437;
-
-  --color-danger: #b8432e;
-  --color-danger-soft: rgba(184, 67, 46, 0.26);
-
-  --color-focus-ring: rgba(193, 140, 98, 0.34);
-}
-
-:root[data-mode='sepia'][data-theme='classic'] {
-  --color-layout-background: #f6ead6;
-  --color-surface-elevated: #fff7e8;
-
-  --color-background: #f4ecdf;
-  --body-gradient-start: #fffaf2;
-  --body-gradient-mid: #f0e2cd;
-  --body-gradient-end: #e2c9a9;
-
-  --color-header-background: rgba(255, 246, 232, 0.95);
-
-  --color-accent: #b7791f;
-  --color-accent-strong: #d8a441;
-  --color-accent-soft: rgba(183, 121, 31, 0.24);
-  --color-accent-softer: rgba(183, 121, 31, 0.16);
-  --color-accent-outline: rgba(183, 121, 31, 0.32);
-  --color-accent-border: rgba(226, 177, 94, 0.65);
-  --color-accent-shadow: rgba(183, 121, 31, 0.44);
-  --color-accent-shadow-strong: rgba(183, 121, 31, 0.5);
-
-  --color-accent-secondary: #2f855a;
-  --color-accent-secondary-strong: #276749;
-  --color-accent-secondary-soft: rgba(47, 133, 90, 0.18);
-  --color-accent-secondary-outline: rgba(47, 133, 90, 0.28);
-  --color-accent-secondary-contrast: #07281a;
-  --color-accent-secondary-shadow: rgba(47, 133, 90, 0.3);
-
-  --color-neutral-50: #f8f0e2;
-  --color-neutral-100: #eedcc1;
-  --color-neutral-200: #e0c69f;
-  --color-neutral-400: #d0a877;
-  --color-neutral-600: #8a6230;
-
-  --color-inline-tag-background: rgba(226, 177, 94, 0.3);
-  --color-inline-tag-text: #503213;
-
-  --color-surface-soft: rgba(183, 121, 31, 0.1);
-  --color-surface-highlight: rgba(226, 177, 94, 0.2);
-
-  --color-border: rgba(226, 177, 94, 0.45);
-  --color-border-strong: rgba(226, 177, 94, 0.58);
-  --color-border-muted: rgba(226, 177, 94, 0.28);
-  --color-code-background: rgba(255, 244, 224, 0.96);
-
-  --color-card-shadow: rgba(92, 63, 36, 0.28);
-  --color-card-shadow-muted: rgba(92, 63, 36, 0.18);
-  --color-card-shadow-soft: rgba(226, 177, 94, 0.3);
-
-  --color-focus-ring: rgba(183, 121, 31, 0.36);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] {
-  --color-layout-background: #ecd1b6;
-  --color-surface-elevated: #ffe8d5;
-
-  --color-background: #f4d8c4;
-  --body-gradient-start: #fff3e6;
-  --body-gradient-mid: #efbe8f;
-  --body-gradient-end: #de9864;
-
-  --color-header-background: linear-gradient(
-    135deg,
-    rgba(88, 46, 29, 0.96) 0%,
-    rgba(161, 95, 55, 0.88) 46%,
-    rgba(71, 37, 23, 0.98) 100%
-  );
-  --color-header-foreground: #fbe6d5;
-  --color-header-shadow: rgba(56, 28, 17, 0.55);
-
-  --color-accent: #d07a3b;
-  --color-accent-strong: #f3b574;
-  --color-accent-soft: rgba(208, 122, 59, 0.32);
-  --color-accent-softer: rgba(243, 181, 116, 0.22);
-  --color-accent-outline: rgba(240, 173, 120, 0.42);
-  --color-accent-border: rgba(242, 195, 143, 0.68);
-  --color-accent-shadow: rgba(180, 92, 48, 0.52);
-  --color-accent-shadow-strong: rgba(230, 149, 90, 0.55);
-  --gradient-accent: linear-gradient(135deg, #d07a3b 0%, #f6c78d 50%, #bb5e30 100%);
-
-  --color-accent-secondary: #6c7d2b;
-  --color-accent-secondary-strong: #536222;
-  --color-accent-secondary-soft: rgba(108, 125, 43, 0.24);
-  --color-accent-secondary-outline: rgba(108, 125, 43, 0.36);
-  --color-accent-secondary-contrast: #2a3439;
-  --color-accent-secondary-shadow: rgba(85, 99, 33, 0.38);
-
-  --view-toggle-inactive-gradient: linear-gradient(
-    135deg,
-    #566720 0%,
-    #94a845 48%,
-    #6c7d2b 100%
-  );
-  --view-toggle-inactive-border: rgba(148, 168, 69, 0.5);
-  --view-toggle-inactive-text: #2a3439;
-  --view-toggle-hover-glow: 0 0 18px rgba(243, 181, 116, 0.55);
-  --view-toggle-active-gradient: linear-gradient(
-    135deg,
-    #d88543 0%,
-    #f7c993 50%,
-    #c46833 100%
-  );
-  --view-toggle-active-text: #3a1d0c;
-
-  --color-neutral-50: #f7eae0;
-  --color-neutral-100: #ebd5c5;
-  --color-neutral-200: #ddbfa9;
-  --color-neutral-400: #c79b7c;
-  --color-neutral-600: #8f5a3d;
-
-  --color-inline-tag-background: rgba(234, 173, 137, 0.3);
-  --color-inline-tag-text: #2a3439;
-  --color-tag-text: #2a3439;
-  --color-text-badge: #2a3439;
-
-  --color-surface-soft: rgba(194, 106, 61, 0.1);
-  --color-surface-highlight: rgba(234, 173, 137, 0.26);
-
-  --color-border: rgba(234, 173, 137, 0.45);
-  --color-border-strong: rgba(234, 173, 137, 0.6);
-  --color-border-muted: rgba(234, 173, 137, 0.3);
-  --color-code-background: rgba(252, 235, 216, 0.96);
-
-  --color-card-shadow: rgba(104, 59, 39, 0.28);
-  --color-card-shadow-muted: rgba(104, 59, 39, 0.2);
-  --color-card-shadow-soft: rgba(234, 173, 137, 0.32);
-
-  --color-focus-ring: rgba(226, 129, 74, 0.36);
-
-  --favorite-heart-mask: url("data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%2024%2024%22%3E%3Cpath%20fill=%22%23000%22%20d=%22M12%2021.35l-1.45-1.32C5.4%2015.36%202%2012.28%202%208.5%202%205.42%204.42%203%207.5%203c1.74%200%203.41%200.81%204.5%202.09C13.09%203.81%2014.76%203%2016.5%203%2019.58%203%2022%205.42%2022%208.5c0%203.78-3.4%206.86-8.55%2011.54L12%2021.35z%22/%3E%3C/svg%3E");
-  --favorite-heart-off: linear-gradient(145deg, #d9d9d9 0%, #bdbdbd 48%, #878787 100%);
-  --favorite-heart-hover: linear-gradient(145deg, #f1f1f1 0%, #dcdcdc 42%, #9f9f9f 100%);
-  --favorite-heart-on: linear-gradient(135deg, #d94ba5 0%, #f472b6 45%, #c026d3 100%);
-  --favorite-heart-shadow-soft: 0 18px 36px -24px rgba(53, 24, 18, 0.6);
-  --favorite-heart-shadow: 0 20px 42px -20px rgba(168, 37, 149, 0.6);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-card .badge {
-  background: var(--view-toggle-inactive-gradient);
-  color: var(--view-toggle-inactive-text, #2a3439);
-  border-color: rgba(248, 250, 235, 0.38);
-  box-shadow: 0 16px 32px -24px rgba(108, 125, 43, 0.45);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .filter-panel {
-  color: #fbe6d5;
-  --color-text-emphasis: #fbe6d5;
-  --color-text-tertiary: rgba(251, 230, 213, 0.82);
-  --color-text-muted: rgba(251, 230, 213, 0.78);
-  --color-text-soft: rgba(251, 230, 213, 0.68);
-  --color-text-badge: #fbe6d5;
-  --color-inline-tag-text: #fbe6d5;
-  --color-text-instruction: rgba(251, 230, 213, 0.86);
-  --color-accent-outline: rgba(251, 230, 213, 0.32);
-  --color-border-muted: rgba(251, 230, 213, 0.26);
-  --color-accent-border: rgba(251, 230, 213, 0.36);
-  --filter-section-background: linear-gradient(
-    150deg,
-    rgba(79, 42, 28, 0.95) 0%,
-    rgba(135, 72, 46, 0.9) 52%,
-    rgba(64, 34, 24, 0.97) 100%
-  );
-  --filter-section-border: rgba(251, 230, 213, 0.32);
-  --filter-section-shadow: rgba(28, 14, 10, 0.65);
-  --filter-panel-group-foreground: #2a3439;
-  --filter-panel-group-muted: rgba(42, 52, 57, 0.72);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .filter-section {
-  color: #fce7d8;
-  --color-text-emphasis: #fce7d8;
-  --color-text-muted: rgba(252, 231, 214, 0.78);
-  --color-text-soft: rgba(252, 231, 214, 0.68);
-  --color-text-badge: #fce7d8;
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .filter-section summary {
-  color: inherit;
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .filter-section summary::after {
-  border-right-color: currentColor;
-  border-bottom-color: currentColor;
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .filter-section__content {
-  gap: 0.7rem;
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .filter-section .ingredient-group,
-:root[data-mode='sepia'][data-theme='copper'] .filter-section .tag-group {
-  background: rgba(255, 235, 220, 0.92);
-  border-color: rgba(176, 112, 74, 0.45);
-  box-shadow: 0 14px 32px -24px rgba(52, 28, 18, 0.55);
-  color: var(--filter-panel-group-foreground, #2a3439);
-  --color-text-emphasis: var(--filter-panel-group-foreground, #2a3439);
-  --color-text-muted: var(--filter-panel-group-muted, rgba(42, 52, 57, 0.72));
-  --color-text-soft: rgba(42, 52, 57, 0.6);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .filter-section .ingredient-group[open],
-:root[data-mode='sepia'][data-theme='copper'] .filter-section .tag-group[open] {
-  background: rgba(255, 239, 228, 0.96);
-  border-color: rgba(214, 164, 127, 0.55);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .favorite-filter {
-  background: linear-gradient(135deg, #5f6772 0%, #30363f 100%);
-  border-color: rgba(251, 230, 213, 0.22);
-  color: var(--color-header-foreground, #fbe6d5);
-  box-shadow: 0 14px 32px -26px rgba(31, 25, 22, 0.55);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .favorite-filter:hover {
-  box-shadow: 0 18px 36px -24px rgba(31, 25, 22, 0.6);
-  background: linear-gradient(135deg, #6c757f 0%, #3a414b 100%);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .favorite-filter.favorite-filter--active,
-:root[data-mode='sepia'][data-theme='copper'] .favorite-filter[aria-pressed='true'] {
-  background: linear-gradient(135deg, #7b848f 0%, #424a55 100%);
-  border-color: rgba(251, 230, 213, 0.28);
-  color: var(--color-header-foreground, #fbe6d5);
-  box-shadow: 0 20px 42px -24px rgba(31, 25, 22, 0.65);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .favorite-filter__icon {
-  display: inline-flex;
-  width: 1.3rem;
-  height: 1.15rem;
-  font-size: 0;
-  color: transparent;
-  background: var(--favorite-heart-off);
-  -webkit-mask-image: var(--favorite-heart-mask);
-  mask-image: var(--favorite-heart-mask);
-  -webkit-mask-repeat: no-repeat;
-  mask-repeat: no-repeat;
-  -webkit-mask-size: contain;
-  mask-size: contain;
-  -webkit-mask-position: center;
-  mask-position: center;
-  filter: drop-shadow(0 10px 20px rgba(52, 28, 18, 0.45));
-  transition: background 0.2s ease, filter 0.2s ease;
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .favorite-filter:hover .favorite-filter__icon {
-  background: var(--favorite-heart-hover);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .favorite-filter.favorite-filter--active .favorite-filter__icon,
-:root[data-mode='sepia'][data-theme='copper'] .favorite-filter[aria-pressed='true'] .favorite-filter__icon {
-  background: var(--favorite-heart-on);
-  filter: drop-shadow(0 14px 30px rgba(168, 37, 149, 0.45));
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .reset-button {
-  background: linear-gradient(135deg, #5f6772 0%, #30363f 100%);
-  border-color: transparent;
-  color: var(--color-header-foreground, #fbe6d5);
-  box-shadow: 0 12px 26px -24px rgba(31, 25, 22, 0.55);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .reset-button:hover {
-  box-shadow: 0 16px 30px -22px rgba(31, 25, 22, 0.62);
-  background: linear-gradient(135deg, #6c757f 0%, #3a414b 100%);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .tag-group__summary,
-:root[data-mode='sepia'][data-theme='copper'] .tag-group__summary-count,
-:root[data-mode='sepia'][data-theme='copper'] .ingredient-group__summary {
-  color: rgba(124, 70, 40, 0.95);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .tag-group__summary-count {
-  background: rgba(217, 75, 165, 0.16);
-  color: rgba(124, 70, 40, 0.92);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-card {
-  color: #2a3439;
-  --color-text-emphasis: #2a3439;
-  --color-text-tertiary: rgba(42, 52, 57, 0.7);
-  --color-text-muted: rgba(42, 52, 57, 0.7);
-  --color-text-soft: rgba(42, 52, 57, 0.58);
-  --color-text-badge: #2a3439;
-  --color-text-instruction: rgba(42, 52, 57, 0.68);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-card__header,
-:root[data-mode='sepia'][data-theme='copper'] .meal-card__section,
-:root[data-mode='sepia'][data-theme='copper'] .meal-card__details > div {
-  color: var(--color-header-foreground, #fbe6d5);
-  --color-text-strong: var(--color-header-foreground, #fbe6d5);
-  --color-text-emphasis: var(--color-header-foreground, #fbe6d5);
-  --color-text-tertiary: rgba(251, 230, 213, 0.82);
-  --color-text-muted: rgba(251, 230, 213, 0.76);
-  --color-text-soft: rgba(251, 230, 213, 0.65);
-  --color-text-badge: var(--color-header-foreground, #fbe6d5);
-  --color-tag-text: var(--color-header-foreground, #fbe6d5);
-  --color-inline-tag-text: var(--color-header-foreground, #fbe6d5);
-  --color-text-inline: var(--color-header-foreground, #fbe6d5);
-  --color-text-instruction: rgba(251, 230, 213, 0.88);
-  --color-accent-secondary-contrast: var(--color-header-foreground, #fbe6d5);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-card__favorite-button {
-  appearance: none;
-  background: var(--favorite-heart-off);
-  border: none;
-  border-radius: 0;
-  color: transparent;
-  font-size: 0;
-  line-height: 0;
-  width: 2.75rem;
-  height: 2.45rem;
-  min-width: 2.75rem;
-  min-height: 2.45rem;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  -webkit-mask-image: var(--favorite-heart-mask);
-  mask-image: var(--favorite-heart-mask);
-  -webkit-mask-repeat: no-repeat;
-  mask-repeat: no-repeat;
-  -webkit-mask-size: contain;
-  mask-size: contain;
-  -webkit-mask-position: center;
-  mask-position: center;
-  box-shadow: var(--favorite-heart-shadow-soft);
-  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-card__favorite-button:hover {
-  transform: translateY(-1px);
-  background: var(--favorite-heart-hover);
-  box-shadow: 0 20px 36px -22px rgba(90, 42, 30, 0.65);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-card__favorite-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(248, 197, 226, 0.45);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-card__favorite-button--active,
-:root[data-mode='sepia'][data-theme='copper'] .meal-card__favorite-button[aria-pressed='true'] {
-  background: var(--favorite-heart-on);
-  box-shadow: var(--favorite-heart-shadow);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .serving-controls {
-  color: #000000;
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-view {
-  background: var(--color-burnished-copper);
-  color: var(--color-header-foreground, #fbe6d5);
-  --color-text-emphasis: var(--color-header-foreground, #fbe6d5);
-  --color-text-secondary: rgba(251, 230, 213, 0.86);
-  --color-text-tertiary: rgba(251, 230, 213, 0.78);
-  --color-text-muted: rgba(251, 230, 213, 0.72);
-  --color-text-soft: rgba(251, 230, 213, 0.64);
-  --meal-plan-border: rgba(79, 42, 28, 0.32);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-view__navigator {
-  background: linear-gradient(
-    135deg,
-    rgba(86, 103, 32, 0.95) 0%,
-    rgba(148, 168, 69, 0.88) 52%,
-    rgba(108, 125, 43, 0.94) 100%
-  );
-  border-color: rgba(251, 230, 213, 0.42);
-  box-shadow: 0 20px 38px -24px rgba(22, 30, 14, 0.68);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-nav__label {
-  color: rgba(251, 230, 213, 0.94);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-nav__controls {
-  gap: 0.75rem;
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-nav__button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  padding: 0;
-  border: none;
-  border-radius: 0;
-  background: none;
-  box-shadow: none;
-  color: #2a3439;
-  font-size: 1.8rem;
-  line-height: 1;
-  transition: color 0.2s ease, transform 0.2s ease;
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-nav__button:hover {
-  transform: translateY(-1px);
-  color: #1f2a30;
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-nav__button:focus-visible {
-  outline: 2px solid rgba(251, 230, 213, 0.65);
-  outline-offset: 2px;
-  border-radius: 4px;
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar,
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-sidebar {
-  background: linear-gradient(
-    140deg,
-    rgba(86, 103, 32, 0.94) 0%,
-    rgba(148, 168, 69, 0.9) 48%,
-    rgba(108, 125, 43, 0.96) 100%
-  );
-  border-color: rgba(251, 230, 213, 0.28);
-  box-shadow: 0 22px 40px -26px rgba(18, 26, 14, 0.7);
-}
-
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__cell,
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__entry,
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__entry-title,
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__more,
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__week-header-date,
-:root[data-mode='sepia'][data-theme='copper'] .meal-plan-calendar__date-number {
-  color: var(--color-gunmetal);
+  --color-danger-soft: rgba(248, 113, 113, 0.25);
+  --color-focus-ring: rgba(96, 165, 250, 0.45);
+
+  --meal-plan-border: rgba(96, 165, 250, 0.3);
+  --meal-plan-surface: rgba(17, 24, 39, 0.92);
 }
 
 .holiday-theme-dialog {
@@ -4683,55 +3686,4 @@ textarea:focus {
 .holiday-theme-dialog__button:focus-visible {
   outline: 3px solid var(--color-accent);
   outline-offset: 2px;
-}
-
-:root[data-mode='sepia'][data-theme='umber'] {
-  --color-layout-background: #d5b890;
-  --color-surface-elevated: #f6e4ca;
-
-  --color-background: #e9ddca;
-  --body-gradient-start: #fdf5e6;
-  --body-gradient-mid: #e1c9a9;
-  --body-gradient-end: #cfab87;
-
-  --color-header-background: rgba(233, 221, 202, 0.94);
-
-  --color-accent: #8a4b2a;
-  --color-accent-strong: #b56a3a;
-  --color-accent-soft: rgba(138, 75, 42, 0.28);
-  --color-accent-softer: rgba(181, 106, 58, 0.22);
-  --color-accent-outline: rgba(181, 106, 58, 0.36);
-  --color-accent-border: rgba(204, 154, 120, 0.6);
-  --color-accent-shadow: rgba(92, 47, 26, 0.5);
-  --color-accent-shadow-strong: rgba(181, 106, 58, 0.52);
-
-  --color-accent-secondary: #3b82f6;
-  --color-accent-secondary-strong: #1d4ed8;
-  --color-accent-secondary-soft: rgba(59, 130, 246, 0.26);
-  --color-accent-secondary-outline: rgba(59, 130, 246, 0.34);
-  --color-accent-secondary-contrast: #0b1f3a;
-  --color-accent-secondary-shadow: rgba(59, 130, 246, 0.3);
-
-  --color-neutral-50: #f1e4d4;
-  --color-neutral-100: #e3ccb4;
-  --color-neutral-200: #d2b494;
-  --color-neutral-400: #b88c67;
-  --color-neutral-600: #7b5233;
-
-  --color-inline-tag-background: rgba(204, 154, 120, 0.34);
-  --color-inline-tag-text: #3e1f0d;
-
-  --color-surface-soft: rgba(138, 75, 42, 0.1);
-  --color-surface-highlight: rgba(204, 154, 120, 0.28);
-
-  --color-border: rgba(204, 154, 120, 0.45);
-  --color-border-strong: rgba(204, 154, 120, 0.6);
-  --color-border-muted: rgba(204, 154, 120, 0.3);
-  --color-code-background: rgba(245, 226, 203, 0.96);
-
-  --color-card-shadow: rgba(74, 41, 24, 0.28);
-  --color-card-shadow-muted: rgba(74, 41, 24, 0.2);
-  --color-card-shadow-soft: rgba(204, 154, 120, 0.32);
-
-  --color-focus-ring: rgba(181, 106, 58, 0.38);
 }


### PR DESCRIPTION
## Summary
- replace the palette picker with background, primary, and accent color controls tied to each mode
- compute theme tokens dynamically from the selected colors (including holiday presets) and persist them across sessions
- refresh the toolbar styling to support the new color inputs and drop the hard-coded theme variants

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dffc6401a48325aac655d03f100c18