### PR TITLE
Revamp recipes header chip layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,314 +8,326 @@
     <link rel="stylesheet" href="styles/app.css" />
   </head>
   <body>
-    <div class="app-shell">
-      <button
-        type="button"
-        class="nav-chip__toggle"
-        id="primary-nav-toggle"
-        aria-label="Toggle primary menu"
-        aria-expanded="false"
-        aria-controls="primary-nav"
-      >
-        <span class="nav-chip__toggle-icon" aria-hidden="true">☰</span>
-        <span class="nav-chip__toggle-label">Menu</span>
-      </button>
-      <nav class="nav-chip" id="primary-nav" aria-label="Primary">
-        <div class="nav-chip__group view-toggle">
-          <div class="nav-chip__section">
-            <button
-              type="button"
-              class="view-toggle__button tab view-toggle__button--active"
-              data-view-target="meals"
-              aria-current="page"
-            >
-              Recipes
-            </button>
-          </div>
-          <div class="nav-chip__section">
-            <button type="button" class="view-toggle__button tab" data-view-target="kitchen">
-              Kitchen
-            </button>
-          </div>
-          <div class="nav-chip__section">
-            <button type="button" class="view-toggle__button tab" data-view-target="pantry">
-              Pantry
-            </button>
-          </div>
-          <div class="nav-chip__section">
-            <button type="button" class="view-toggle__button tab" data-view-target="meal-plan">
-              Meal Plan
-            </button>
-          </div>
-          <div class="nav-chip__section">
-            <button
-              type="button"
-              class="view-toggle__button tab"
-              data-view-target="family"
-              id="family-button"
-            >
-              Family
-            </button>
-          </div>
-        </div>
-        <details class="settings-panel nav-chip__settings" id="settings-panel">
-          <summary
-            class="settings-panel__summary settings-btn"
-            aria-label="Display and unit settings"
-            aria-haspopup="true"
-            title="Display and unit settings"
+    <div class="app-shell" id="recipes-page">
+      <header class="topbar">
+        <div class="topbar__row">
+          <button
+            type="button"
+            class="nav-chip__toggle"
+            id="primary-nav-toggle"
+            aria-label="Toggle primary menu"
+            aria-expanded="false"
+            aria-controls="primary-nav"
           >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                d="M19.14 12.94a7.9 7.9 0 0 0 .05-.94 7.9 7.9 0 0 0-.05-.94l2.02-1.57a.6.6 0 0 0 .14-.77l-1.91-3.3a.6.6 0 0 0-.72-.27l-2.38.96a7.53 7.53 0 0 0-1.63-.95l-.36-2.54A.6.6 0 0 0 13.1 1h-3.2a.6.6 0 0 0-.59.52l-.36 2.54c-.58.24-1.13.55-1.63.95l-2.38-.96a.6.6 0 0 0-.72.27L2.31 8.12a.6.6 0 0 0 .14.77l2.02 1.57c-.03.31-.05.62-.05.94s.02.63.05.94L2.45 14.9a.6.6 0 0 0-.14.77l1.91 3.3c.16.28.5.4.8.27l2.38-.96c.5.4 1.05.71 1.63.95l.36 2.54c.05.29.3.53.59.53h3.2c.29 0 .54-.24.59-.53l.36-2.54c.58-.24 1.13-.55 1.63-.95l2.38.96c.3.13.64.01.8-.27l1.91-3.3a.6.6 0 0 0-.14-.77l-2.02-1.57Z"
