### PR TITLE
Adjust nav button colors to match background

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -491,7 +491,7 @@ select {
   border-radius: 999px;
   border: none;
   background: transparent;
-  color: var(--text);
+  color: var(--bg);
   box-shadow: inset 0 0 0 1px var(--nav-chip-button-outline);
   backdrop-filter: blur(18px);
   font-weight: 600;
@@ -516,7 +516,7 @@ select {
 
 
 .nav-chip .view-toggle__button--active {
-  color: var(--text);
+  color: var(--bg);
   background: color-mix(in srgb, var(--accent-1) 22%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-1) 60%, transparent);
 }
@@ -601,22 +601,22 @@ select {
 }
 
 .settings-panel[open] .settings-panel__summary {
-  color: var(--brand);
+  color: var(--bg);
 }
 
 .nav-chip .settings-panel__summary {
-  color: var(--nav-chip-button-bg);
+  color: var(--bg);
   background: transparent;
 }
 
 .nav-chip .settings-panel__summary:hover,
 .nav-chip .settings-panel__summary:focus-visible {
-  color: var(--nav-chip-button-hover-bg);
+  color: var(--bg);
   background: color-mix(in srgb, var(--layer-0) 16%, transparent);
 }
 
 .nav-chip .settings-panel[open] .settings-panel__summary {
-  color: var(--nav-chip-button-active-bg);
+  color: var(--bg);
 }
 
 


### PR DESCRIPTION
## Summary
- set primary navigation button labels to use the app background color
- update the settings gear trigger in the navigation to follow the same background color styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2c91f718c8325b95b50c761840454