### PR TITLE
Refine recipes header styling

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -5721,14 +5721,6 @@
     renderApp();
   };
 
-  const clearMealFilterFamilyMembers = () => {
-    const filters = ensureMealFilters();
-    if (Array.isArray(filters.familyMembers) && filters.familyMembers.length) {
-      filters.familyMembers = [];
-      renderApp();
-    }
-  };
-
   const populateCheckboxGroup = (view, container, options, field, config) => {
     let spanClassName;
     let labelFormatter;
@@ -6071,20 +6063,6 @@
     list.className = 'recipe-family-filter__list';
     list.setAttribute('role', 'group');
     list.setAttribute('aria-label', 'Filter recipes by family member');
-    const hasSelection = ids.length > 0;
-    const allButton = document.createElement('button');
-    allButton.type = 'button';
-    allButton.className = 'recipe-family-filter__button recipe-family-filter__button--all tab';
-    if (!hasSelection) {
-      allButton.classList.add('recipe-family-filter__button--active');
-    }
-    allButton.textContent = 'All';
-    allButton.title = 'Show recipes for all family members';
-    allButton.setAttribute('aria-pressed', hasSelection ? 'false' : 'true');
-    allButton.addEventListener('click', () => {
-      clearMealFilterFamilyMembers();
-    });
-    list.appendChild(allButton);
     const selectedSet = new Set(ids);
     members.forEach((member) => {
       if (!member || !member.id) {
@@ -8330,6 +8308,45 @@
     persistAppState();
   };
 
+  const enhanceRecipesHeader = () => {
+    const headerRow = document.querySelector('#recipes-page .topbar__row');
+    if (!headerRow) {
+      return;
+    }
+
+    const quickFilters =
+      document.querySelector('#quick-filters') ||
+      document.querySelector('.quick-filters');
+    if (quickFilters && !quickFilters.closest('.nav-chip')) {
+      const controls = Array.from(quickFilters.querySelectorAll('button, a'));
+      if (controls.length) {
+        const chip = document.createElement('div');
+        chip.className = 'nav-chip nav-chip--filters';
+        controls.forEach((control) => {
+          control.classList.add('icon-btn');
+        });
+        chip.append(...controls);
+        headerRow.insertBefore(chip, headerRow.children[1] || null);
+      }
+    }
+
+    const holidayButton =
+      document.querySelector('#holiday-settings-button') ||
+      document.querySelector('#holiday-theme-settings') ||
+      headerRow.querySelector('.holiday-settings-btn');
+    if (holidayButton instanceof HTMLElement) {
+      holidayButton.classList.add('holiday-settings-btn');
+      if (!holidayButton.querySelector('svg .gear-hole')) {
+        holidayButton.innerHTML = `
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M19.14 12.94a7.9 7.9 0 0 0 .05-.94 7.9 7.9 0 0 0-.05-.94l2.02-1.57a.6.6 0 0 0 .14-.77l-1.91-3.3a.6.6 0 0 0-.72-.27l-2.38.96a7.53 7.53 0 0 0-1.63-.95l-.36-2.54A.6.6 0 0 0 13.1 1h-3.2a.6.6 0 0 0-.59.52l-.36 2.54c-.58.24-1.13.55-1.63.95l-2.38-.96a.6.6 0 0 0-.72.27L2.31 8.12a.6.6 0 0 0 .14.77l2.02 1.57c-.03.31-.05.62-.05.94s.02.63.05.94L2.45 14.9a.6.6 0 0 0-.14.77l1.91 3.3c.16.28.5.4.8.27l2.38-.96c.5.4 1.05.71 1.63.95l.36 2.54c.05.29.3.53.59.53h3.2c.29 0 .54-.24.59-.53l.36-2.54c.58-.24 1.13-.55 1.63-.95l2.38.96c.3.13.64.01.8-.27l1.91-3.3a.6.6 0 0 0-.14-.77l-2.02-1.57Z" />
+            <circle class="gear-hole" cx="12" cy="12" r="3.2" />
+          </svg>
+        `.trim();
+      }
+    }
+  };
+
   const bindEvents = () => {
     elements.viewToggleButtons.forEach((button) => {
       button.addEventListener('click', () => {
@@ -8649,6 +8666,7 @@
 
   const init = () => {
     cacheElements();
+    enhanceRecipesHeader();
     bindEvents();
     initThemeControls();
     initMeasurementControls();

--- a/styles/app.css
+++ b/styles/app.css
@@ -424,6 +424,121 @@ select {
   min-inline-size: min(100%, 18rem);
 }
 
+/* Recipes header refinements */
+/* Header melts into page; no extra rectangles */
+#recipes-page .topbar {
+  background: var(--layer-0) !important;
+  border: 0 !important;
+  box-shadow: none !important;
+}
+
+#recipes-page .topbar__row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  background: transparent !important;
+  border: 0 !important;
+  padding: 0.5rem 0.75rem;
+}
+
+/* Any legacy wrappers around the moved menus — make them transparent */
+#recipes-page .quick-filters,
+#recipes-page .actions-mini,
+#recipes-page .quick-filters > *,
+#recipes-page .actions-mini > * {
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
+/* All chips are auto-width; none should stretch */
+#recipes-page .nav-chip {
+  flex: 0 0 auto;
+  max-width: max-content;
+}
+
+/* Left (tabs) — ensure internal list can’t grow to fill */
+#recipes-page .nav-chip--tabs .tabs-list {
+  flex: 0 0 auto;
+  width: auto;
+}
+
+/* Center (quick filters) — enforce red chip (card color) */
+#recipes-page .nav-chip--filters {
+  background: var(--layer-2) !important;
+  border: 2px solid var(--border-strong) !important;
+  border-radius: 999px !important;
+  padding: 0.25rem 0.5rem !important;
+}
+
+/* Right (actions) — keep standard chip frame */
+#recipes-page .nav-chip--actions {
+  flex: 0 0 auto;
+}
+
+/* Last-resort: stop any flex:1 */
+#recipes-page .nav-chip--tabs,
+#recipes-page .nav-chip--tabs .tabs-list {
+  flex: 0 0 auto !important;
+}
+
+/* Seamless pills (no gaps) */
+#recipes-page .nav-chip {
+  gap: 0;
+}
+
+#recipes-page .nav-chip .tab + .tab,
+#recipes-page .nav-chip .icon-btn + .icon-btn {
+  margin-left: -1px;
+}
+
+/* Settings dropdown / panel should match page bg, not card color */
+#recipes-page .settings-menu,
+#recipes-page .settings-panel,
+#recipes-page .settings-dropdown,
+#recipes-page .settings-popover {
+  background: var(--layer-0) !important;
+  color: var(--text) !important;
+  border: 1px solid var(--border-strong) !important;
+  box-shadow: var(--shadow-2) !important;
+}
+
+/* Reuse the protruding gear styling */
+#recipes-page .holiday-settings-btn {
+  inline-size: 32px;
+  block-size: 32px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  display: grid;
+  place-items: center;
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.35));
+  color: var(--text);
+}
+
+#recipes-page .holiday-settings-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--layer-2), var(--layer-0) 65%);
+}
+
+#recipes-page .holiday-settings-btn svg {
+  width: 22px;
+  height: 22px;
+  display: block;
+  fill: var(--layer-0);
+  transition: transform 0.15s ease;
+}
+
+#recipes-page .holiday-settings-btn:hover svg {
+  transform: rotate(12deg);
+}
+
+#recipes-page .holiday-settings-btn svg .gear-hole {
+  fill: var(--layer-2);
+}
+
 .nav-chip__group {
   display: inline-flex;
   align-items: center;
@@ -844,7 +959,7 @@ select {
   cursor: pointer;
 }
 
-.holiday-theme-settings {
+.holiday-theme-settings:not(.holiday-settings-btn) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -859,14 +974,14 @@ select {
     box-shadow 0.2s ease;
 }
 
-.holiday-theme-settings:hover {
+.holiday-theme-settings:not(.holiday-settings-btn):hover {
   color: var(--text);
   border-color: var(--border-1);
   transform: translateY(-1px);
   box-shadow: var(--shadow-1);
 }
 
-.holiday-theme-settings:focus-visible {
+.holiday-theme-settings:not(.holiday-settings-btn):focus-visible {
   outline: 3px solid var(--border-1);
   outline-offset: 2px;
 }
@@ -1267,7 +1382,8 @@ select {
 }
 
 .recipe-family-filter__list {
-  display: inline-flex;
+  display: flex;
+  flex-wrap: nowrap;
   align-items: center;
   gap: 0.35rem;
 }
@@ -1278,6 +1394,7 @@ select {
   justify-content: center;
   font-size: 1.3rem;
   line-height: 1;
+  flex: 0 0 auto;
 }
 
 .recipe-family-filter__button.icon-btn {
@@ -1286,19 +1403,11 @@ select {
   padding: 0;
 }
 
-.recipe-family-filter__button--all {
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
 .recipe-family-filter__button--active {
   outline: 2px solid var(--border-strong);
   outline-offset: -2px;
 }
 
-.recipe-family-filter__button--active.recipe-family-filter__button--all {
-  outline-offset: -2px;
-}
 
 .input-group {
   display: flex;


### PR DESCRIPTION
## Summary
- polish the recipes page header so chips stay compact, backgrounds are transparent, and the holiday quick filters/action chips keep the intended framing
- restyle the holiday themes control to reuse the gear visuals and ensure supporting markup/classes are added at runtime when needed
- remove the redundant "All" recipe-family quick filter button and keep the member icons flowing horizontally inside the center chip

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e31de1ca5c83258ffd05ff785183d2