### PR TITLE
Implement family view page and update kitchen list UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,12 @@
           <button type="button" class="view-toggle__button" data-view-target="meal-plan">
             Meal Plan
           </button>
-          <button type="button" class="view-toggle__button family-button" id="family-button">
+          <button
+            type="button"
+            class="view-toggle__button"
+            data-view-target="family"
+            id="family-button"
+          >
             Family
           </button>
         </div>
@@ -339,14 +344,18 @@
           <header class="pantry-view__header">
             <div>
               <h2>Kitchen</h2>
-              <p>Keep track of cookware, appliances, and tools available in your kitchen.</p>
+              <p>Mark the equipment you have on hand to plan recipes with confidence.</p>
             </div>
-            <div class="pantry-view__summary">
+            <div class="pantry-view__summary kitchen-view__summary">
               <span id="kitchen-count">0</span>
-              <p>items ready for cooking</p>
+              <p>items in your kitchen</p>
             </div>
           </header>
-          <div class="pantry-grid kitchen-grid" id="kitchen-grid"></div>
+          <p class="kitchen-view__intro">
+            Check off the cookware, appliances, and tools you own. We'll remember your selections for
+            next time.
+          </p>
+          <ul class="kitchen-list" id="kitchen-list"></ul>
         </section>
         <section class="pantry-view" id="pantry-view" hidden>
           <header class="pantry-view__header">
@@ -428,6 +437,26 @@
             </aside>
           </div>
         </section>
+        <section class="family-view" id="family-view" hidden aria-labelledby="family-view-title">
+          <header class="family-view__header">
+            <div class="family-view__header-text">
+              <h2 class="family-panel__title" id="family-view-title">Family</h2>
+              <p class="family-view__description">
+                Manage the people you cook for to tailor filters, substitutions, and meal plans.
+              </p>
+            </div>
+            <button type="button" class="family-panel__add family-view__add" id="family-add-member">
+              Add family member
+            </button>
+          </header>
+          <div class="family-view__body">
+            <p class="family-panel__intro">
+              Add the people you cook for regularly, including allergies, diets, targets, and icons for quick
+              planning.
+            </p>
+            <div class="family-panel__list" id="family-member-list"></div>
+          </div>
+        </section>
       </main>
       <datalist id="pantry-unit-options">
         <option value="each"></option>
@@ -453,30 +482,6 @@
     <script src="data/recipes.js" defer></script>
     <script src="scripts/ingredient-matching.js" defer></script>
     <script src="scripts/app.js" defer></script>
-    <div class="family-panel" id="family-panel" hidden>
-      <div class="family-panel__backdrop" id="family-panel-backdrop" aria-hidden="true"></div>
-      <section
-        class="family-panel__content"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="family-panel-title"
-      >
-        <header class="family-panel__header">
-          <h2 class="family-panel__title" id="family-panel-title">Family</h2>
-          <button type="button" class="family-panel__close" id="family-panel-close" aria-label="Close family panel">
-            Close
-          </button>
-        </header>
-        <div class="family-panel__body">
-          <p class="family-panel__intro">
-            Add the people you cook for regularly, including allergies, diets, targets, and icons for
-            quick planning.
-          </p>
-          <div class="family-panel__list" id="family-member-list"></div>
-          <button type="button" class="family-panel__add" id="family-add-member">Add family member</button>
-        </div>
-      </section>
-    </div>
     <div class="meal-plan-day-modal" id="meal-plan-day-modal" hidden>
       <div class="meal-plan-day-modal__backdrop" id="meal-plan-day-modal-backdrop" aria-hidden="true"></div>
       <section

