### PR TITLE
Refine recipes settings gear styling

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -740,41 +740,57 @@ select {
   outline-offset: 2px;
 }
 
-#recipes-page .nav-chip--tabs .settings-btn {
+#recipes-page .nav-chip--tabs .settings-btn,
+#recipes-page .nav-chip--tabs .icon-btn.settings-btn {
   background: transparent !important;
   border: none !important;
   box-shadow: none !important;
   padding: 0 !important;
-  inline-size: 32px;
-  block-size: 32px;
-  display: grid;
-  place-items: center;
+  inline-size: auto !important;
+  block-size: auto !important;
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  outline: none !important;
+}
+
+#recipes-page .nav-chip--tabs .settings-btn::before,
+#recipes-page .nav-chip--tabs .settings-btn::after {
+  content: none !important;
+}
+
+#recipes-page .nav-chip--tabs .settings-btn svg {
+  width: 20px;
+  height: 20px;
+  display: block;
+  fill: var(--layer-0) !important;
+  stroke: none;
+  filter: none;
+  transition: transform 0.15s ease;
+}
+
+#recipes-page .nav-chip--tabs .settings-btn svg .gear-hole {
+  fill: var(--layer-2) !important;
 }
 
 #recipes-page .nav-chip--tabs .settings-btn:focus-visible {
   outline: none !important;
 }
 
-#recipes-page .nav-chip--tabs .settings-btn svg {
-  width: 22px;
-  height: 22px;
-  display: block;
-  fill: var(--layer-0);
-  transition: transform 0.15s ease;
-  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.35));
-}
-
 #recipes-page .nav-chip--tabs .settings-btn:hover svg {
   transform: rotate(12deg);
 }
 
-#recipes-page .nav-chip--tabs .settings-btn svg .gear-hole {
-  fill: var(--layer-2);
+#recipes-page .nav-chip--tabs .settings-btn[aria-current],
+#recipes-page .nav-chip--tabs .settings-btn.is-active {
+  outline: none !important;
 }
 
-#recipes-page .nav-chip--tabs .settings-btn::before,
-#recipes-page .nav-chip--tabs .settings-btn::after {
-  content: none !important;
+#recipes-page .nav-chip--tabs .icon-btn.settings-btn {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 [data-theme='dark'] .nav-chip .tab,


### PR DESCRIPTION
## Summary
- strip the recipes nav settings gear of inherited pill styles so only the SVG displays on the chip
- tune the icon sizing, fill, and hover behavior to match the requested gear-only appearance
- neutralize the `.icon-btn` class if it remains on the gear button to prevent rounded backgrounds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e33669d81c83258cd9acdd935763f5