-              />
-              <circle class="gear-hole" cx="12" cy="12" r="3.2" />
-            </svg>
-          </summary>
-          <div class="settings-panel__content">
-                    <div class="theme-toolbar" id="theme-toolbar">
-                      <div class="theme-toolbar__group">
-                        <span class="theme-toolbar__label">Mode</span>
-                        <div class="theme-toolbar__options" id="mode-toggle">
-                          <button
-                            type="button"
-                            class="mode-toggle__button mode-toggle__button--active"
-                            data-theme="light"
-                            aria-pressed="true"
-                          >
-                            Light
-                          </button>
-                          <button
-                            type="button"
-                            class="mode-toggle__button"
-                            data-theme="dark"
-                            aria-pressed="false"
-                          >
-                            Dark
-                          </button>
+            <span class="nav-chip__toggle-icon" aria-hidden="true">☰</span>
+            <span class="nav-chip__toggle-label">Menu</span>
+          </button>
+          <nav class="nav-chip nav-chip--tabs" id="primary-nav" aria-label="Primary">
+            <div class="nav-chip__group view-toggle">
+              <div class="nav-chip__section">
+                <button
+                  type="button"
+                  class="view-toggle__button tab view-toggle__button--active"
+                  data-view-target="meals"
+                  aria-current="page"
+                >
+                  Recipes
+                </button>
+              </div>
+              <div class="nav-chip__section">
+                <button type="button" class="view-toggle__button tab" data-view-target="kitchen">
+                  Kitchen
+                </button>
+              </div>
+              <div class="nav-chip__section">
+                <button type="button" class="view-toggle__button tab" data-view-target="pantry">
+                  Pantry
+                </button>
+              </div>
+              <div class="nav-chip__section">
+                <button type="button" class="view-toggle__button tab" data-view-target="meal-plan">
+                  Meal Plan
+                </button>
+              </div>
+              <div class="nav-chip__section">
+                <button
+                  type="button"
+                  class="view-toggle__button tab"
+                  data-view-target="family"
+                  id="family-button"
+                >
+                  Family
+                </button>
+              </div>
+            </div>
+            <details class="settings-panel nav-chip__settings" id="settings-panel">
+              <summary
+                class="settings-panel__summary settings-btn"
+                aria-label="Display and unit settings"
+                aria-haspopup="true"
+                title="Display and unit settings"
+              >
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path
+                    d="M19.14 12.94a7.9 7.9 0 0 0 .05-.94 7.9 7.9 0 0 0-.05-.94l2.02-1.57a.6.6 0 0 0 .14-.77l-1.91-3.3a.6.6 0 0 0-.72-.27l-2.38.96a7.53 7.53 0 0 0-1.63-.95l-.36-2.54A.6.6 0 0 0 13.1 1h-3.2a.6.6 0 0 0-.59.52l-.36 2.54c-.58.24-1.13.55-1.63.95l-2.38-.96a.6.6 0 0 0-.72.27L2.31 8.12a.6.6 0 0 0 .14.77l2.02 1.57c-.03.31-.05.62-.05.94s.02.63.05.94L2.45 14.9a.6.6 0 0 0-.14.77l1.91 3.3c.16.28.5.4.8.27l2.38-.96c.5.4 1.05.71 1.63.95l.36 2.54c.05.29.3.53.59.53h3.2c.29 0 .54-.24.59-.53l.36-2.54c.58-.24 1.13-.55 1.63-.95l2.38.96c.3.13.64.01.8-.27l1.91-3.3a.6.6 0 0 0-.14-.77l-2.02-1.57Z"
+                  />
+                  <circle class="gear-hole" cx="12" cy="12" r="3.2" />
+                </svg>
+              </summary>
+              <div class="settings-panel__content">
+                <div class="theme-toolbar" id="theme-toolbar">
+                  <div class="theme-toolbar__group">
+                    <span class="theme-toolbar__label">Mode</span>
+                    <div class="theme-toolbar__options" id="mode-toggle">
+                      <button
+                        type="button"
+                        class="mode-toggle__button mode-toggle__button--active"
+                        data-theme="light"
+                        aria-pressed="true"
+                      >
+                        Light
+                      </button>
+                      <button
+                        type="button"
+                        class="mode-toggle__button"
+                        data-theme="dark"
+                        aria-pressed="false"
+                      >
+                        Dark
+                      </button>
+                    </div>
+                  </div>
+                  <div class="theme-toolbar__group">
+                    <span class="theme-toolbar__label">Palette</span>
+                    <div class="theme-toolbar__palette" id="theme-palette">
+                      <div class="theme-color-control">
+                        <span class="theme-color-control__label" id="theme-color-label-background"
+                          >Background</span
+                        >
+                        <div class="theme-color-control__inputs">
+                          <input
+                            type="color"
+                            class="theme-color-control__picker"
+                            data-color-role="background"
+                            aria-labelledby="theme-color-label-background"
+                          />
+                          <input
+                            type="text"
+                            class="theme-color-control__value"
+                            data-color-role="background"
+                            aria-labelledby="theme-color-label-background"
+                            placeholder="#RRGGBB"
+                            spellcheck="false"
+                            autocapitalize="off"
+                            autocomplete="off"
+                            inputmode="text"
+                            maxlength="7"
+                            pattern="^#?[0-9A-Fa-f]{3,6}$"
+                          />
                         </div>
                       </div>
