### PR TITLE
Remove gap between view toggle buttons

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -3799,7 +3799,7 @@ textarea:focus {
 }
 .view-toggle {
   display: flex;
-  gap: 0.75rem;
+  gap: 0;
   flex-wrap: wrap;
 }
 


### PR DESCRIPTION
## Summary
- set the view toggle container gap to zero so adjacent toggle buttons no longer have padding between them

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0a9f313948325b4b9a61f033b4920