### PR TITLE
Align panel and card backgrounds

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -386,7 +386,7 @@ select {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  background: var(--layer-1);
+  background: var(--layer-2);
   border-radius: 999px;
   box-shadow: var(--shadow-1);
   border: 1px solid var(--border-strong);
@@ -894,7 +894,7 @@ select {
   flex-direction: column;
   gap: 1.4rem;
   padding: 1.5rem;
-  background: var(--layer-1);
+  background: var(--layer-2);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
   color: var(--text);


### PR DESCRIPTION
## Summary
- match the filter panel container background with the meal card layer color for consistent visuals
- set the fixed primary navigation chip to the same layer tone so all primary surfaces align

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e085b23eb48325b5a9c9a081e6b18b