-                      <div class="theme-toolbar__group">
-                        <span class="theme-toolbar__label">Palette</span>
-                        <div class="theme-toolbar__palette" id="theme-palette">
-                          <div class="theme-color-control">
-                            <span class="theme-color-control__label" id="theme-color-label-background"
-                              >Background</span
-                            >
-                            <div class="theme-color-control__inputs">
-                              <input
-                                type="color"
-                                class="theme-color-control__picker"
-                                data-color-role="background"
-                                aria-labelledby="theme-color-label-background"
-                              />
-                              <input
-                                type="text"
-                                class="theme-color-control__value"
-                                data-color-role="background"
-                                aria-labelledby="theme-color-label-background"
-                                placeholder="#RRGGBB"
-                                spellcheck="false"
-                                autocapitalize="off"
-                                autocomplete="off"
-                                inputmode="text"
-                                maxlength="7"
-                                pattern="^#?[0-9A-Fa-f]{3,6}$"
-                              />
-                            </div>
-                          </div>
-                          <div class="theme-color-control">
-                            <span class="theme-color-control__label" id="theme-color-label-primary"
-                              >Primary</span
-                            >
-                            <div class="theme-color-control__inputs">
-                              <input
-                                type="color"
-                                class="theme-color-control__picker"
-                                data-color-role="main"
-                                aria-labelledby="theme-color-label-primary"
-                              />
-                              <input
-                                type="text"
-                                class="theme-color-control__value"
-                                data-color-role="main"
-                                aria-labelledby="theme-color-label-primary"
-                                placeholder="#RRGGBB"
-                                spellcheck="false"
-                                autocapitalize="off"
-                                autocomplete="off"
-                                inputmode="text"
-                                maxlength="7"
-                                pattern="^#?[0-9A-Fa-f]{3,6}$"
-                              />
-                            </div>
-                          </div>
-                          <div class="theme-color-control">
-                            <span class="theme-color-control__label" id="theme-color-label-accent-1"
-                              >Accent 1</span
-                            >
-                            <div class="theme-color-control__inputs">
-                              <input
-                                type="color"
-                                class="theme-color-control__picker"
-                                data-color-role="accent1"
-                                aria-labelledby="theme-color-label-accent-1"
-                              />
-                              <input
-                                type="text"
-                                class="theme-color-control__value"
-                                data-color-role="accent1"
-                                aria-labelledby="theme-color-label-accent-1"
-                                placeholder="#RRGGBB"
-                                spellcheck="false"
-                                autocapitalize="off"
-                                autocomplete="off"
-                                inputmode="text"
-                                maxlength="7"
-                                pattern="^#?[0-9A-Fa-f]{3,6}$"
-                              />
-                            </div>
-                          </div>
-                          <div class="theme-color-control">
-                            <span class="theme-color-control__label" id="theme-color-label-accent-2"
-                              >Accent 2</span
-                            >
-                            <div class="theme-color-control__inputs">
-                              <input
-                                type="color"
-                                class="theme-color-control__picker"
-                                data-color-role="accent2"
-                                aria-labelledby="theme-color-label-accent-2"
-                              />
-                              <input
-                                type="text"
-                                class="theme-color-control__value"
-                                data-color-role="accent2"
-                                aria-labelledby="theme-color-label-accent-2"
-                                placeholder="#RRGGBB"
-                                spellcheck="false"
-                                autocapitalize="off"
-                                autocomplete="off"
-                                inputmode="text"
-                                maxlength="7"
-                                pattern="^#?[0-9A-Fa-f]{3,6}$"
-                              />
-                            </div>
-                          </div>
+                      <div class="theme-color-control">
+                        <span class="theme-color-control__label" id="theme-color-label-primary"
+                          >Primary</span
+                        >
+                        <div class="theme-color-control__inputs">
+                          <input
+                            type="color"
+                            class="theme-color-control__picker"
+                            data-color-role="main"
+                            aria-labelledby="theme-color-label-primary"
+                          />
+                          <input
+                            type="text"
+                            class="theme-color-control__value"
+                            data-color-role="main"
+                            aria-labelledby="theme-color-label-primary"
+                            placeholder="#RRGGBB"
+                            spellcheck="false"
+                            autocapitalize="off"
+                            autocomplete="off"
+                            inputmode="text"
+                            maxlength="7"
+                            pattern="^#?[0-9A-Fa-f]{3,6}$"
+                          />
                         </div>
                       </div>
