### PR TITLE
Refine theme palette layering

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,21 +135,47 @@
                             </div>
                           </div>
                           <div class="theme-color-control">
-                            <span class="theme-color-control__label" id="theme-color-label-accent"
-                              >Accent</span
+                            <span class="theme-color-control__label" id="theme-color-label-accent-1"
+                              >Accent 1</span
                             >
                             <div class="theme-color-control__inputs">
                               <input
                                 type="color"
                                 class="theme-color-control__picker"
-                                data-color-role="accent"
-                                aria-labelledby="theme-color-label-accent"
+                                data-color-role="accent1"
+                                aria-labelledby="theme-color-label-accent-1"
                               />
                               <input
                                 type="text"
                                 class="theme-color-control__value"
-                                data-color-role="accent"
-                                aria-labelledby="theme-color-label-accent"
+                                data-color-role="accent1"
+                                aria-labelledby="theme-color-label-accent-1"
+                                placeholder="#RRGGBB"
+                                spellcheck="false"
+                                autocapitalize="off"
+                                autocomplete="off"
+                                inputmode="text"
+                                maxlength="7"
+                                pattern="^#?[0-9A-Fa-f]{3,6}$"
+                              />
+                            </div>
+                          </div>
+                          <div class="theme-color-control">
+                            <span class="theme-color-control__label" id="theme-color-label-accent-2"
+                              >Accent 2</span
+                            >
+                            <div class="theme-color-control__inputs">
+                              <input
+                                type="color"
+                                class="theme-color-control__picker"
+                                data-color-role="accent2"
+                                aria-labelledby="theme-color-label-accent-2"
+                              />
+                              <input
+                                type="text"
+                                class="theme-color-control__value"
+                                data-color-role="accent2"
+                                aria-labelledby="theme-color-label-accent-2"
                                 placeholder="#RRGGBB"
                                 spellcheck="false"
                                 autocapitalize="off"

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1335,13 +1335,15 @@
   const DEFAULT_THEME_PALETTES = {
     light: {
       background: '#F5F8FF',
-      main: '#3B82F6',
-      accent: '#22D3EE',
+      primary: '#3B82F6',
+      accent1: '#22D3EE',
+      accent2: '#F97316',
     },
     dark: {
       background: '#0F172A',
-      main: '#60A5FA',
-      accent: '#38BDF8',
+      primary: '#60A5FA',
+      accent1: '#38BDF8',
+      accent2: '#FB923C',
     },
   };
 
