### PR TITLE
feat: refresh recipes page styling

### DIFF
--- a/scripts/theme-utils.js
+++ b/scripts/theme-utils.js
@@ -1,20 +1,19 @@
 (function () {
-  const isDev =
-    (typeof process !== 'undefined' && process?.env?.NODE_ENV !== 'production') ||
-    (typeof process === 'undefined' && typeof document !== 'undefined');
+  if (typeof document === 'undefined') {
+    return;
+  }
 
-  if (!isDev) return;
+  if (typeof process !== 'undefined' && process?.env?.NODE_ENV === 'production') {
+    return;
+  }
 
-  const checkAdjacency = (sel) => {
+  const targets = ['.recipe-card', '.filter-category', '.panel', '.meal-card'];
+  targets.forEach((sel) => {
     document.querySelectorAll(sel).forEach((el) => {
       const cs = getComputedStyle(el);
-      const bg = cs.backgroundColor;
-      const border = cs.borderTopColor;
-      if (bg === border) {
+      if (cs.backgroundColor === cs.borderTopColor) {
         console.warn('[Theme] Same-color adjacency:', el);
       }
     });
-  };
-
-  checkAdjacency('.card, .recipe-card, .panel, .filter-category, .meal-card, .filter-section');
+  });
 })();

--- a/styles/app.css
+++ b/styles/app.css
@@ -332,14 +332,14 @@ a:hover {
 
 html,
 body {
-  background: var(--bg);
+  background: var(--layer-0);
   color: var(--text);
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--bg);
+  background: var(--layer-0);
   color: var(--text);
 }
 
@@ -371,6 +371,12 @@ select {
   flex-direction: column;
   color: var(--text);
   padding-top: 5rem;
+  background: var(--layer-0);
+}
+
+#app-layout {
+  background: var(--layer-0);
+  color: var(--text);
 }
 
 .nav-chip {
@@ -380,14 +386,15 @@ select {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  background: var(--surface-0);
+  background: var(--layer-1);
   border-radius: 999px;
   box-shadow: var(--shadow-1);
-  border: 1px solid var(--border-1);
+  border: 1px solid var(--border-strong);
   padding: 0.25rem 0.45rem;
   overflow: visible;
   backdrop-filter: blur(14px);
   z-index: 20;
+  color: var(--text);
 }
 
 .nav-chip__group {
@@ -397,8 +404,13 @@ select {
 }
 
 .nav-chip__group.view-toggle {
-  gap: 0;
+  gap: 0.5rem;
   flex-wrap: nowrap;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  background: var(--layer-1);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
 }
 
 .nav-chip__settings {
@@ -448,53 +460,39 @@ select {
 }
 
 .nav-chip .view-toggle__button {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   min-width: 0;
-  border: 1px solid var(--border-1);
+  appearance: none;
+  padding: 0.35rem 0.9rem;
   border-radius: 999px;
-  padding: 0.45rem 0.95rem;
-  background: transparent;
+  border: 1px solid var(--border-strong);
+  background: var(--layer-1);
   color: var(--text);
   box-shadow: none;
   font-weight: 600;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  line-height: 1;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
-.nav-chip .view-toggle__button + .view-toggle__button {
-  position: relative;
+.nav-chip .view-toggle__button:hover {
+  background: var(--layer-3);
 }
 
-.nav-chip .view-toggle__button + .view-toggle__button::before {
-  content: '';
-  position: absolute;
-  top: 22%;
-  bottom: 22%;
-  left: -0.55rem;
-  width: 1px;
-  background: var(--border-1);
-}
-
-.nav-chip .view-toggle__button:hover,
 .nav-chip .view-toggle__button:focus-visible {
-  transform: none;
-  box-shadow: none;
-  outline: none;
-  background: var(--surface-2);
-  border-color: var(--border-1);
+  outline: 2px solid var(--border-strong);
+  outline-offset: 2px;
 }
 
 .nav-chip .view-toggle__button--active {
-  background: var(--surface-1);
+  background: var(--brand);
   color: var(--text);
-  border-color: var(--border-1);
-  box-shadow: none;
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--brand), white 20%) inset;
 }
 
-.nav-chip .view-toggle__button--active:hover,
-.nav-chip .view-toggle__button--active:focus-visible {
-  background: var(--surface-1);
-  color: var(--text);
-  border-color: var(--border-1);
+.nav-chip .view-toggle__button--active:hover {
+  background: var(--brand);
 }
 
 @media (max-width: 62.5rem) {
@@ -896,10 +894,9 @@ select {
   flex-direction: column;
   gap: 1.4rem;
   padding: 1.5rem;
-  background: var(--surface-0);
-  border: 1px solid var(--border-1);
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
+  background: var(--layer-1);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
   color: var(--text);
   --color-text-emphasis: var(--text);
   --color-text-tertiary: var(--text-muted);
@@ -938,11 +935,15 @@ select {
 }
 
 .panel-header__actions {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: flex-start;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.5rem;
+  background: var(--layer-1);
+  border: 1px solid var(--border-strong);
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
 }
 
 .panel-header--actions-only {
@@ -984,7 +985,7 @@ select {
 .favorite-filter[aria-pressed='true'] {
   background: var(--brand);
   color: var(--text);
-  border-color: var(--border-1);
+  border-color: var(--border-strong);
   box-shadow: var(--shadow-1);
 }
 
@@ -995,33 +996,53 @@ select {
 }
 
 .filter-action-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.55rem;
-  height: 2.55rem;
+  display: inline-grid;
+  place-items: center;
+  inline-size: 36px;
+  block-size: 36px;
   padding: 0;
   border-radius: 50%;
-  border: 2px solid var(--border-1);
-  background: var(--surface-0);
+  border: 1px solid var(--border-strong);
+  background: var(--layer-1);
   color: var(--text);
   line-height: 1;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
-    color 0.2s ease, border-color 0.2s ease;
+  box-shadow: var(--shadow-1);
+  position: relative;
+  transition: transform 0.08s ease, background 0.15s ease, color 0.15s ease,
+    border-color 0.15s ease;
 }
 
 .filter-action-button:hover {
+  background: var(--layer-3);
   transform: translateY(-1px);
-  box-shadow: var(--shadow-1);
-  background: var(--surface-2);
-  border-color: var(--border-1);
-  color: var(--text);
+}
+
+.filter-action-button:active {
+  transform: translateY(0);
 }
 
 .filter-action-button:focus-visible {
-  outline: none;
-  box-shadow: none;
+  outline: 2px solid var(--border-strong);
+  outline-offset: 2px;
+}
+
+.filter-action-button .badge,
+.meal-card__schedule-button .badge,
+.meal-card__favorite-button .badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--accent-1);
+  color: var(--chip-fg);
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  font-weight: 700;
+  border: 1px solid var(--border-soft);
 }
 
 .pantry-only-filter {
@@ -1184,9 +1205,15 @@ select {
   border: 1px solid var(--border-1);
   border-radius: calc(var(--radius) - 6px);
   padding: 0.6rem 0.75rem;
-  background: var(--surface-0);
+  background: var(--layer-1);
   color: var(--text);
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+#filter-search {
+  background: var(--layer-3);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
 }
 
 .input-group input:focus,
@@ -1228,9 +1255,10 @@ textarea:focus {
   color: var(--chip-fg);
   text-transform: none;
   background: var(--accent-1);
-  border: 1px solid var(--border-soft);
-  border-radius: calc(var(--radius) - 4px);
-  padding: 0.6rem 0.75rem;
+  border: 0;
+  border-bottom: 1px solid var(--border-soft);
+  border-radius: calc(var(--radius) - 6px) calc(var(--radius) - 6px) 0 0;
+  padding: 0.6rem 0.85rem;
 }
 
 .filter-section summary::-webkit-details-marker {
@@ -1258,17 +1286,18 @@ textarea:focus {
 .filter-section summary:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px var(--color-focus-ring);
-  border-radius: calc(var(--radius) - 4px);
+  border-radius: calc(var(--radius) - 6px);
 }
 
 .filter-section__content {
-  margin-top: 0.85rem;
+  margin-top: 0.75rem;
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
   background: var(--layer-3);
-  border: 1px solid var(--border-soft);
-  border-radius: calc(var(--radius) - 6px);
+  border: 0;
+  border-top: 1px solid var(--border-soft);
+  border-radius: 0 0 calc(var(--radius) - 8px) calc(var(--radius) - 8px);
   padding: 0.75rem 0.85rem;
 }
 
@@ -1285,10 +1314,10 @@ textarea:focus {
 }
 
 .tag-group {
-  border: 1px solid var(--border-2);
-  border-radius: calc(var(--radius) - 6px);
+  border: 1px solid var(--border-soft);
+  border-radius: calc(var(--radius) - 8px);
   padding: 0.2rem 0.4rem 0.6rem;
-  background: var(--surface-2);
+  background: var(--layer-3);
   color: var(--text);
   --color-text-emphasis: var(--text);
   --color-text-muted: var(--text-muted);
@@ -1297,9 +1326,9 @@ textarea:focus {
 }
 
 .tag-group[open] {
-  border-color: var(--border-2);
+  border-color: var(--border-soft);
   box-shadow: var(--shadow-1);
-  background: var(--surface-2);
+  background: var(--layer-3);
 }
 
 .tag-group__summary {
@@ -1371,9 +1400,9 @@ textarea:focus {
 }
 
 .ingredient-group {
-  border: 1px solid var(--border-2);
-  border-radius: calc(var(--radius) - 6px);
-  background: var(--surface-2);
+  border: 1px solid var(--border-soft);
+  border-radius: calc(var(--radius) - 8px);
+  background: var(--layer-3);
   color: var(--text);
   --color-text-emphasis: var(--text);
   --color-text-muted: var(--text-muted);
@@ -1383,9 +1412,9 @@ textarea:focus {
 }
 
 .ingredient-group[open] {
-  border-color: var(--border-2);
+  border-color: var(--border-soft);
   box-shadow: var(--shadow-1);
-  background: var(--surface-2);
+  background: var(--layer-3);
 }
 
 .ingredient-group__summary {
@@ -1670,8 +1699,9 @@ textarea:focus {
   align-items: flex-start;
   background: var(--accent-1);
   color: var(--chip-fg);
-  border: 1px solid var(--border-soft);
-  border-radius: calc(var(--radius) - 4px) calc(var(--radius) - 4px) 0 0;
+  border: 0;
+  border-bottom: 1px solid var(--border-soft);
+  border-radius: calc(var(--radius) - 6px) calc(var(--radius) - 6px) 0 0;
   padding: 1rem 1.2rem;
   box-shadow: var(--shadow-1);
 }
@@ -1680,7 +1710,7 @@ textarea:focus {
 .meal-card__details > div {
   background: var(--meal-section-background);
   border: 1px solid var(--meal-section-border);
-  border-radius: calc(var(--radius) - 6px);
+  border-radius: calc(var(--radius) - 8px);
   padding: 1rem 1.2rem;
   box-shadow: var(--shadow-1);
   backdrop-filter: none;
@@ -1699,75 +1729,55 @@ textarea:focus {
   gap: 0.6rem;
 }
 
-.meal-card__schedule-button {
+.meal-card__schedule-button,
+.meal-card__favorite-button {
   appearance: none;
-  border: 1px solid var(--border-1);
-  border-radius: 999px;
+  display: inline-grid;
+  place-items: center;
+  inline-size: 36px;
+  block-size: 36px;
+  border-radius: 50%;
+  border: 1px solid var(--border-strong);
+  background: var(--layer-1);
+  color: var(--text);
+  cursor: pointer;
+  box-shadow: var(--shadow-1);
+  position: relative;
+  transition: transform 0.08s ease, background 0.15s ease, color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.meal-card__schedule-button {
   background: var(--brand);
   color: var(--text);
-  padding: 0.35rem 0.7rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 2rem;
-  min-height: 2rem;
-  font-size: 1rem;
-  line-height: 1;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease,
-    box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.meal-card__schedule-button:hover,
+.meal-card__favorite-button:hover {
+  background: var(--layer-3);
+  transform: translateY(-1px);
+}
+
+.meal-card__schedule-button:active,
+.meal-card__favorite-button:active {
+  transform: translateY(0);
+}
+
+.meal-card__schedule-button:focus-visible,
+.meal-card__favorite-button:focus-visible {
+  outline: 2px solid var(--border-strong);
+  outline-offset: 2px;
 }
 
 .meal-card__schedule-button:hover {
-  transform: translateY(-1px);
   background: color-mix(in oklab, var(--brand), white 12%);
-  color: var(--text);
-  border-color: var(--border-1);
-  box-shadow: var(--shadow-1);
-}
-
-.meal-card__schedule-button:focus-visible {
-  outline: none;
-  box-shadow: none;
-}
-
-.meal-card__favorite-button {
-  appearance: none;
-  border: 1px solid var(--border-1);
-  border-radius: 999px;
-  background: var(--surface-2);
-  color: var(--text);
-  padding: 0.3rem 0.85rem;
-  font-size: 1.1rem;
-  line-height: 1;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 2.2rem;
-  min-height: 2.2rem;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease,
-    border-color 0.2s ease, transform 0.2s ease;
-}
-
-.meal-card__favorite-button:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-1);
-  background: var(--brand);
-  color: var(--text);
-  border-color: var(--border-1);
-}
-
-.meal-card__favorite-button:focus-visible {
-  outline: none;
-  box-shadow: none;
 }
 
 .meal-card__favorite-button--active,
 .meal-card__favorite-button[aria-pressed='true'] {
   background: var(--brand);
   color: var(--text);
-  border-color: var(--border-1);
+  border-color: var(--border-strong);
   box-shadow: var(--shadow-2);
 }
 
@@ -1827,14 +1837,22 @@ textarea:focus {
   gap: 0.4rem;
 }
 
+.tag,
+.badge,
+.pill {
+  background: var(--chip-bg) !important;
+  color: var(--chip-fg) !important;
+  border: 0 !important;
+}
+
 .badge {
   display: inline-flex;
   align-items: center;
   padding: 0.2rem 0.65rem;
   border-radius: 999px;
-  background: var(--chip-bg);
-  color: var(--chip-fg);
-  border: 1px solid var(--border-1);
+  background: var(--chip-bg) !important;
+  color: var(--chip-fg) !important;
+  border: 0;
   box-shadow: none;
   font-size: 0.82rem;
 }
@@ -1927,6 +1945,10 @@ textarea:focus {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 0.75rem;
+}
+
+.grid-divider {
+  border-color: var(--border-soft) !important;
 }
 
 .inline-list {
@@ -4010,4 +4032,35 @@ textarea:focus {
 .holiday-theme-dialog__button:focus-visible {
   outline: 3px solid var(--border-1);
   outline-offset: 2px;
+}
+
+/* Recipes page hammer overrides */
+.recipe-card,
+.meal-card,
+.filter-category,
+.panel {
+  background: var(--layer-2) !important;
+  border: 2px solid var(--border-strong) !important;
+}
+
+.recipe-card__section,
+.meal-card__section,
+.panel .section {
+  background: var(--layer-3) !important;
+  border: 1px solid var(--border-soft) !important;
+}
+
+.recipe-card__header,
+.meal-card__header,
+.filter-category .header {
+  background: var(--accent-1) !important;
+  color: var(--chip-fg) !important;
+  border-bottom: 1px solid var(--border-soft) !important;
+}
+
+.tag,
+.badge,
+.pill {
+  background: var(--chip-bg) !important;
+  color: var(--chip-fg) !important;
 }


### PR DESCRIPTION
## Summary
- map the recipes layout shells and sidebar components to the new layer token palette
- restyle the navigation tabs and icon buttons to use capsule treatments with updated focus states
- tune recipe card sections, tags, and hammer overrides to keep layer contrasts consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e079bd91588325956d0051aeb1886b