-                      <div class="theme-toolbar__group theme-toolbar__group--holiday">
-                        <div class="theme-toolbar__holiday-row">
-                          <label class="holiday-theme-toggle" for="holiday-theme-toggle">
-                            <input type="checkbox" id="holiday-theme-toggle" />
-                            <span>Holiday Themes</span>
-                          </label>
-                          <button
-                            type="button"
-                            class="holiday-theme-settings"
-                            id="holiday-theme-settings"
-                            aria-label="Choose holidays for automatic themes"
-                            aria-haspopup="dialog"
-                            aria-controls="holiday-theme-dialog"
-                            title="Choose holidays for automatic themes"
-                          >
-                            <span class="holiday-theme-settings__icon" aria-hidden="true">
-                              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                                <path
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.3.136.855.142 1.205-.108l.737-.527a1.125 1.125 0 0 1 1.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.11v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.397-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 0 1-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.78.929l-.15.894c-.09.543-.56.94-1.11.94h-1.094c-.55 0-1.019-.397-1.11-.94l-.148-.894c-.071-.424-.384-.764-.78-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 0 1-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.11v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.107-1.204l-.527-.738a1.125 1.125 0 0 1 .12-1.45l.773-.773a1.125 1.125 0 0 1 1.45-.12l.737.527c.35.25.806.272 1.204.107.397-.165.71-.505.78-.929l.149-.894z"
-                                ></path>
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"></path>
-                              </svg>
-                            </span>
-                          </button>
+                      <div class="theme-color-control">
+                        <span class="theme-color-control__label" id="theme-color-label-accent-1"
+                          >Accent 1</span
+                        >
+                        <div class="theme-color-control__inputs">
+                          <input
+                            type="color"
+                            class="theme-color-control__picker"
+                            data-color-role="accent1"
+                            aria-labelledby="theme-color-label-accent-1"
+                          />
+                          <input
+                            type="text"
+                            class="theme-color-control__value"
+                            data-color-role="accent1"
+                            aria-labelledby="theme-color-label-accent-1"
+                            placeholder="#RRGGBB"
+                            spellcheck="false"
+                            autocapitalize="off"
+                            autocomplete="off"
+                            inputmode="text"
+                            maxlength="7"
+                            pattern="^#?[0-9A-Fa-f]{3,6}$"
+                          />
                         </div>
-                        <p class="holiday-theme-toggle__description">
-                          Automatically switch palettes on selected holidays.
-                        </p>
-                        <p class="holiday-theme-toggle__status" id="holiday-theme-status" hidden aria-live="polite"></p>
                       </div>