@@ -1511,11 +1513,20 @@
 
   const sanitizeThemePalette = (palette, mode) => {
     const defaults = DEFAULT_THEME_PALETTES[mode] || DEFAULT_THEME_PALETTES.light;
-    return {
-      background: normalizeHexColor(palette?.background) || defaults.background,
-      main: normalizeHexColor(palette?.main) || defaults.main,
-      accent: normalizeHexColor(palette?.accent) || defaults.accent,
-    };
+    const background = normalizeHexColor(palette?.background) || defaults.background;
+    const primary =
+      normalizeHexColor(palette?.primary)
+      || normalizeHexColor(palette?.main)
+      || defaults.primary;
+    const accent1 =
+      normalizeHexColor(palette?.accent1)
+      || normalizeHexColor(palette?.accent)
+      || defaults.accent1;
+    const accent2 =
+      normalizeHexColor(palette?.accent2)
+      || normalizeHexColor(palette?.accentSecondary)
+      || defaults.accent2;
+    return { background, primary, accent1, accent2 };
   };
 
   const sanitizeThemePalettes = (palettes) => {
@@ -4961,14 +4972,16 @@
     const sanitized = sanitizeThemePalette(palette, mode);
     const fallback = DEFAULT_THEME_PALETTES[mode] || DEFAULT_THEME_PALETTES.light;
     const background = hexToRgb(sanitized.background) || hexToRgb(fallback.background);
-    const main = hexToRgb(sanitized.main) || hexToRgb(fallback.main);
-    const accent = hexToRgb(sanitized.accent) || hexToRgb(fallback.accent);
+    const primary = hexToRgb(sanitized.primary) || hexToRgb(fallback.primary);
+    const accent1 = hexToRgb(sanitized.accent1) || hexToRgb(fallback.accent1);
+    const accent2 = hexToRgb(sanitized.accent2) || hexToRgb(fallback.accent2);
     const white = WHITE_RGB || hexToRgb('#FFFFFF');
     const black = BLACK_RGB || hexToRgb('#020617');
 
     const backgroundHex = background.hex;
-    const mainHex = main.hex;
-    const accentHex = accent.hex;
+    const primaryHex = primary.hex;
+    const accent1Hex = accent1.hex;
+    const accent2Hex = accent2.hex;
 
     const textPrimaryHex = getReadableTextColor(background, [
       '#0F172A',
@@ -5017,31 +5030,48 @@
       mixColors(background, mode === 'light' ? white : black, mode === 'light' ? 0.55 : 0.4),
     );
 
-    const accentStrong = adjustLightness(adjustSaturation(main, 0.05), mode === 'light' ? -0.18 : -0.08);
-    const accentStrongHex = rgbToHex(accentStrong);
-    const accentSecondaryStrong = adjustLightness(adjustSaturation(accent, 0.05), mode === 'light' ? -0.16 : -0.08);
-    const accentSecondaryStrongHex = rgbToHex(accentSecondaryStrong);
-    const accentInverseHex = getReadableTextColor(accent, [
+    const primaryStrong = adjustLightness(
+      adjustSaturation(primary, 0.05),
+      mode === 'light' ? -0.18 : -0.08,
+    );
+    const primaryStrongHex = rgbToHex(primaryStrong);
+    const primaryContrastHex = getReadableTextColor(primary, [
       '#F8FAFC',
       '#F1F5F9',
       '#0F172A',
       '#020617',
     ]);
-    const accentContrastHex = getReadableTextColor(main, [
+    const accent1Strong = adjustLightness(
+      adjustSaturation(accent1, 0.05),
+      mode === 'light' ? -0.16 : -0.08,
+    );
+    const accent1StrongHex = rgbToHex(accent1Strong);
+    const accent1ContrastHex = getReadableTextColor(accent1, [
+      '#F8FAFC',
+      '#F1F5F9',
+      '#0F172A',
+      '#020617',
+    ]);
+    const accent2Strong = adjustLightness(
+      adjustSaturation(accent2, 0.05),
+      mode === 'light' ? -0.16 : -0.08,
+    );
+    const accent2StrongHex = rgbToHex(accent2Strong);
+    const accent2ContrastHex = getReadableTextColor(accent2, [
       '#F8FAFC',
       '#F1F5F9',
       '#0F172A',
       '#020617',
     ]);
 
-    const borderColor = mixColors(main, background, mode === 'light' ? 0.45 : 0.3);
-    const borderStrongColor = mixColors(main, textPrimary, mode === 'light' ? 0.4 : 0.35);
+    const borderColor = mixColors(primary, background, mode === 'light' ? 0.45 : 0.3);
+    const borderStrongColor = mixColors(primary, textPrimary, mode === 'light' ? 0.4 : 0.35);
     const borderMutedColor = mixColors(background, white, mode === 'light' ? 0.68 : 0.35);
 
     const headerShadowColor = mixColors(textPrimary, black, mode === 'light' ? 0.45 : 0.2);
-    const cardShadowColor = mixColors(main, black, mode === 'light' ? 0.25 : 0.55);
-    const cardShadowMutedColor = mixColors(main, black, mode === 'light' ? 0.18 : 0.48);
-    const cardShadowSoftColor = mixColors(accent, main, 0.4);
+    const cardShadowColor = mixColors(primary, black, mode === 'light' ? 0.25 : 0.55);
+    const cardShadowMutedColor = mixColors(primary, black, mode === 'light' ? 0.18 : 0.48);
+    const cardShadowSoftColor = mixColors(primary, black, mode === 'light' ? 0.32 : 0.4);
 
     const neutral50Hex = rgbToHex(mixColors(background, textPrimary, mode === 'light' ? 0.08 : 0.16));
     const neutral100Hex = rgbToHex(mixColors(background, textPrimary, mode === 'light' ? 0.14 : 0.22));
@@ -5052,30 +5082,39 @@
     const codeBackgroundHex = rgbToHex(
       mixColors(surfaceElevated, textPrimary, mode === 'light' ? 0.08 : 0.35),
     );
-    const mealPlanSnackHex = rgbToHex(mixColors(main, accent, 0.5));
     const mealPlanSurfaceValue = mode === 'light' ? '#FFFFFF' : toRgba(surfaceElevated, 0.92);
 
-    const inactiveBlend = mixColors(main, accent, 0.5);
-    const inactiveGradient = `linear-gradient(135deg, ${alphaColor(mainHex, mode === 'light' ? 0.65 : 0.58)}, ${alphaColor(accentHex, mode === 'light' ? 0.65 : 0.6)})`;
-    const activeGradient = `linear-gradient(135deg, ${mainHex}, ${accentHex})`;
-    const inactiveTextHex = getReadableTextColor(inactiveBlend, [
+    const accentBlend = mixColors(accent1, accent2, 0.5);
+    const accentBlendHex = rgbToHex(accentBlend);
+    const inactiveGradient = `linear-gradient(135deg, ${alphaColor(
+      accent1Hex,
+      mode === 'light' ? 0.55 : 0.5,
+    )}, ${alphaColor(accent2Hex, mode === 'light' ? 0.55 : 0.5)})`;
+    const activeGradient = `linear-gradient(135deg, ${accent1Hex}, ${accent2Hex})`;
+    const inactiveTextHex = getReadableTextColor(accentBlend, [
       '#F8FAFC',
       '#F1F5F9',
       '#0F172A',
     ]);
-    const activeTextHex = getReadableTextColor(inactiveBlend, [
-      '#F8FAFC',
-      '#F1F5F9',
-      '#0F172A',
-    ]);
+    const activeTextHex = inactiveTextHex;
 
-    const elevatedGradient = `linear-gradient(158deg, ${alphaColor(accentHex, mode === 'light' ? 0.16 : 0.22)}, ${surfaceElevatedHex})`;
-    const sectionGradient = `linear-gradient(155deg, ${alphaColor(mainHex, mode === 'light' ? 0.12 : 0.2)}, ${alphaColor(accentHex, mode === 'light' ? 0.16 : 0.24)})`;
+    const primaryGlassStrong = alphaColor(primaryHex, mode === 'light' ? 0.16 : 0.26);
+    const primaryGlassSoft = alphaColor(primaryHex, mode === 'light' ? 0.1 : 0.18);
+    const primaryGlassSofter = alphaColor(primaryHex, mode === 'light' ? 0.06 : 0.14);
+    const elevatedGradient = `linear-gradient(158deg, ${primaryGlassStrong}, ${surfaceElevatedHex})`;
+    const sectionGradient = `linear-gradient(155deg, ${primaryGlassSoft}, ${primaryGlassSofter})`;
+    const cardGradient = `linear-gradient(160deg, ${primaryGlassStrong}, ${alphaColor(
+      primaryHex,
+      mode === 'light' ? 0.04 : 0.12,
+    )})`;
 
     return {
       '--theme-background': backgroundHex,
-      '--theme-main': mainHex,
-      '--theme-accent': accentHex,
+      '--theme-main': primaryHex,
+      '--theme-primary': primaryHex,
+      '--theme-accent': accent1Hex,
+      '--theme-accent-1': accent1Hex,
+      '--theme-accent-2': accent2Hex,
       '--color-background': backgroundHex,
       '--body-gradient-start': gradientStartHex,
       '--body-gradient-mid': gradientMidHex,
@@ -5085,19 +5124,16 @@
       '--color-header-shadow': alphaColor(rgbToHex(headerShadowColor), mode === 'light' ? 0.25 : 0.65),
       '--color-surface': surfaceHex,
       '--color-surface-elevated': surfaceElevatedHex,
-      '--color-surface-soft': alphaColor(mainHex, mode === 'light' ? 0.12 : 0.2),
-      '--color-surface-highlight': alphaColor(accentHex, mode === 'light' ? 0.18 : 0.26),
+      '--color-surface-soft': alphaColor(primaryHex, mode === 'light' ? 0.1 : 0.18),
+      '--color-surface-highlight': alphaColor(primaryHex, mode === 'light' ? 0.18 : 0.26),
       '--color-card-shadow': alphaColor(rgbToHex(cardShadowColor), mode === 'light' ? 0.24 : 0.6),
       '--color-card-shadow-muted': alphaColor(rgbToHex(cardShadowMutedColor), mode === 'light' ? 0.18 : 0.5),
       '--color-card-shadow-soft': alphaColor(rgbToHex(cardShadowSoftColor), mode === 'light' ? 0.2 : 0.34),
       '--color-border': alphaColor(rgbToHex(borderColor), mode === 'light' ? 0.45 : 0.38),
-      '--color-border-strong': alphaColor(
-        rgbToHex(borderStrongColor),
-        mode === 'light' ? 0.55 : 0.6,
-      ),
+      '--color-border-strong': alphaColor(rgbToHex(borderStrongColor), mode === 'light' ? 0.55 : 0.6),
       '--color-border-muted': alphaColor(rgbToHex(borderMutedColor), mode === 'light' ? 0.68 : 0.55),
-      '--color-inline-tag-background': alphaColor(accentHex, mode === 'light' ? 0.2 : 0.26),
-      '--color-inline-tag-text': accentInverseHex,
+      '--color-inline-tag-background': alphaColor(accent1Hex, mode === 'light' ? 0.2 : 0.26),
+      '--color-inline-tag-text': accent1ContrastHex,
       '--color-code-background': codeBackgroundHex,
       '--color-neutral-50': neutral50Hex,
       '--color-neutral-100': neutral100Hex,
@@ -5113,59 +5149,69 @@
       '--color-text-badge': textBadgeHex,
       '--color-text-soft': toRgba(textSoftColor, mode === 'light' ? 0.7 : 0.68),
       '--color-text-instruction': textInstructionHex,
-      '--color-text-inline': mainHex,
-      '--color-tag-text': mainHex,
-      '--color-text-inverse': accentContrastHex,
+      '--color-text-inline': accent1Hex,
+      '--color-tag-text': accent1Hex,
+      '--color-text-inverse': primaryContrastHex,
       '--color-gunmetal': textStrongHex,
       '--color-text-emphasis': textPrimaryHex,
-      '--color-accent': mainHex,
-      '--color-accent-strong': accentStrongHex,
-      '--color-accent-soft': alphaColor(mainHex, mode === 'light' ? 0.18 : 0.28),
-      '--color-accent-softer': alphaColor(mainHex, mode === 'light' ? 0.12 : 0.22),
-      '--color-accent-outline': alphaColor(mainHex, mode === 'light' ? 0.3 : 0.45),
-      '--color-accent-border': alphaColor(mainHex, mode === 'light' ? 0.38 : 0.5),
+      '--color-accent': primaryHex,
+      '--color-accent-strong': primaryStrongHex,
+      '--color-accent-soft': alphaColor(primaryHex, mode === 'light' ? 0.18 : 0.28),
+      '--color-accent-softer': alphaColor(primaryHex, mode === 'light' ? 0.12 : 0.22),
+      '--color-accent-outline': alphaColor(primaryHex, mode === 'light' ? 0.3 : 0.45),
+      '--color-accent-border': alphaColor(primaryHex, mode === 'light' ? 0.38 : 0.5),
       '--color-accent-shadow': alphaColor(
-        rgbToHex(mixColors(main, black, mode === 'light' ? 0.4 : 0.35)),
+        rgbToHex(mixColors(primary, black, mode === 'light' ? 0.4 : 0.35)),
         mode === 'light' ? 0.32 : 0.45,
       ),
-      '--color-accent-shadow-strong': alphaColor(mainHex, mode === 'light' ? 0.42 : 0.5),
-      '--color-accent-contrast': accentContrastHex,
-      '--color-accent-secondary': accentHex,
-      '--color-accent-secondary-strong': accentSecondaryStrongHex,
-      '--color-accent-secondary-soft': alphaColor(accentHex, mode === 'light' ? 0.22 : 0.32),
-      '--color-accent-secondary-outline': alphaColor(accentHex, mode === 'light' ? 0.3 : 0.45),
-      '--color-accent-secondary-contrast': accentInverseHex,
+      '--color-accent-shadow-strong': alphaColor(primaryHex, mode === 'light' ? 0.42 : 0.5),
+      '--color-accent-contrast': primaryContrastHex,
+      '--color-accent-secondary': accent1Hex,
+      '--color-accent-secondary-strong': accent1StrongHex,
+      '--color-accent-secondary-soft': alphaColor(accent1Hex, mode === 'light' ? 0.22 : 0.32),
+      '--color-accent-secondary-outline': alphaColor(accent1Hex, mode === 'light' ? 0.3 : 0.45),
+      '--color-accent-secondary-contrast': accent1ContrastHex,
       '--color-accent-secondary-shadow': alphaColor(
-        rgbToHex(mixColors(accent, black, mode === 'light' ? 0.35 : 0.3)),
+        rgbToHex(mixColors(accent1, black, mode === 'light' ? 0.35 : 0.3)),
         mode === 'light' ? 0.32 : 0.42,
       ),
-      '--color-burnished-copper': mainHex,
-      '--color-burnished-copper-soft': accentStrongHex,
-      '--color-burnished-copper-border': alphaColor(mainHex, mode === 'light' ? 0.25 : 0.38),
+      '--color-accent-tertiary': accent2Hex,
+      '--color-accent-tertiary-strong': accent2StrongHex,
+      '--color-accent-tertiary-soft': alphaColor(accent2Hex, mode === 'light' ? 0.22 : 0.32),
+      '--color-accent-tertiary-outline': alphaColor(accent2Hex, mode === 'light' ? 0.32 : 0.45),
+      '--color-accent-tertiary-contrast': accent2ContrastHex,
+      '--color-accent-tertiary-shadow': alphaColor(
+        rgbToHex(mixColors(accent2, black, mode === 'light' ? 0.35 : 0.32)),
+        mode === 'light' ? 0.32 : 0.44,
+      ),
+      '--color-burnished-copper': primaryHex,
+      '--color-burnished-copper-soft': primaryStrongHex,
+      '--color-burnished-copper-border': alphaColor(primaryHex, mode === 'light' ? 0.25 : 0.38),
       '--color-burnished-copper-shadow': alphaColor(
         rgbToHex(cardShadowColor),
         mode === 'light' ? 0.35 : 0.5,
       ),
-      '--gradient-accent': `linear-gradient(135deg, ${mainHex}, ${accentStrongHex})`,
-      '--gradient-accent-secondary': `linear-gradient(135deg, ${accentHex}, ${accentSecondaryStrongHex})`,
-      '--gradient-burnished-copper': `linear-gradient(140deg, ${accentStrongHex}, ${mainHex})`,
-      '--meal-plan-type-meal': mainHex,
-      '--meal-plan-type-drink': accentHex,
-      '--meal-plan-type-snack': mealPlanSnackHex,
+      '--gradient-accent': `linear-gradient(135deg, ${primaryHex}, ${primaryStrongHex})`,
+      '--gradient-accent-secondary': `linear-gradient(135deg, ${accent1Hex}, ${accent1StrongHex})`,
+      '--gradient-accent-tertiary': `linear-gradient(135deg, ${accent2Hex}, ${accent2StrongHex})`,
+      '--gradient-burnished-copper': `linear-gradient(140deg, ${primaryStrongHex}, ${primaryHex})`,
+      '--meal-plan-type-meal': primaryHex,
+      '--meal-plan-type-drink': accent1Hex,
+      '--meal-plan-type-snack': accent2Hex,
       '--meal-plan-type-text': surfaceTextHex,
-      '--meal-plan-border': alphaColor(mainHex, mode === 'light' ? 0.24 : 0.32),
+      '--meal-plan-border': alphaColor(primaryHex, mode === 'light' ? 0.24 : 0.32),
       '--meal-plan-surface': mealPlanSurfaceValue,
       '--view-toggle-inactive-gradient': inactiveGradient,
-      '--view-toggle-inactive-border': alphaColor(mainHex, mode === 'light' ? 0.5 : 0.45),
+      '--view-toggle-inactive-border': alphaColor(accent1Hex, mode === 'light' ? 0.45 : 0.4),
       '--view-toggle-inactive-text': inactiveTextHex,
-      '--view-toggle-hover-glow': `0 0 16px ${alphaColor(accentHex, mode === 'light' ? 0.35 : 0.45)}`,
+      '--view-toggle-hover-glow': `0 0 16px ${alphaColor(accentBlendHex, mode === 'light' ? 0.35 : 0.45)}`,
       '--view-toggle-active-gradient': activeGradient,
       '--view-toggle-active-text': activeTextHex,
       '--surface-elevated-gradient': elevatedGradient,
       '--surface-panel-gradient': elevatedGradient,
       '--surface-section-gradient': sectionGradient,
-      '--surface-card-gradient': elevatedGradient,
-      '--color-focus-ring': alphaColor(mainHex, mode === 'light' ? 0.28 : 0.4),
+      '--surface-card-gradient': cardGradient,
+      '--color-focus-ring': alphaColor(accent1Hex, mode === 'light' ? 0.28 : 0.4),
       '--color-header-foreground': surfaceTextHex,
     };
   };

--- a/styles/app.css
+++ b/styles/app.css
@@ -26,13 +26,16 @@
   --color-layout-background: #e2e8f0;
 
   --theme-background: #f5f8ff;
-  --theme-main: #3b82f6;
-  --theme-accent: #22d3ee;
+  --theme-primary: #3b82f6;
+  --theme-accent-1: #22d3ee;
+  --theme-accent-2: #f97316;
+  --theme-main: var(--theme-primary);
+  --theme-accent: var(--theme-accent-1);
 
   --color-surface: #ffffff;
   --color-surface-elevated: #ffffff;
   --color-surface-soft: rgba(59, 130, 246, 0.08);
-  --color-surface-highlight: rgba(34, 211, 238, 0.18);
+  --color-surface-highlight: rgba(59, 130, 246, 0.14);
   --color-header-background: rgba(255, 255, 255, 0.92);
 
   --color-header-shadow: rgba(15, 23, 42, 0.25);
@@ -44,8 +47,8 @@
   --color-border-strong: rgba(71, 85, 105, 0.5);
   --color-border-muted: rgba(203, 213, 225, 0.65);
   --color-code-background: #e2e8f0;
-  --color-inline-tag-background: rgba(148, 163, 184, 0.3);
-  --color-inline-tag-text: #1f2937;
+  --color-inline-tag-background: rgba(34, 211, 238, 0.18);
+  --color-inline-tag-text: #0f172a;
 
   --color-neutral-50: #eef2ff;
   --color-neutral-100: #e0e7ff;
@@ -54,74 +57,119 @@
   --color-neutral-600: #4f46e5;
   --color-neutral-soft: rgba(15, 23, 42, 0.08);
 
-  --color-accent: #3b82f6;
-  --color-accent-strong: #1d4ed8;
-  --color-accent-soft: rgba(59, 130, 246, 0.18);
-  --color-accent-softer: rgba(59, 130, 246, 0.12);
-  --color-accent-outline: rgba(59, 130, 246, 0.24);
-  --color-accent-border: rgba(59, 130, 246, 0.35);
-  --color-accent-shadow: rgba(15, 23, 42, 0.24);
-  --color-accent-shadow-strong: rgba(59, 130, 246, 0.38);
-  --color-accent-contrast: #f8fafc;
+  --color-primary: #3b82f6;
+  --color-primary-strong: #1d4ed8;
+  --color-primary-soft: rgba(59, 130, 246, 0.18);
+  --color-primary-softer: rgba(59, 130, 246, 0.12);
+  --color-primary-outline: rgba(59, 130, 246, 0.24);
+  --color-primary-border: rgba(59, 130, 246, 0.35);
+  --color-primary-shadow: rgba(15, 23, 42, 0.24);
+  --color-primary-shadow-strong: rgba(59, 130, 246, 0.38);
+  --color-primary-contrast: #f8fafc;
 
-  --color-accent-secondary: #22d3ee;
-  --color-accent-secondary-strong: #0ea5e9;
-  --color-accent-secondary-soft: rgba(34, 211, 238, 0.2);
-  --color-accent-secondary-outline: rgba(34, 211, 238, 0.3);
-  --color-accent-secondary-contrast: #083344;
-  --color-accent-secondary-shadow: rgba(8, 145, 178, 0.28);
+  --color-accent-1: #22d3ee;
+  --color-accent-1-strong: #0ea5e9;
+  --color-accent-1-soft: rgba(34, 211, 238, 0.2);
+  --color-accent-1-softer: rgba(34, 211, 238, 0.12);
+  --color-accent-1-outline: rgba(34, 211, 238, 0.3);
+  --color-accent-1-border: rgba(34, 211, 238, 0.4);
+  --color-accent-1-shadow: rgba(8, 145, 178, 0.28);
+  --color-accent-1-contrast: #083344;
 
-  --gradient-accent: linear-gradient(135deg, var(--color-accent), var(--color-accent-strong));
+  --color-accent-2: #f97316;
+  --color-accent-2-strong: #ea580c;
+  --color-accent-2-soft: rgba(249, 115, 22, 0.2);
+  --color-accent-2-softer: rgba(249, 115, 22, 0.12);
+  --color-accent-2-outline: rgba(249, 115, 22, 0.3);
+  --color-accent-2-border: rgba(249, 115, 22, 0.4);
+  --color-accent-2-shadow: rgba(155, 65, 8, 0.35);
+  --color-accent-2-contrast: #fff7ed;
+
+  --color-accent: var(--color-primary);
+  --color-accent-strong: var(--color-primary-strong);
+  --color-accent-soft: var(--color-primary-soft);
+  --color-accent-softer: var(--color-primary-softer);
+  --color-accent-outline: var(--color-primary-outline);
+  --color-accent-border: var(--color-primary-border);
+  --color-accent-shadow: var(--color-primary-shadow);
+  --color-accent-shadow-strong: var(--color-primary-shadow-strong);
+  --color-accent-contrast: var(--color-primary-contrast);
+
+  --color-accent-secondary: var(--color-accent-1);
+  --color-accent-secondary-strong: var(--color-accent-1-strong);
+  --color-accent-secondary-soft: var(--color-accent-1-soft);
+  --color-accent-secondary-outline: var(--color-accent-1-outline);
+  --color-accent-secondary-contrast: var(--color-accent-1-contrast);
+  --color-accent-secondary-shadow: var(--color-accent-1-shadow);
+
+  --color-accent-tertiary: var(--color-accent-2);
+  --color-accent-tertiary-strong: var(--color-accent-2-strong);
+  --color-accent-tertiary-soft: var(--color-accent-2-soft);
+  --color-accent-tertiary-outline: var(--color-accent-2-outline);
+  --color-accent-tertiary-contrast: var(--color-accent-2-contrast);
+  --color-accent-tertiary-shadow: var(--color-accent-2-shadow);
+
+  --gradient-primary: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+  --gradient-accent: var(--gradient-primary);
   --gradient-accent-secondary: linear-gradient(
     135deg,
     var(--color-accent-secondary),
     var(--color-accent-secondary-strong)
   );
+  --gradient-accent-tertiary: linear-gradient(
+    135deg,
+    var(--color-accent-tertiary),
+    var(--color-accent-tertiary-strong)
+  );
 
-  --color-burnished-copper: var(--color-accent);
-  --color-burnished-copper-soft: var(--color-accent-strong);
+  --color-burnished-copper: var(--color-primary);
+  --color-burnished-copper-soft: var(--color-primary-strong);
   --gradient-burnished-copper: linear-gradient(
     140deg,
-    var(--color-accent-strong),
-    var(--color-accent)
+    var(--color-primary-strong),
+    var(--color-primary)
   );
   --color-burnished-copper-border: rgba(59, 130, 246, 0.25);
   --color-burnished-copper-shadow: rgba(15, 23, 42, 0.35);
 
-  --meal-plan-type-meal: var(--color-accent);
+  --meal-plan-type-meal: var(--color-primary);
   --meal-plan-type-drink: var(--color-accent-secondary);
-  --meal-plan-type-snack: #10b981;
+  --meal-plan-type-snack: var(--color-accent-tertiary);
   --meal-plan-type-text: var(--color-text-inverse);
   --meal-plan-border: rgba(59, 130, 246, 0.2);
   --meal-plan-surface: #ffffff;
 
   --view-toggle-inactive-gradient: linear-gradient(
     135deg,
-    rgba(59, 130, 246, 0.65),
-    rgba(22, 163, 74, 0.65)
+    rgba(34, 211, 238, 0.55),
+    rgba(249, 115, 22, 0.55)
   );
-  --view-toggle-inactive-border: rgba(59, 130, 246, 0.5);
-  --view-toggle-inactive-text: #f0f9ff;
-  --view-toggle-hover-glow: 0 0 16px rgba(34, 211, 238, 0.35);
+  --view-toggle-inactive-border: rgba(34, 211, 238, 0.45);
+  --view-toggle-inactive-text: #0b1120;
+  --view-toggle-hover-glow: 0 0 16px rgba(183, 109, 130, 0.35);
   --view-toggle-active-gradient: linear-gradient(
     135deg,
-    var(--color-accent),
-    var(--color-accent-secondary)
+    var(--color-accent-secondary),
+    var(--color-accent-tertiary)
   );
-  --view-toggle-active-text: var(--color-text-inverse);
+  --view-toggle-active-text: var(--color-accent-secondary-contrast);
 
   --surface-elevated-gradient: linear-gradient(
     158deg,
-    rgba(34, 211, 238, 0.16),
+    rgba(59, 130, 246, 0.16),
     var(--color-surface-elevated)
   );
   --surface-panel-gradient: var(--surface-elevated-gradient);
   --surface-section-gradient: linear-gradient(
     155deg,
     rgba(59, 130, 246, 0.12),
-    var(--color-surface-soft)
+    rgba(59, 130, 246, 0.05)
   );
-  --surface-card-gradient: var(--surface-elevated-gradient);
+  --surface-card-gradient: linear-gradient(
+    160deg,
+    rgba(59, 130, 246, 0.16),
+    rgba(59, 130, 246, 0.04)
+  );
 
   --color-danger: #ef4444;
   --color-danger-soft: rgba(239, 68, 68, 0.16);
@@ -312,20 +360,24 @@ select {
   color: var(--view-toggle-active-text, var(--color-accent-contrast));
 }
 
+
 .nav-chip .family-button {
   font-weight: 600;
+  color: var(--color-accent-tertiary-strong, var(--color-accent-secondary));
 }
 
 .family-button {
   border: none;
   background: transparent;
-  color: inherit;
+  color: var(--color-accent-tertiary, currentColor);
   cursor: pointer;
+  transition: color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .family-button:hover,
 .family-button:focus-visible {
   outline: none;
+  color: var(--color-accent-tertiary-strong, var(--color-accent-tertiary));
 }
 
 @media (max-width: 62.5rem) {
@@ -345,8 +397,7 @@ select {
 }
 
 .family-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--color-focus-ring);
+  box-shadow: 0 0 0 3px var(--color-accent-tertiary-outline, var(--color-focus-ring));
 }
 
 .menu-column .view-toggle {
@@ -741,24 +792,20 @@ select {
   flex-direction: column;
   gap: 1.4rem;
   padding: 1.5rem;
-  background: var(--view-toggle-inactive-gradient);
-  border-color: rgba(244, 247, 229, 0.35);
+  background: var(--surface-panel-gradient);
+  border-color: var(--color-accent-outline, var(--color-border-muted));
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  color: var(--view-toggle-inactive-text, #f4f7e5);
-  --color-text-emphasis: var(--view-toggle-inactive-text, #f4f7e5);
-  --color-text-tertiary: rgba(244, 247, 229, 0.78);
-  --color-text-muted: rgba(244, 247, 229, 0.75);
-  --color-text-soft: rgba(244, 247, 229, 0.65);
-  --color-text-badge: rgba(244, 247, 229, 0.92);
-  --color-inline-tag-text: rgba(244, 247, 229, 0.9);
-  --color-accent-outline: rgba(244, 247, 229, 0.28);
-  --color-border-muted: rgba(244, 247, 229, 0.22);
-  --color-accent-border: rgba(244, 247, 229, 0.42);
-  --surface-section-gradient: var(--color-background);
-  --filter-section-background: var(--color-background);
-  --filter-section-border: var(--color-accent-border, rgba(244, 247, 229, 0.45));
-  --filter-section-shadow: rgba(20, 33, 61, 0.24);
+  color: var(--color-text-emphasis);
+  --color-text-emphasis: var(--color-text-strong);
+  --color-text-tertiary: var(--color-text-tertiary);
+  --color-text-muted: var(--color-text-muted);
+  --color-text-soft: var(--color-text-soft);
+  --color-text-badge: var(--color-text-badge);
+  --color-inline-tag-text: var(--color-inline-tag-text);
+  --filter-section-background: var(--surface-section-gradient);
+  --filter-section-border: var(--color-border);
+  --filter-section-shadow: var(--color-card-shadow-soft);
 }
 
 .pantry-view,
@@ -1446,8 +1493,8 @@ textarea:focus {
 }
 
 .meal-card {
-  background: var(--view-toggle-inactive-gradient);
-  border: 1px solid rgba(244, 247, 229, 0.32);
+  background: var(--surface-section-gradient);
+  border: 1px solid var(--color-accent-outline, var(--color-border-muted));
   border-radius: 18px;
   box-shadow: 0 24px 48px -28px var(--color-card-shadow-soft);
   display: flex;
@@ -1455,17 +1502,17 @@ textarea:focus {
   gap: 1.2rem;
   padding: 1.4rem 1.6rem;
   transition: box-shadow 0.2s ease, transform 0.2s ease;
-  color: var(--view-toggle-inactive-text, #f4f7e5);
-  --color-text-emphasis: var(--view-toggle-inactive-text, #f4f7e5);
-  --color-text-muted: rgba(244, 247, 229, 0.78);
-  --color-text-soft: rgba(244, 247, 229, 0.65);
-  --color-text-badge: rgba(244, 247, 229, 0.92);
-  --color-text-instruction: rgba(244, 247, 229, 0.88);
-  --color-border-muted: rgba(244, 247, 229, 0.25);
-  --meal-section-background: var(--gradient-burnished-copper);
-  --meal-section-border: var(--color-burnished-copper-border);
-  --meal-section-shadow-color: var(--color-burnished-copper-shadow);
-  --serving-control-color: var(--color-accent-contrast, #ffffff);
+  color: var(--color-text-emphasis);
+  --color-text-emphasis: var(--color-text-strong);
+  --color-text-muted: var(--color-text-muted);
+  --color-text-soft: var(--color-text-soft);
+  --color-text-badge: var(--color-text-badge);
+  --color-text-instruction: var(--color-text-instruction);
+  --color-border-muted: var(--color-border-muted);
+  --meal-section-background: var(--surface-card-gradient);
+  --meal-section-border: var(--color-border);
+  --meal-section-shadow-color: var(--color-card-shadow-soft);
+  --serving-control-color: var(--color-primary-contrast, #ffffff);
 }
 
 .meal-card:hover {


### PR DESCRIPTION
## Summary
- add separate Accent 1 and Accent 2 controls alongside the primary theme color
- update theme token generation to derive glass surfaces from primary shades and keep accent gradients independent
- refresh styling so panels and cards inherit depth-based primary glass tones while accent interactions use the new accent variables

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e01402bc608325ac51db7f351b67ed