### PR TITLE
Rework UI color layering for primary and accent usage

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -5,9 +5,9 @@
 :root {
   color-scheme: light;
   --color-background: #f5f8ff;
-  --body-gradient-start: #f5f8ff;
-  --body-gradient-mid: #dbeafe;
-  --body-gradient-end: #bfdbfe;
+  --body-gradient-start: #f7faff;
+  --body-gradient-mid: #e3ecff;
+  --body-gradient-end: #ccd9ff;
 
   --color-text-primary: #0f172a;
   --color-text-strong: #0b1120;
@@ -109,8 +109,16 @@
   --color-accent-tertiary-contrast: var(--color-accent-2-contrast);
   --color-accent-tertiary-shadow: var(--color-accent-2-shadow);
 
-  --gradient-primary: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
-  --gradient-accent: var(--gradient-primary);
+  --gradient-primary: linear-gradient(
+    135deg,
+    rgba(59, 130, 246, 0.9),
+    rgba(29, 78, 216, 0.95)
+  );
+  --gradient-accent: linear-gradient(
+    135deg,
+    rgba(34, 211, 238, 0.92),
+    rgba(14, 165, 233, 0.95)
+  );
   --gradient-accent-secondary: linear-gradient(
     135deg,
     var(--color-accent-secondary),
@@ -141,35 +149,54 @@
 
   --view-toggle-inactive-gradient: linear-gradient(
     135deg,
-    rgba(34, 211, 238, 0.55),
-    rgba(249, 115, 22, 0.55)
+    rgba(34, 211, 238, 0.24),
+    rgba(34, 211, 238, 0.12)
   );
-  --view-toggle-inactive-border: rgba(34, 211, 238, 0.45);
+  --view-toggle-inactive-border: rgba(34, 211, 238, 0.35);
   --view-toggle-inactive-text: #0b1120;
-  --view-toggle-hover-glow: 0 0 16px rgba(183, 109, 130, 0.35);
+  --view-toggle-hover-glow: 0 0 16px rgba(34, 211, 238, 0.45);
   --view-toggle-active-gradient: linear-gradient(
     135deg,
-    var(--color-accent-secondary),
-    var(--color-accent-tertiary)
+    rgba(34, 211, 238, 0.9),
+    rgba(14, 165, 233, 0.95)
   );
   --view-toggle-active-text: var(--color-accent-secondary-contrast);
 
-  --surface-elevated-gradient: linear-gradient(
-    158deg,
-    rgba(59, 130, 246, 0.16),
-    var(--color-surface-elevated)
-  );
-  --surface-panel-gradient: var(--surface-elevated-gradient);
-  --surface-section-gradient: linear-gradient(
-    155deg,
-    rgba(59, 130, 246, 0.12),
-    rgba(59, 130, 246, 0.05)
-  );
-  --surface-card-gradient: linear-gradient(
+  --surface-glass-background: linear-gradient(
     160deg,
-    rgba(59, 130, 246, 0.16),
-    rgba(59, 130, 246, 0.04)
+    rgba(245, 248, 255, 0.88),
+    rgba(224, 231, 255, 0.72)
   );
+  --surface-glass-background-strong: linear-gradient(
+    160deg,
+    rgba(228, 235, 255, 0.92),
+    rgba(204, 216, 255, 0.78)
+  );
+  --surface-glass-primary: linear-gradient(
+    158deg,
+    rgba(59, 130, 246, 0.2),
+    rgba(59, 130, 246, 0.08)
+  );
+  --surface-glass-primary-soft: linear-gradient(
+    160deg,
+    rgba(59, 130, 246, 0.14),
+    rgba(59, 130, 246, 0.06)
+  );
+  --surface-glass-accent-1: linear-gradient(
+    160deg,
+    rgba(34, 211, 238, 0.22),
+    rgba(34, 211, 238, 0.12)
+  );
+  --surface-glass-accent-2: linear-gradient(
+    160deg,
+    rgba(249, 115, 22, 0.22),
+    rgba(249, 115, 22, 0.12)
+  );
+
+  --surface-elevated-gradient: var(--surface-glass-background-strong);
+  --surface-panel-gradient: var(--surface-glass-background);
+  --surface-section-gradient: var(--surface-glass-primary);
+  --surface-card-gradient: var(--surface-glass-primary-soft);
 
   --color-danger: #ef4444;
   --color-danger-soft: rgba(239, 68, 68, 0.16);
@@ -433,16 +460,9 @@ select {
       --view-toggle-inactive-border,
       var(--color-accent-secondary-outline, var(--color-border))
     );
-  background: var(
-    --view-toggle-inactive-gradient,
-    linear-gradient(
-      140deg,
-      var(--color-accent-softer, var(--color-accent-soft)),
-      var(--color-surface)
-    )
-  );
+  background: var(--view-toggle-inactive-gradient);
   box-shadow: 0 6px 18px -16px
-    var(--color-accent-secondary-shadow, rgba(34, 48, 12, 0.55));
+    var(--color-accent-secondary-shadow, rgba(8, 145, 178, 0.35));
   transition: transform 0.2s ease, box-shadow 0.25s ease, background 0.25s ease,
     color 0.25s ease, border-color 0.25s ease;
 }
@@ -456,7 +476,7 @@ select {
   box-shadow:
     var(--view-toggle-hover-glow, 0 0 16px rgba(233, 204, 138, 0.45)),
     0 12px 25px -18px
-      var(--color-accent-secondary-shadow, rgba(34, 48, 12, 0.55));
+      var(--color-accent-secondary-shadow, rgba(8, 145, 178, 0.35));
 }
 
 .settings-panel__summary:focus-visible {
@@ -467,9 +487,9 @@ select {
 .settings-panel[open] .settings-panel__summary {
   background: var(--view-toggle-active-gradient, var(--gradient-accent));
   color: var(--view-toggle-active-text, var(--color-accent-contrast));
-  border-color: rgba(212, 129, 69, 0.65);
+  border-color: var(--color-accent-secondary);
   box-shadow: 0 18px 32px -20px
-    var(--color-accent-shadow-strong, rgba(184, 93, 46, 0.65));
+    var(--color-accent-shadow-strong, rgba(8, 145, 178, 0.45));
 }
 
 .settings-panel__icon {
@@ -771,7 +791,7 @@ select {
   gap: 1.75rem;
   padding: 2rem 3rem 3rem 0;
   align-items: flex-start;
-  background: var(--color-layout-background);
+  background: var(--surface-glass-background);
   border-radius: 0;
 }
 
@@ -779,21 +799,16 @@ select {
   grid-template-columns: minmax(0, 1fr);
 }
 
-.filter-panel,
-.pantry-view,
-.kitchen-view {
-  border: 1px solid var(--color-accent-outline, var(--color-border-muted));
-  border-radius: 18px;
-  box-shadow: 0 24px 48px -28px var(--color-card-shadow);
-}
-
 .filter-panel {
   display: flex;
   flex-direction: column;
   gap: 1.4rem;
   padding: 1.5rem;
+  --surface-panel-gradient: var(--surface-glass-primary);
+  --filter-section-background: var(--surface-glass-background-strong);
+  --filter-section-border: var(--color-primary-border);
   background: var(--surface-panel-gradient);
-  border-color: var(--color-accent-outline, var(--color-border-muted));
+  border: 1px solid var(--color-primary-border, var(--color-border-muted));
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   color: var(--color-text-emphasis);
@@ -803,14 +818,26 @@ select {
   --color-text-soft: var(--color-text-soft);
   --color-text-badge: var(--color-text-badge);
   --color-inline-tag-text: var(--color-inline-tag-text);
-  --filter-section-background: var(--surface-section-gradient);
-  --filter-section-border: var(--color-border);
   --filter-section-shadow: var(--color-card-shadow-soft);
 }
 
+.filter-panel,
 .pantry-view,
 .kitchen-view {
+  border-radius: 18px;
+  box-shadow: 0 24px 48px -28px var(--color-card-shadow);
+}
+
+.pantry-view {
+  --surface-panel-gradient: var(--surface-glass-background-strong);
   background: var(--surface-panel-gradient);
+  border: 1px solid var(--color-border-muted);
+}
+
+.kitchen-view {
+  --surface-panel-gradient: var(--surface-glass-background);
+  background: var(--surface-panel-gradient);
+  border: 1px solid var(--color-border-muted);
 }
 
 .panel-header {
@@ -885,9 +912,9 @@ select {
   height: 2.55rem;
   padding: 0;
   border-radius: 50%;
-  border: 1px solid rgba(42, 52, 57, 0.55);
-  background: rgba(42, 52, 57, 0.12);
-  color: var(--color-gunmetal);
+  border: 1px solid var(--color-accent-secondary-border, rgba(34, 211, 238, 0.32));
+  background: var(--color-accent-secondary-soft, rgba(34, 211, 238, 0.18));
+  color: var(--color-accent-secondary-strong, var(--color-accent-secondary));
   line-height: 1;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
@@ -898,9 +925,9 @@ select {
   transform: translateY(-1px);
   box-shadow: 0 12px 25px -18px
     var(--color-accent-secondary-shadow, var(--color-card-shadow-soft));
-  background: rgba(42, 52, 57, 0.18);
-  border-color: rgba(42, 52, 57, 0.7);
-  color: var(--color-gunmetal);
+  background: var(--surface-glass-accent-1);
+  border-color: var(--color-accent-secondary);
+  color: var(--color-accent-secondary-contrast);
 }
 
 .filter-action-button:focus-visible {
@@ -914,16 +941,16 @@ select {
 
 .pantry-only-filter:not(.pantry-only-filter--active):not([aria-pressed='true']),
 .substitution-toggle:not(.substitution-toggle--active):not([aria-pressed='true']) {
-  color: var(--color-gunmetal);
-  border-color: rgba(42, 52, 57, 0.55);
-  background: rgba(42, 52, 57, 0.12);
+  color: var(--color-accent-tertiary-strong, var(--color-accent-tertiary));
+  border-color: var(--color-accent-tertiary-outline, var(--color-accent-outline));
+  background: var(--color-accent-tertiary-soft, rgba(249, 115, 22, 0.18));
 }
 
 .pantry-only-filter:not(.pantry-only-filter--active):not([aria-pressed='true']):hover,
 .substitution-toggle:not(.substitution-toggle--active):not([aria-pressed='true']):hover {
-  color: var(--color-gunmetal);
-  border-color: rgba(42, 52, 57, 0.7);
-  background: rgba(42, 52, 57, 0.18);
+  color: var(--color-accent-tertiary-contrast);
+  border-color: var(--color-accent-tertiary);
+  background: var(--surface-glass-accent-2);
 }
 
 .pantry-only-filter__icon {
@@ -957,32 +984,32 @@ select {
 
 .pantry-only-filter.pantry-only-filter--active,
 .pantry-only-filter[aria-pressed='true'] {
-  background: var(--color-accent-secondary);
-  color: var(--color-accent-secondary-contrast);
-  border-color: var(--color-accent-secondary);
+  background: var(--color-accent-tertiary);
+  color: var(--color-accent-tertiary-contrast);
+  border-color: var(--color-accent-tertiary);
   box-shadow: 0 12px 25px -18px
-    var(--color-accent-secondary-shadow, var(--color-card-shadow-soft));
+    var(--color-accent-tertiary-shadow, var(--color-card-shadow-soft));
 }
 
 .pantry-only-filter.pantry-only-filter--active .pantry-only-filter__icon,
 .pantry-only-filter[aria-pressed='true'] .pantry-only-filter__icon {
-  color: var(--color-accent-secondary-contrast);
+  color: var(--color-accent-tertiary-contrast);
   filter: none;
   opacity: 1;
 }
 
 .substitution-toggle.substitution-toggle--active,
 .substitution-toggle[aria-pressed='true'] {
-  background: var(--color-accent-secondary);
-  color: var(--color-accent-secondary-contrast);
-  border-color: var(--color-accent-secondary);
+  background: var(--color-accent-tertiary);
+  color: var(--color-accent-tertiary-contrast);
+  border-color: var(--color-accent-tertiary);
   box-shadow: 0 12px 25px -18px
-    var(--color-accent-secondary-shadow, var(--color-card-shadow-soft));
+    var(--color-accent-tertiary-shadow, var(--color-card-shadow-soft));
 }
 
 .substitution-toggle.substitution-toggle--active .substitution-toggle__icon,
 .substitution-toggle[aria-pressed='true'] .substitution-toggle__icon {
-  color: var(--color-accent-secondary-contrast);
+  color: var(--color-accent-tertiary-contrast);
   opacity: 1;
 }
 
@@ -1636,7 +1663,7 @@ textarea:focus {
   margin: 0.35rem 0 0.75rem;
   padding: 0.6rem 0.75rem;
   border-radius: 12px;
-  background: var(--color-accent-softer, rgba(217, 75, 165, 0.12));
+  background: var(--color-accent-softer, rgba(59, 130, 246, 0.12));
   color: var(--color-text-strong);
   display: flex;
   flex-direction: column;
@@ -1681,11 +1708,7 @@ textarea:focus {
   align-items: center;
   padding: 0.2rem 0.65rem;
   border-radius: 999px;
-  background: linear-gradient(
-    135deg,
-    var(--color-accent-secondary-soft, var(--color-accent-soft)),
-    var(--color-accent-soft)
-  );
+  background: var(--gradient-accent-secondary);
   color: var(--color-accent-secondary-contrast, var(--color-text-badge));
   border: 1px solid var(--color-accent-secondary-outline, transparent);
   box-shadow: 0 8px 18px -14px
@@ -1899,9 +1922,10 @@ textarea:focus {
   padding: 1.5rem;
   max-height: calc(100vh - 6rem);
   overflow: hidden;
+  --surface-panel-gradient: var(--surface-glass-primary-soft);
   background: var(--surface-panel-gradient);
   border-radius: 18px;
-  border: 1px solid var(--color-accent-outline, var(--color-border-muted));
+  border: 1px solid var(--color-primary-border, var(--color-border-muted));
   box-shadow: 0 24px 48px -28px var(--color-card-shadow);
   --meal-plan-view-height: auto;
   --meal-plan-layout-height: auto;
@@ -2415,11 +2439,12 @@ textarea:focus {
 .schedule-dialog__button--primary {
   background: var(--gradient-accent);
   color: var(--color-accent-contrast, #fff);
-  border-color: rgba(212, 129, 69, 0.65);
+  border-color: var(--color-accent-secondary);
 }
 
 .schedule-dialog__button--primary:hover {
-  box-shadow: 0 18px 36px -24px var(--color-accent-shadow, rgba(0, 0, 0, 0.2));
+  box-shadow: 0 18px 36px -24px
+    var(--color-accent-secondary-shadow, rgba(8, 145, 178, 0.45));
 }
 
 .schedule-dialog__button:focus-visible {
@@ -2464,8 +2489,12 @@ textarea:focus {
   justify-content: space-between;
   gap: 1rem;
   padding: 1.2rem 1.5rem;
-  background: linear-gradient(135deg, rgba(68, 83, 214, 0.15), rgba(245, 158, 11, 0.12));
-  border-bottom: 1px solid rgba(68, 83, 214, 0.12);
+  background: linear-gradient(
+    135deg,
+    rgba(59, 130, 246, 0.18),
+    rgba(29, 78, 216, 0.12)
+  );
+  border-bottom: 1px solid rgba(59, 130, 246, 0.18);
 }
 
 .family-panel__title {
@@ -3446,7 +3475,8 @@ textarea:focus {
 
 .pantry-card--favorite {
   border-color: var(--color-accent-border);
-  box-shadow: 0 18px 36px -26px var(--color-accent-shadow, rgba(217, 75, 165, 0.3));
+  box-shadow: 0 18px 36px -26px
+    var(--color-accent-shadow, rgba(34, 211, 238, 0.35));
 }
 
 .pantry-card__inline-input {
@@ -3596,14 +3626,7 @@ textarea:focus {
     );
   border-radius: 999px;
   padding: 0.45rem 1.15rem;
-  background: var(
-    --view-toggle-inactive-gradient,
-    linear-gradient(
-      140deg,
-      var(--color-accent-softer, var(--color-accent-soft)),
-      var(--color-surface)
-    )
-  );
+  background: var(--view-toggle-inactive-gradient);
   color: var(
     --view-toggle-inactive-text,
     var(--color-accent-secondary, var(--color-accent))
@@ -3622,9 +3645,9 @@ textarea:focus {
 .view-toggle__button:hover {
   transform: translateY(-1px);
   box-shadow:
-    var(--view-toggle-hover-glow, 0 0 16px rgba(233, 204, 138, 0.45)),
+    var(--view-toggle-hover-glow, 0 0 16px rgba(34, 211, 238, 0.45)),
     0 12px 25px -18px
-      var(--color-accent-secondary-shadow, rgba(34, 48, 12, 0.55));
+      var(--color-accent-secondary-shadow, rgba(8, 145, 178, 0.35));
 }
 
 .view-toggle__button--active {
@@ -3687,6 +3710,37 @@ textarea:focus {
 
   --meal-plan-border: rgba(96, 165, 250, 0.3);
   --meal-plan-surface: rgba(17, 24, 39, 0.92);
+
+  --surface-glass-background: linear-gradient(
+    160deg,
+    rgba(15, 23, 42, 0.92),
+    rgba(15, 23, 42, 0.78)
+  );
+  --surface-glass-background-strong: linear-gradient(
+    160deg,
+    rgba(11, 17, 32, 0.94),
+    rgba(11, 17, 32, 0.82)
+  );
+  --surface-glass-primary: linear-gradient(
+    158deg,
+    rgba(59, 130, 246, 0.2),
+    rgba(59, 130, 246, 0.12)
+  );
+  --surface-glass-primary-soft: linear-gradient(
+    160deg,
+    rgba(59, 130, 246, 0.16),
+    rgba(59, 130, 246, 0.1)
+  );
+  --surface-glass-accent-1: linear-gradient(
+    160deg,
+    rgba(34, 211, 238, 0.24),
+    rgba(34, 211, 238, 0.14)
+  );
+  --surface-glass-accent-2: linear-gradient(
+    160deg,
+    rgba(249, 115, 22, 0.28),
+    rgba(249, 115, 22, 0.16)
+  );
 }
 
 .holiday-theme-dialog {


### PR DESCRIPTION
## Summary
- introduce glass-style gradient tokens so layout, filter, pantry, kitchen, and meal plan panels sit on distinct background shades
- align navigation and filter controls with primary/secondary accent colors and remove multi-hue gradients from buttons and badges
- refresh dialog and family header treatments to rely on single-color gradients and updated accent shadows

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0302ebbdc8325821e051044ee8d35