### PR TITLE
Refine nav chip tab seams and settings gear styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,24 +59,20 @@
           </div>
         </div>
         <details class="settings-panel nav-chip__settings" id="settings-panel">
-                  <summary
-                    class="settings-panel__summary settings-btn icon-btn"
-                    aria-label="Display and unit settings"
-                    aria-haspopup="true"
-                    title="Display and unit settings"
-                  >
-                    <span class="settings-panel__icon" aria-hidden="true">
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 0 1 1.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.11v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 0 1-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.78.929l-.15.894c-.09.543-.56.94-1.11.94h-1.094c-.55 0-1.019-.397-1.11-.94l-.148-.894c-.071-.424-.384-.764-.78-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 0 1-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.11v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.107-1.204l-.527-.738a1.125 1.125 0 0 1 .12-1.45l.773-.773a1.125 1.125 0 0 1 1.45-.12l.737.527c.35.25.806.272 1.204.107.397-.165.71-.505.78-.929l.149-.894z"
-                        ></path>
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"></path>
-                      </svg>
-                    </span>
-                  </summary>
-                  <div class="settings-panel__content">
+          <summary
+            class="settings-panel__summary settings-btn"
+            aria-label="Display and unit settings"
+            aria-haspopup="true"
+            title="Display and unit settings"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M19.14 12.94a7.9 7.9 0 0 0 .05-.94 7.9 7.9 0 0 0-.05-.94l2.02-1.57a.6.6 0 0 0 .14-.77l-1.91-3.3a.6.6 0 0 0-.72-.27l-2.38.96a7.53 7.53 0 0 0-1.63-.95l-.36-2.54A.6.6 0 0 0 13.1 1h-3.2a.6.6 0 0 0-.59.52l-.36 2.54c-.58.24-1.13.55-1.63.95l-2.38-.96a.6.6 0 0 0-.72.27L2.31 8.12a.6.6 0 0 0 .14.77l2.02 1.57c-.03.31-.05.62-.05.94s.02.63.05.94L2.45 14.9a.6.6 0 0 0-.14.77l1.91 3.3c.16.28.5.4.8.27l2.38-.96c.5.4 1.05.71 1.63.95l.36 2.54c.05.29.3.53.59.53h3.2c.29 0 .54-.24.59-.53l.36-2.54c.58-.24 1.13-.55 1.63-.95l2.38.96c.3.13.64.01.8-.27l1.91-3.3a.6.6 0 0 0-.14-.77l-2.02-1.57Z"
+              />
+              <circle class="gear-hole" cx="12" cy="12" r="3.2" />
+            </svg>
+          </summary>
+          <div class="settings-panel__content">
                     <div class="theme-toolbar" id="theme-toolbar">
                       <div class="theme-toolbar__group">
                         <span class="theme-toolbar__label">Mode</span>

--- a/styles/app.css
+++ b/styles/app.css
@@ -393,7 +393,7 @@ select {
   left: 1.5rem;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0;
   padding: 0.25rem 0.5rem;
   background: var(--layer-2);
   border: 2px solid var(--border-strong);
@@ -472,8 +472,7 @@ select {
 
 
 .nav-chip .tab,
-.nav-chip .icon-btn,
-.nav-chip .settings-btn {
+.nav-chip .icon-btn {
   appearance: none;
   display: inline-flex;
   align-items: center;
@@ -500,8 +499,7 @@ select {
   cursor: pointer;
 }
 
-.nav-chip .icon-btn,
-.nav-chip .settings-btn {
+.nav-chip .icon-btn {
   inline-size: 36px;
   block-size: 36px;
   padding: 0;
@@ -509,9 +507,37 @@ select {
   place-items: center;
 }
 
+.nav-chip .tab {
+  margin: 0;
+  position: relative;
+  z-index: 1;
+  background-clip: padding-box;
+}
+
+.nav-chip .tab + .tab {
+  margin-left: -1px;
+}
+
 .nav-chip .tab:hover,
-.nav-chip .icon-btn:hover,
-.nav-chip .settings-btn:hover {
+.nav-chip .tab:focus,
+.nav-chip .tab.is-active {
+  z-index: 2;
+}
+
+.nav-chip .tab:hover::after,
+.nav-chip .tab:focus-visible::after,
+.nav-chip .tab.is-active::after {
+  content: "";
+  position: absolute;
+  inset: -1px -1px;
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklab, var(--layer-0), white 10%);
+  pointer-events: none;
+}
+
+.nav-chip .tab:hover,
+.nav-chip .icon-btn:hover {
   background: linear-gradient(
     to bottom,
     color-mix(in oklab, var(--layer-0), white 10%) 0%,
@@ -521,8 +547,7 @@ select {
 }
 
 .nav-chip .tab:active,
-.nav-chip .icon-btn:active,
-.nav-chip .settings-btn:active {
+.nav-chip .icon-btn:active {
   transform: translateY(0);
 }
 
@@ -534,27 +559,54 @@ select {
 }
 
 .nav-chip .tab:focus-visible,
-.nav-chip .icon-btn:focus-visible,
-.nav-chip .settings-btn:focus-visible {
+.nav-chip .icon-btn:focus-visible {
   outline: 2px solid var(--border-strong);
   outline-offset: 2px;
 }
 
-.nav-chip .settings-panel[open] .settings-btn {
-  outline: 2px solid var(--border-strong);
-  outline-offset: -2px;
+.nav-chip .settings-btn {
+  inline-size: 32px;
+  block-size: 32px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  border-radius: 999px;
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.35));
+}
+
+.nav-chip .settings-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--layer-2), var(--layer-0) 65%);
+}
+
+.nav-chip .settings-btn svg {
+  display: block;
+  width: 22px;
+  height: 22px;
+  fill: var(--layer-0);
+  filter: drop-shadow(0 0 0 rgba(0, 0, 0, 0));
+  transition: transform 0.15s ease;
+}
+
+.nav-chip .settings-btn:hover svg {
+  transform: rotate(12deg);
+}
+
+.nav-chip .settings-btn svg .gear-hole {
+  fill: var(--layer-2);
 }
 
 [data-theme='dark'] .nav-chip .tab,
-[data-theme='dark'] .nav-chip .icon-btn,
-[data-theme='dark'] .nav-chip .settings-btn {
+[data-theme='dark'] .nav-chip .icon-btn {
   border-color: color-mix(in oklab, var(--layer-0), white 16%);
 }
 
 @supports not (color: color-mix(in oklab, black, white)) {
   .nav-chip .tab,
-  .nav-chip .icon-btn,
-  .nav-chip .settings-btn {
+  .nav-chip .icon-btn {
     background: var(--layer-0);
     border-color: var(--border-soft);
     box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25);
@@ -635,23 +687,6 @@ select {
   outline: none;
 }
 
-
-.settings-panel__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.25rem;
-  height: 1.25rem;
-  overflow: visible;
-}
-
-.settings-panel__icon svg {
-  width: 100%;
-  height: 100%;
-  display: block;
-  transform: translate(0.25px, 0.25px);
-  transform-origin: center;
-}
 
 .settings-panel__content {
   position: absolute;


### PR DESCRIPTION
## Summary
- remove gaps between nav chip tabs and add seam-highlighting hover/active treatments
- restyle the settings gear button with the provided SVG and theme-aware focus/drop-shadow effects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d1da50288325afab0b8837105e98