-                      <div class="theme-toolbar__group">
-                        <span class="theme-toolbar__label">Units</span>
-                        <div class="theme-toolbar__options" id="measurement-toggle">
-                          <button
-                            type="button"
-                            class="mode-toggle__button measurement-toggle__button"
-                            data-measurement="imperial"
-                            aria-pressed="false"
-                          >
-                            Imperial
-                          </button>
-                          <button
-                            type="button"
-                            class="mode-toggle__button measurement-toggle__button"
-                            data-measurement="metric"
-                            aria-pressed="false"
-                          >
-                            Metric
-                          </button>
+                      <div class="theme-color-control">
+                        <span class="theme-color-control__label" id="theme-color-label-accent-2"
+                          >Accent 2</span
+                        >
+                        <div class="theme-color-control__inputs">
+                          <input
+                            type="color"
+                            class="theme-color-control__picker"
+                            data-color-role="accent2"
+                            aria-labelledby="theme-color-label-accent-2"
+                          />
+                          <input
+                            type="text"
+                            class="theme-color-control__value"
+                            data-color-role="accent2"
+                            aria-labelledby="theme-color-label-accent-2"
+                            placeholder="#RRGGBB"
+                            spellcheck="false"
+                            autocapitalize="off"
+                            autocomplete="off"
+                            inputmode="text"
+                            maxlength="7"
+                            pattern="^#?[0-9A-Fa-f]{3,6}$"
+                          />
                         </div>
                       </div>
                     </div>
                   </div>
-        </details>
-      </nav>
+                  <div class="theme-toolbar__group theme-toolbar__group--holiday">
+                    <div class="theme-toolbar__holiday-row">
+                      <label class="holiday-theme-toggle" for="holiday-theme-toggle">
+                        <input type="checkbox" id="holiday-theme-toggle" />
+                        <span>Holiday Themes</span>
+                      </label>
+                      <button
+                        type="button"
+                        class="holiday-theme-settings"
+                        id="holiday-theme-settings"
+                        aria-label="Choose holidays for automatic themes"
+                        aria-haspopup="dialog"
+                        aria-controls="holiday-theme-dialog"
+                        title="Choose holidays for automatic themes"
+                      >
+                        <span class="holiday-theme-settings__icon" aria-hidden="true">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.3.136.855.142 1.205-.108l.737-.527a1.125 1.125 0 0 1 1.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.11v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.397-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 0 1-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.78.929l-.15.894c-.09.543-.56.94-1.11.94h-1.094c-.55 0-1.019-.397-1.11-.94l-.148-.894c-.071-.424-.384-.764-.78-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 0 1-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.11v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.107-1.204l-.527-.738a.6.6 0 0 1 .12-1.45l.773-.773a1.125 1.125 0 0 1 1.45-.12l.737.527c.35.25.806.272 1.204.107.397-.165.71-.505.78-.929l.149-.894z"
+                            ></path>
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"></path>
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
+                    <p class="holiday-theme-toggle__description">
+                      Automatically switch palettes on selected holidays.
+                    </p>
+                    <p class="holiday-theme-toggle__status" id="holiday-theme-status" hidden aria-live="polite"></p>
+                  </div>
+                  <div class="theme-toolbar__group">
+                    <span class="theme-toolbar__label">Units</span>
+                    <div class="theme-toolbar__options" id="measurement-toggle">
+                      <button
+                        type="button"
+                        class="mode-toggle__button measurement-toggle__button"
+                        data-measurement="imperial"
+                        aria-pressed="false"
+                      >
+                        Imperial
+                      </button>
+                      <button
+                        type="button"
+                        class="mode-toggle__button measurement-toggle__button"
+                        data-measurement="metric"
+                        aria-pressed="false"
+                      >
+                        Metric
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </details>
+          </nav>
+          <div
+            class="nav-chip nav-chip--filters recipe-family-filter"
+            id="recipe-family-filter"
+            hidden
+            aria-hidden="true"
+          ></div>
+          <div
+            class="nav-chip nav-chip--actions"
+            id="recipe-action-chip"
+            role="group"
+            aria-label="Recipe quick actions"
+          >
+            <button
+              type="button"
+              class="favorite-filter filter-action-button icon-btn"
+              id="favorite-filter"
+              aria-pressed="false"
+              aria-label="Filter by favorite recipes"
+              title="Filter by favorite recipes"
+            >
+              <span class="favorite-filter__icon" aria-hidden="true">♥</span>
+            </button>
+            <button
+              type="button"
+              class="pantry-only-filter filter-action-button icon-btn"
+              id="pantry-only-toggle"
+              aria-pressed="false"
+              aria-label="Pantry filter off: include all recipes"
+              title="Pantry filter off: include all recipes"
+            >
+              <span class="pantry-only-filter__icon" aria-hidden="true">🧺</span>
+            </button>
+            <button
+              type="button"
+              class="substitution-toggle filter-action-button icon-btn"
+              id="substitution-toggle"
+              aria-pressed="false"
+              aria-label="Substitutions off: recipes must match pantry exactly"
+              title="Substitutions off: recipes must match pantry exactly"
+            >
+              <span class="substitution-toggle__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                  <path d="M4 8h14" stroke-linecap="round"></path>
+                  <path d="M18 8l-3-3" stroke-linecap="round" stroke-linejoin="round"></path>
+                  <path d="M18 8l-3 3" stroke-linecap="round" stroke-linejoin="round"></path>
+                  <path d="M20 16H6" stroke-linecap="round"></path>
+                  <path d="M6 16l3-3" stroke-linecap="round" stroke-linejoin="round"></path>
+                  <path d="M6 16l3 3" stroke-linecap="round" stroke-linejoin="round"></path>
+                </svg>
+              </span>
+            </button>
+            <button
+              type="button"
+              class="reset-button filter-action-button icon-btn"
+              id="reset-filters"
+              aria-label="Reset filters"
+              title="Reset filters"
+            >
+              <span class="reset-button__icon" aria-hidden="true">↻</span>
+            </button>
+          </div>
+        </div>
+      </header>
       <main class="layout" id="app-layout">
         <aside class="filter-panel" id="filter-panel">
