### PR TITLE
Refine Recipes header chip layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,54 +11,33 @@
     <div class="app-shell" id="recipes-page">
       <header class="topbar">
         <div class="topbar__row">
-          <button
-            type="button"
-            class="nav-chip__toggle"
-            id="primary-nav-toggle"
-            aria-label="Toggle primary menu"
-            aria-expanded="false"
-            aria-controls="primary-nav"
-          >
-            <span class="nav-chip__toggle-icon" aria-hidden="true">☰</span>
-            <span class="nav-chip__toggle-label">Menu</span>
-          </button>
           <nav class="nav-chip nav-chip--tabs" id="primary-nav" aria-label="Primary">
-            <div class="nav-chip__group view-toggle">
-              <div class="nav-chip__section">
-                <button
-                  type="button"
-                  class="view-toggle__button tab view-toggle__button--active"
-                  data-view-target="meals"
-                  aria-current="page"
-                >
-                  Recipes
-                </button>
-              </div>
-              <div class="nav-chip__section">
-                <button type="button" class="view-toggle__button tab" data-view-target="kitchen">
-                  Kitchen
-                </button>
-              </div>
-              <div class="nav-chip__section">
-                <button type="button" class="view-toggle__button tab" data-view-target="pantry">
-                  Pantry
-                </button>
-              </div>
-              <div class="nav-chip__section">
-                <button type="button" class="view-toggle__button tab" data-view-target="meal-plan">
-                  Meal Plan
-                </button>
-              </div>
-              <div class="nav-chip__section">
-                <button
-                  type="button"
-                  class="view-toggle__button tab"
-                  data-view-target="family"
-                  id="family-button"
-                >
-                  Family
-                </button>
-              </div>
+            <div class="tabs-list view-toggle">
+              <button
+                type="button"
+                class="view-toggle__button tab view-toggle__button--active"
+                data-view-target="meals"
+                aria-current="page"
+              >
+                Recipes
+              </button>
+              <button type="button" class="view-toggle__button tab" data-view-target="kitchen">
+                Kitchen
+              </button>
+              <button type="button" class="view-toggle__button tab" data-view-target="pantry">
+                Pantry
+              </button>
+              <button type="button" class="view-toggle__button tab" data-view-target="meal-plan">
+                Meal Plan
+              </button>
+              <button
+                type="button"
+                class="view-toggle__button tab"
+                data-view-target="family"
+                id="family-button"
+              >
+                Family
+              </button>
             </div>
             <details class="settings-panel nav-chip__settings" id="settings-panel">
               <summary
@@ -74,7 +53,7 @@
                   <circle class="gear-hole" cx="12" cy="12" r="3.2" />
                 </svg>
               </summary>
-              <div class="settings-panel__content">
+              <div class="settings-panel__content settings-menu">
                 <div class="theme-toolbar" id="theme-toolbar">
                   <div class="theme-toolbar__group">
                     <span class="theme-toolbar__label">Mode</span>

--- a/styles/app.css
+++ b/styles/app.css
@@ -424,25 +424,152 @@ select {
   min-inline-size: min(100%, 18rem);
 }
 
-/* Recipes header refinements */
-/* Header melts into page; no extra rectangles */
+/* Header row: invisible container, consistent spacing */
 #recipes-page .topbar {
-  background: var(--layer-0) !important;
-  border: 0 !important;
-  box-shadow: none !important;
-}
-
-#recipes-page .topbar__row {
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
-  flex-wrap: wrap;
-  background: transparent !important;
-  border: 0 !important;
+  background: var(--layer-0);
+  border: 0;
+  box-shadow: none;
   padding: 0.5rem 0.75rem;
 }
+#recipes-page .topbar__row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
 
