### PR TITLE
Adjust nav chip padding and glass view toggle styling

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -390,7 +390,7 @@ select {
   border-radius: 999px;
   box-shadow: var(--shadow-1);
   border: 1px solid var(--border-strong);
-  padding: 0.25rem 0.45rem;
+  padding: 7px;
   overflow: visible;
   backdrop-filter: blur(14px);
   z-index: 20;
@@ -480,20 +480,24 @@ select {
   padding: 0.6rem 0.75rem;
   border-radius: 0;
   border: none;
-  border-bottom: 2px solid transparent;
-  background: transparent;
+  background: color-mix(in srgb, var(--layer-0) 36%, transparent);
   color: var(--text);
-  box-shadow: none;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border-strong), transparent 70%);
+  backdrop-filter: blur(18px);
   font-weight: 600;
   line-height: 1.1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  transition: color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
 }
 
 .nav-chip .view-toggle__button:hover {
-  background: color-mix(in oklab, var(--brand), transparent 85%);
+  background: color-mix(in srgb, var(--layer-0) 42%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-1) 60%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--accent-1) 45%, transparent),
+    0 0 18px color-mix(in srgb, var(--accent-1) 28%, transparent);
 }
 
 .nav-chip .view-toggle__button:focus-visible {
@@ -502,13 +506,16 @@ select {
 }
 
 .nav-chip .view-toggle__button--active {
-  color: var(--brand);
-  background: color-mix(in oklab, var(--brand), transparent 90%);
-  border-bottom-color: var(--brand);
+  color: var(--text);
+  background: color-mix(in srgb, var(--layer-0) 46%, var(--accent-1) 14%);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-1) 60%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--accent-1) 45%, transparent),
+    0 0 20px color-mix(in srgb, var(--accent-1) 32%, transparent);
 }
 
 .nav-chip .view-toggle__button--active:hover {
-  background: color-mix(in oklab, var(--brand), transparent 80%);
+  background: color-mix(in srgb, var(--layer-0) 40%, var(--accent-1) 20%);
 }
 
 @media (max-width: 62.5rem) {


### PR DESCRIPTION
## Summary
- set the fixed navigation chip padding to 7px for more compact spacing
- update view toggle buttons with a translucent glass treatment and accent glow feedback on hover and active states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0a68447fc83259846dea7c7cb2905