-          <div class="panel-header panel-header--actions-only">
-            <div class="panel-header__actions">
-              <button
-                type="button"
-                class="favorite-filter filter-action-button"
-                id="favorite-filter"
-                aria-pressed="false"
-                aria-label="Filter by favorite recipes"
-                title="Filter by favorite recipes"
-              >
-                <span class="favorite-filter__icon" aria-hidden="true">♥</span>
-              </button>
-              <button
-                type="button"
-                class="pantry-only-filter filter-action-button"
-                id="pantry-only-toggle"
-                aria-pressed="false"
-                aria-label="Pantry filter off: include all recipes"
-                title="Pantry filter off: include all recipes"
-              >
-                <span class="pantry-only-filter__icon" aria-hidden="true">🧺</span>
-              </button>
-              <button
-                type="button"
-                class="substitution-toggle filter-action-button"
-                id="substitution-toggle"
-                aria-pressed="false"
-                aria-label="Substitutions off: recipes must match pantry exactly"
-                title="Substitutions off: recipes must match pantry exactly"
-              >
-                <span class="substitution-toggle__icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                    <path d="M4 8h14" stroke-linecap="round"></path>
-                    <path d="M18 8l-3-3" stroke-linecap="round" stroke-linejoin="round"></path>
-                    <path d="M18 8l-3 3" stroke-linecap="round" stroke-linejoin="round"></path>
-                    <path d="M20 16H6" stroke-linecap="round"></path>
-                    <path d="M6 16l3-3" stroke-linecap="round" stroke-linejoin="round"></path>
-                    <path d="M6 16l3 3" stroke-linecap="round" stroke-linejoin="round"></path>
-                  </svg>
-                </span>
-              </button>
-              <button
-                type="button"
-                class="reset-button filter-action-button"
-                id="reset-filters"
-                aria-label="Reset filters"
-                title="Reset filters"
-              >
-                <span class="reset-button__icon" aria-hidden="true">↻</span>
-              </button>
-            </div>
-          </div>
-          <div class="recipe-family-filter" id="recipe-family-filter" hidden aria-hidden="true"></div>
           <div class="input-group input-group--search">
             <input
               type="search"

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -5613,6 +5613,7 @@
     elements.recipeFamilyFilter = document.getElementById('recipe-family-filter');
     elements.pantryOnlyToggle = document.getElementById('pantry-only-toggle');
     elements.substitutionToggle = document.getElementById('substitution-toggle');