-/* Any legacy wrappers around the moved menus — make them transparent */
+/* Chips: identical frames (card red + sage border) */
+#recipes-page .nav-chip {
+  display: flex;
+  align-items: center;
+  background: var(--layer-2);
+  border: 2px solid var(--border-strong);
+  border-radius: 999px;
+  padding: 0.25rem 0.5rem;
+  gap: 0.5rem;
+  flex: 0 0 auto;
+}
+
+/* Tabs inside left chip: pills butt with no red gutters */
+#recipes-page .nav-chip--tabs .tabs-list {
+  display: flex;
+  gap: 0;
+}
+#recipes-page .nav-chip--tabs .tabs-list .tab {
+  margin: 0;
+  position: relative;
+  z-index: 1;
+}
+#recipes-page .nav-chip--tabs .tabs-list .tab + .tab {
+  margin-left: -1px;
+}
+
+/* Icon-only chips (center/right) — standard icon size */
+#recipes-page .nav-chip--filters .icon-btn,
+#recipes-page .nav-chip--actions .icon-btn {
+  inline-size: 32px;
+  block-size: 32px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+}
+
+/* Matte button treatment (applies to tabs & icon buttons, not the gear) */
+#recipes-page .nav-chip .tab,
+#recipes-page .nav-chip .icon-btn {
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab, var(--layer-0), white 22%);
+  background: linear-gradient(
+      to bottom,
+      color-mix(in oklab, var(--layer-0), white 8%) 0%,
+      color-mix(in oklab, var(--layer-0), black 2%) 100%
+    );
+  color: var(--text);
+  box-shadow:
+    inset 0 1px 0 color-mix(in oklab, var(--layer-0), white 10%),
+    0 1px 1px rgba(0, 0, 0, 0.25);
+  transition: background 0.15s, border-color 0.15s, transform 0.06s;
+}
+#recipes-page .nav-chip .tab:hover,
+#recipes-page .nav-chip .icon-btn:hover {
+  transform: translateY(-1px);
+}
+#recipes-page .nav-chip .tab:active,
+#recipes-page .nav-chip .icon-btn:active {
+  transform: translateY(0);
+}
+#recipes-page .nav-chip--tabs .tabs-list .tab.is-active,
+#recipes-page .nav-chip--tabs .tabs-list .tab[aria-current="page"] {
+  outline: 2px solid var(--border-strong);
+  outline-offset: -2px;
+}
+
+/* PURE GEAR: no pill, no outline, no inherited chrome */
+#recipes-page .nav-chip--tabs .settings-btn {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-left: 0.5rem;
+}
+#recipes-page .nav-chip--tabs .settings-btn:focus,
+#recipes-page .nav-chip--tabs .settings-btn:focus-visible {
+  outline: none;
+}
+#recipes-page .nav-chip--tabs .settings-btn::before,
+#recipes-page .nav-chip--tabs .settings-btn::after {
+  content: none !important;
+}
+/* SVG colors: teeth = pure black, hole = chip red */
+#recipes-page .nav-chip--tabs .settings-btn svg {
+  width: 20px;
+  height: 20px;
+  display: block;
+  fill: #000 !important;
+  stroke: none;
+  filter: none;
+  transition: transform 0.15s ease;
+}
+#recipes-page .nav-chip--tabs .settings-btn svg .gear-hole {
+  fill: var(--layer-2) !important;
+}
+#recipes-page .nav-chip--tabs .settings-btn:hover svg {
+  transform: rotate(12deg);
+}
+/* Defensive: if the element also has icon-btn class, nuke it */
+#recipes-page .nav-chip--tabs .icon-btn.settings-btn {
+  all: unset !important;
+  display: inline-flex !important;
+}
+
+/* Settings MENU/POPOVER background = page background */
+#recipes-page .settings-menu,
+#recipes-page .settings-panel,
+#recipes-page .settings-dropdown,
+#recipes-page .settings-popover,
+#recipes-page [role="menu"].settings,
+#recipes-page .popover.settings,
+#recipes-page .dropdown-menu.settings {
+  background: var(--layer-0) !important;
+  color: var(--text) !important;
+  border: 1px solid var(--border-strong) !important;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-2) !important;
+}
+#recipes-page .settings-menu .menu-item,
+#recipes-page .settings-panel .menu-item,
+#recipes-page .settings-dropdown .menu-item {
+  background: transparent;
+  color: var(--text);
+  border-radius: 10px;
+}
+#recipes-page .settings-menu .menu-item:hover,
+#recipes-page .settings-panel .menu-item:hover,
+#recipes-page .settings-dropdown .menu-item:hover {
+  background: var(--layer-1);
+}
+
 #recipes-page .quick-filters,
 #recipes-page .actions-mini,
 #recipes-page .quick-filters > *,
@@ -453,75 +580,11 @@ select {
   padding: 0 !important;
 }
 
-/* All chips are auto-width; none should stretch */
-#recipes-page .nav-chip {
-  flex: 0 0 auto;
-  max-width: max-content;
-}
-
-/* Left (tabs) — ensure internal list can’t grow to fill */
-#recipes-page .nav-chip--tabs .tabs-list {
-  flex: 0 0 auto;
-  width: auto;
-}
-
-/* Center (quick filters) — enforce red chip (card color) */
-#recipes-page .nav-chip--filters {
-  background: var(--layer-2) !important;
-  border: 2px solid var(--border-strong) !important;
-  border-radius: 999px !important;
-  padding: 0.25rem 0.5rem !important;
-}
-
-/* Right (actions) — keep standard chip frame */
-#recipes-page .nav-chip--actions {
-  flex: 0 0 auto;
-}
-
-/* Last-resort: stop any flex:1 */
-#recipes-page .nav-chip--tabs,
-#recipes-page .nav-chip--tabs .tabs-list {
-  flex: 0 0 auto !important;
-}
-
-/* Seamless pills (no gaps) */
-#recipes-page .nav-chip {
-  gap: 0;
-}
-
-#recipes-page .nav-chip .tab + .tab,
-#recipes-page .nav-chip .icon-btn + .icon-btn {
-  margin-left: -1px;
-}
-
-/* Panel container background = page background, with sage border */
-#recipes-page .settings-menu,
-#recipes-page .settings-panel,
-#recipes-page .settings-dropdown,
-#recipes-page .settings-popover,
-#recipes-page [role='menu'].settings,
-#recipes-page .popover.settings,
-#recipes-page .dropdown-menu.settings {
-  background: var(--layer-0) !important;
-  color: var(--text) !important;
-  border: 1px solid var(--border-strong) !important;
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-2) !important;
-}
-
-/* Menu items + hovers, keep contrast without introducing new hues */
-#recipes-page .settings-menu .menu-item,
-#recipes-page .settings-panel .menu-item,
-#recipes-page .settings-dropdown .menu-item {
-  background: transparent;
-  color: var(--text);
-  border-radius: 10px;
-}
-
-#recipes-page .settings-menu .menu-item:hover,
-#recipes-page .settings-panel .menu-item:hover,
-#recipes-page .settings-dropdown .menu-item:hover {
-  background: var(--layer-1);
+#recipes-page .nav-chip--tabs .settings-btn,
+#recipes-page .nav-chip--tabs .settings-btn * {
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
 }
 
 /* Switches/inputs inside the panel stay neutral and accessible */


### PR DESCRIPTION
## Summary
- restructure the recipes header so the tabs sit in a single chip alongside the settings gear
- apply consistent chip styling for the tabs, filters, and actions controls and update the gear treatment
- ensure the settings panel inherits the page background and legacy wrappers stay transparent

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e3dd2421c48325aaac11bc50b8ab81