--- a/styles/app.css
+++ b/styles/app.css
@@ -251,7 +251,7 @@ select {
   height: 1px;
   padding: 0;
   margin: -1px;
-  overflow: hidden;
+  overflow: visible;
   clip: rect(0 0 0 0);
   white-space: nowrap;
   border: 0;
@@ -276,7 +276,7 @@ select {
   box-shadow: 0 20px 42px -28px var(--color-card-shadow-soft);
   border: 1px solid rgba(255, 255, 255, 0.65);
   padding: 0.25rem 0.45rem;
-  overflow: hidden;
+  overflow: visible;
   backdrop-filter: blur(14px);
   z-index: 20;
 }
@@ -383,26 +383,6 @@ select {
   color: var(--view-toggle-active-text, var(--color-accent-contrast));
 }
 
-
-.nav-chip .family-button {
-  font-weight: 600;
-  color: var(--color-accent-tertiary-strong, var(--color-accent-secondary));
-}
-
-.family-button {
-  border: none;
-  background: transparent;
-  color: var(--color-accent-tertiary, currentColor);
-  cursor: pointer;
-  transition: color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.family-button:hover,
-.family-button:focus-visible {
-  outline: none;
-  color: var(--color-accent-tertiary-strong, var(--color-accent-tertiary));
-}
-
 @media (max-width: 62.5rem) {
   .nav-chip {
     display: none;
@@ -435,10 +415,6 @@ select {
   .nav-chip__toggle {
     display: none;
   }
-}
-
-.family-button:focus-visible {
-  box-shadow: 0 0 0 3px var(--color-accent-tertiary-outline, var(--color-focus-ring));
 }
 
 .menu-column .view-toggle {
@@ -1936,6 +1912,16 @@ textarea:focus {
   color: var(--color-accent);
 }
 
+.kitchen-view__summary p {
+  margin: 0;
+}
+
+.kitchen-view__intro {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
 .pantry-grid {
   flex: 1;
   overflow-y: auto;
@@ -1943,6 +1929,67 @@ textarea:focus {
   display: flex;
   flex-direction: column;
   gap: 2rem;
+}
+
+.kitchen-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.kitchen-list__item {
+  list-style: none;
+}
+
+.kitchen-list__item + .kitchen-list__item {
+  border-top: 1px solid var(--color-border-muted, rgba(42, 52, 57, 0.14));
+}
+
+.kitchen-list__label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.9rem 0;
+  cursor: pointer;
+}
+
+.kitchen-list__label:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
+}
+
+.kitchen-list__checkbox {
+  width: 1.15rem;
+  height: 1.15rem;
+  accent-color: var(--color-accent, var(--color-primary));
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+}
+
+.kitchen-list__name {
+  flex: 1 1 auto;
+  font-weight: 500;
+  color: var(--color-text-strong);
+}
+
+.kitchen-list__usage {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.kitchen-list__label[data-owned='true'] .kitchen-list__name {
+  font-weight: 600;
+  color: var(--color-accent, var(--color-primary));
+}
+
+.kitchen-list__label[data-owned='true'] .kitchen-list__usage {
+  color: var(--color-text-muted);
 }
 
 .pantry-category {
@@ -2489,48 +2536,34 @@ textarea:focus {
 }
 
 
-.family-panel {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem;
-  z-index: 40;
-}
-
-.family-panel__backdrop {
-  position: absolute;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.35);
-  backdrop-filter: blur(6px);
-}
-
-.family-panel__content {
-  position: relative;
-  width: min(720px, 92vw);
-  max-height: 90vh;
+.family-view {
   display: flex;
   flex-direction: column;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.98);
-  border: 1px solid rgba(68, 83, 214, 0.18);
-  box-shadow: 0 30px 70px -40px rgba(15, 23, 42, 0.5);
+  gap: 1.5rem;
+  padding: 1.75rem 2rem 2.25rem;
+  background: var(--surface-panel-gradient);
+  border: 1px solid var(--color-border-muted);
+  border-radius: 18px;
+  box-shadow: 0 24px 48px -28px var(--color-card-shadow);
+  color: var(--color-text-emphasis);
+  flex: 1;
+  max-height: calc(100vh - 6rem);
   overflow: hidden;
 }
 
-.family-panel__header {
+.family-view__header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 1.2rem 1.5rem;
-  background: linear-gradient(
-    135deg,
-    rgba(59, 130, 246, 0.18),
-    rgba(29, 78, 216, 0.12)
-  );
-  border-bottom: 1px solid rgba(59, 130, 246, 0.18);
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.family-view__header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-width: min(100%, 520px);
 }
 
 .family-panel__title {
@@ -2540,33 +2573,18 @@ textarea:focus {
   color: var(--color-text-emphasis);
 }
 
-.family-panel__close {
-  border: none;
-  background: rgba(255, 255, 255, 0.85);
-  border-radius: 999px;
-  padding: 0.4rem 0.9rem;
-  font-weight: 600;
+.family-view__description {
+  margin: 0;
+  font-size: 0.95rem;
   color: var(--color-text-secondary);
-  cursor: pointer;
-  transition: background 0.2s ease, box-shadow 0.2s ease;
 }
 
-.family-panel__close:hover {
-  background: rgba(255, 255, 255, 1);
-  box-shadow: 0 10px 25px -20px var(--color-card-shadow);
-}
-
-.family-panel__close:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--color-focus-ring);
-}
-
-.family-panel__body {
-  padding: 1.25rem 1.5rem 1.5rem;
-  overflow-y: auto;
+.family-view__body {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.5rem;
+  flex: 1;
+  overflow: hidden;
 }
 
 .family-panel__intro {
@@ -2579,6 +2597,8 @@ textarea:focus {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
 }
 
 .family-panel__empty {
@@ -2588,7 +2608,6 @@ textarea:focus {
 }
 
 .family-panel__add {
-  align-self: flex-start;
   padding: 0.6rem 1.1rem;
   border-radius: 999px;
   border: 1px solid var(--view-toggle-inactive-border, rgba(125, 147, 65, 0.45));
@@ -2596,7 +2615,15 @@ textarea:focus {
   color: var(--color-text-emphasis);
   font-weight: 600;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.family-view__add {
+  align-self: flex-start;
+  white-space: nowrap;
 }
 
 .family-panel__add:hover {
@@ -3405,17 +3432,6 @@ textarea:focus {
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.kitchen-card {
-  gap: 0.5rem;
-  padding: 1rem 1.1rem;
-}
-
-.kitchen-card__usage {
-  margin: 0;
-  color: var(--color-text-muted);
-  font-size: 0.9rem;
-}
-
 .pantry-card:focus-within {
   border-color: var(--color-accent-border);
   box-shadow: 0 12px 28px -20px var(--color-card-shadow-soft);
@@ -3569,7 +3585,8 @@ textarea:focus {
 
   .pantry-view,
   .kitchen-view,
-  .meal-plan-view {
+  .meal-plan-view,
+  .family-view {
     position: sticky;
     top: 5.5rem;
   }


### PR DESCRIPTION
## Summary
- convert the family management overlay into a dedicated view that matches the other navigation targets
- rework the kitchen screen into a checkbox list that records owned equipment and persists selections
- allow the settings toggle to display its dropdown by letting the nav chip surface overflow content

## Testing
- python3 -m http.server 4173

------
https://chatgpt.com/codex/tasks/task_e_68e039fdbe488325a0f9e90d7ce1cf74