+    elements.recipeActionChip = document.getElementById('recipe-action-chip');
     elements.ingredientSection = document.getElementById('ingredient-section');
     elements.tagSection = document.getElementById('tag-section');
     elements.allergySection = document.getElementById('allergy-section');
@@ -6073,7 +6074,7 @@
     const hasSelection = ids.length > 0;
     const allButton = document.createElement('button');
     allButton.type = 'button';
-    allButton.className = 'recipe-family-filter__button recipe-family-filter__button--all';
+    allButton.className = 'recipe-family-filter__button recipe-family-filter__button--all tab';
     if (!hasSelection) {
       allButton.classList.add('recipe-family-filter__button--active');
     }
@@ -6091,7 +6092,7 @@
       }
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = 'recipe-family-filter__button';
+      button.className = 'recipe-family-filter__button icon-btn';
       const isActive = selectedSet.has(member.id);
       if (isActive) {
         button.classList.add('recipe-family-filter__button--active');
@@ -6160,6 +6161,15 @@
         elements.substitutionToggle.hidden = true;
         elements.substitutionToggle.disabled = true;
         elements.substitutionToggle.setAttribute('aria-hidden', 'true');
+      }
+    }
+    if (elements.recipeActionChip) {
+      if (isMealsView) {
+        elements.recipeActionChip.hidden = false;
+        elements.recipeActionChip.removeAttribute('aria-hidden');
+      } else {
+        elements.recipeActionChip.hidden = true;
+        elements.recipeActionChip.setAttribute('aria-hidden', 'true');
       }
     }
     if (elements.filterSearch) {

--- a/styles/app.css
+++ b/styles/app.css
@@ -374,7 +374,7 @@ select {
   display: flex;
   flex-direction: column;
   color: var(--text);
-  padding-top: 5rem;
+  padding: 1.5rem 1.5rem 3rem;
   background: var(--glass-surface);
   -webkit-backdrop-filter: blur(24px);
   backdrop-filter: blur(24px);
@@ -388,9 +388,6 @@ select {
 }
 
 .nav-chip {
-  position: fixed;
-  top: 1rem;
-  left: 1.5rem;
   display: flex;
   align-items: center;
   gap: 0;
@@ -401,7 +398,30 @@ select {
   box-shadow: var(--shadow-1);
   color: var(--text);
   overflow: visible;
-  z-index: 20;
+}
+
+#recipes-page .topbar {
+  background: var(--layer-0);
+  border: 0;
+  box-shadow: none;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+#recipes-page .topbar__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+#recipes-page .topbar__row > * {
+  flex: 0 0 auto;
+}
+
+#recipes-page .topbar__row > .nav-chip--tabs {
+  flex: 1 1 20rem;
+  min-inline-size: min(100%, 18rem);
 }
 
 .nav-chip__group {
@@ -430,9 +450,6 @@ select {
 }
 
 .nav-chip__toggle {
-  position: fixed;
-  top: 1rem;
-  left: 1.5rem;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -446,7 +463,7 @@ select {
   box-shadow: var(--shadow-1);
   transition: transform 0.2s ease, box-shadow 0.2s ease,
     background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-  z-index: 21;
+  flex-shrink: 0;
 }
 
 .nav-chip__toggle:hover,
@@ -507,6 +524,15 @@ select {
   place-items: center;
 }
 
+.nav-chip--filters .icon-btn,
+.nav-chip--actions .icon-btn {
+  inline-size: 36px;
+  block-size: 36px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+}
+
 .nav-chip .tab {
   margin: 0;
   position: relative;
@@ -514,7 +540,10 @@ select {
   background-clip: padding-box;
 }
 
-.nav-chip .tab + .tab {
+.nav-chip .tab + .tab,
+.nav-chip .icon-btn + .icon-btn,
+.nav-chip .tab + .icon-btn,
+.nav-chip .icon-btn + .tab {
   margin-left: -1px;
 }
 
@@ -564,7 +593,7 @@ select {
   outline-offset: 2px;
 }
 
-.nav-chip .settings-btn {
+.nav-chip--tabs .settings-btn {
   inline-size: 32px;
   block-size: 32px;
   padding: 0;
@@ -577,12 +606,12 @@ select {
   filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.35));
 }
 
-.nav-chip .settings-btn:focus-visible {
+.nav-chip--tabs .settings-btn:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px color-mix(in oklab, var(--layer-2), var(--layer-0) 65%);
 }
 
-.nav-chip .settings-btn svg {
+.nav-chip--tabs .settings-btn svg {
   display: block;
   width: 22px;
   height: 22px;
@@ -591,11 +620,11 @@ select {
   transition: transform 0.15s ease;
 }
 
-.nav-chip .settings-btn:hover svg {
+.nav-chip--tabs .settings-btn:hover svg {
   transform: rotate(12deg);
 }
 
-.nav-chip .settings-btn svg .gear-hole {
+.nav-chip--tabs .settings-btn svg .gear-hole {
   fill: var(--layer-2);
 }
 
@@ -620,27 +649,25 @@ select {
 }
 
 @media (max-width: 62.5rem) {
-  .nav-chip {
+  .nav-chip--tabs {
     display: none;
   }
 
-  .nav-chip.nav-chip--open {
+  .nav-chip--tabs.nav-chip--open {
     display: flex;
     flex-direction: column;
     align-items: stretch;
     gap: 0.5rem;
-    left: 50%;
-    transform: translateX(-50%);
+    width: 100%;
     padding: 0.75rem;
-    max-width: calc(100vw - 2rem);
   }
 
-  .nav-chip.nav-chip--open .nav-chip__group {
+  .nav-chip--tabs.nav-chip--open .nav-chip__group {
     flex-direction: column;
     gap: 0.35rem;
   }
 
-  .nav-chip.nav-chip--open .nav-chip__settings {
+  .nav-chip--tabs.nav-chip--open .nav-chip__settings {
     margin-left: 0;
     padding-left: 0;
     align-self: flex-end;
@@ -1224,21 +1251,18 @@ select {
 }
 
 .recipe-family-filter {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 0.35rem;
-  padding: 0.4rem 0.55rem;
-  margin: 0.35rem 0 0.65rem;
-  border-radius: 999px;
-  border: 2px solid var(--border-1);
-  background: var(--surface-1);
-  box-shadow: var(--shadow-1);
-  width: fit-content;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  width: auto;
 }
 
-.recipe-family-filter[data-filter-active='true'] {
-  border-color: var(--border-1);
+#recipes-page .nav-chip--filters[data-filter-active='true'] {
   box-shadow: var(--shadow-2);
 }
 
@@ -1252,44 +1276,28 @@ select {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.1rem;
-  height: 2.1rem;
   font-size: 1.3rem;
   line-height: 1;
-  border-radius: 999px;
-  border: 1px solid var(--border-1);
-  background: var(--surface-2);
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.recipe-family-filter__button.icon-btn {
+  inline-size: 36px;
+  block-size: 36px;
+  padding: 0;
 }
 
 .recipe-family-filter__button--all {
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   font-weight: 600;
-  color: var(--text);
-  width: auto;
-  min-width: 2.6rem;
-  padding: 0.15rem 0.6rem;
-}
-
-.recipe-family-filter__button:hover {
-  background: var(--surface-1);
-}
-
-.recipe-family-filter__button:focus-visible {
-  outline: none;
-  box-shadow: none;
 }
 
 .recipe-family-filter__button--active {
-  background: var(--brand);
-  border-color: var(--border-1);
-  color: var(--text);
-  box-shadow: var(--shadow-1);
+  outline: 2px solid var(--border-strong);
+  outline-offset: -2px;
 }
 
 .recipe-family-filter__button--active.recipe-family-filter__button--all {
-  color: var(--text);
+  outline-offset: -2px;
 }
 
 .input-group {


### PR DESCRIPTION
## Summary
- wrap the recipes navigation, quick filters, and action controls into a new topbar chip layout
- refresh chip styling to match the new header design and keep layouts responsive across breakpoints
- update recipes scripts so family filter buttons adopt the chip style and hide the actions chip on non-recipe views

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e2e42a1dd48325b67f911e8435de79