### PR TITLE
Refine recipes tabs chip seams and gear sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,13 @@
     <div class="app-shell" id="recipes-page">
       <header class="topbar">
         <div class="topbar__row">
-          <nav class="nav-chip nav-chip--tabs" id="primary-nav" aria-label="Primary">
-            <div class="tabs-list view-toggle">
+          <nav
+            class="nav-chip nav-chip--tabs"
+            id="primary-nav"
+            aria-label="Primary"
+            data-chip="tabs"
+          >
+            <div class="tabs-list">
               <button
                 type="button"
                 class="view-toggle__button tab view-toggle__button--active"
@@ -247,12 +252,14 @@
             id="recipe-family-filter"
             hidden
             aria-hidden="true"
+            data-chip="filters"
           ></div>
           <div
             class="nav-chip nav-chip--actions"
             id="recipe-action-chip"
             role="group"
             aria-label="Recipe quick actions"
+            data-chip="actions"
           >
             <button
               type="button"

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -8314,6 +8314,35 @@
       return;
     }
 
+    const chips = headerRow.querySelectorAll('.nav-chip');
+    if (chips[0]) {
+      chips[0].setAttribute('data-chip', 'tabs');
+    }
+    if (chips[1]) {
+      chips[1].setAttribute('data-chip', 'filters');
+    }
+    if (chips[2]) {
+      chips[2].setAttribute('data-chip', 'actions');
+    }
+
+    const tabsChip = headerRow.querySelector('[data-chip="tabs"]') || chips[0] || null;
+    if (tabsChip) {
+      let tabsList = tabsChip.querySelector('.tabs-list');
+      if (!tabsList) {
+        tabsList = document.createElement('div');
+        tabsList.className = 'tabs-list';
+        const tabButtons = Array.from(tabsChip.querySelectorAll('button.tab, a.tab'));
+        tabButtons.forEach((button) => tabsList.appendChild(button));
+        tabsChip.insertBefore(tabsList, tabsChip.firstChild || null);
+      }
+
+      const gear = tabsChip.querySelector('.settings-btn');
+      if (gear) {
+        gear.classList.add('settings-btn');
+        gear.classList.remove('icon-btn', 'tab');
+      }
+    }
+
     const quickFilters =
       document.querySelector('#quick-filters') ||
       document.querySelector('.quick-filters');
@@ -8322,6 +8351,7 @@
       if (controls.length) {
         const chip = document.createElement('div');
         chip.className = 'nav-chip nav-chip--filters';
+        chip.setAttribute('data-chip', 'filters');
         controls.forEach((control) => {
           control.classList.add('icon-btn');
         });

--- a/styles/app.css
+++ b/styles/app.css
@@ -4419,3 +4419,131 @@ textarea:focus {
   background: var(--chip-bg) !important;
   color: var(--chip-fg) !important;
 }
+/* ================= LOCK THE LEFT CHIP SIZE ================= */
+#recipes-page [data-chip="tabs"]{
+  flex: 0 0 auto !important;          /* never grow/shrink */
+  width: auto !important;
+  max-width: none !important;
+  background: var(--layer-2);
+  border: 2px solid var(--border-strong);
+  border-radius: 999px;
+  padding: .25rem .5rem;
+  gap: .5rem;
+  align-items: center;
+}
+#recipes-page [data-chip="tabs"] .tabs-list{
+  display: flex; gap: 0;
+  flex: 0 0 auto !important;          /* stop flex:1 from libs */
+  width: auto !important;
+  align-items: center;
+  flex-wrap: nowrap;
+  border-radius: 999px;
+  overflow: hidden;
+}
+#recipes-page [data-chip="tabs"] .tabs-list .tab{
+  inline-size: auto;
+  block-size: 32px;                    /* align with icon chip controls */
+  padding: 0 .95rem;
+  display: inline-flex; align-items: center; justify-content: center;
+  margin: 0; position: relative; z-index: 1;
+  border-radius: 0;
+}
+#recipes-page [data-chip="tabs"] .tabs-list .tab + .tab{ margin-left: -1px; }  /* overlap only BETWEEN tabs */
+#recipes-page [data-chip="tabs"] .tabs-list .tab:first-child{
+  border-top-left-radius: 999px;
+  border-bottom-left-radius: 999px;
+}
+#recipes-page [data-chip="tabs"] .tabs-list .tab:last-child{
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
+}
+
+/* ================= PURE GEAR ICON (no pill/outline) ==================== */
+#recipes-page [data-chip="tabs"] .settings-btn{
+  all: unset;                          /* obliterate inherited pill chrome */
+  display: inline-flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  margin-left: .5rem;                  /* spacing away from overlapped tabs */
+  inline-size: 32px;
+  block-size: 32px;
+  min-inline-size: 32px;
+  min-block-size: 32px;
+  list-style: none;
+}
+#recipes-page [data-chip="tabs"] .settings-btn::-webkit-details-marker{ display: none; }
+#recipes-page [data-chip="tabs"] .settings-btn:focus,
+#recipes-page [data-chip="tabs"] .settings-btn:focus-visible{ outline: none; }
+#recipes-page [data-chip="tabs"] .settings-btn::before,
+#recipes-page [data-chip="tabs"] .settings-btn::after{ content: none !important; }
+
+/* Gear visual itself: teeth = page bg (black in dark), hole = chip red */
+#recipes-page [data-chip="tabs"] .settings-btn svg{
+  width: 20px; height: 20px; display: block;
+  fill: var(--layer-0) !important; stroke: none !important; filter: none !important;
+  transition: transform .15s ease;
+}
+#recipes-page [data-chip="tabs"] .settings-btn svg .gear-hole{ fill: var(--layer-2) !important; }
+#recipes-page [data-chip="tabs"] .settings-btn:hover svg{ transform: rotate(12deg); }
+
+/* If some library re-adds .icon-btn styles to the gear, neutralize them */
+#recipes-page [data-chip="tabs"] .icon-btn.settings-btn{ all: unset !important; display: inline-flex !important; }
+#recipes-page [data-chip="tabs"] .settings-btn *{ background: transparent !important; border: 0 !important; box-shadow: none !important; }
+
+/* ================= MATCH CHIP HEIGHTS (filters/actions) ================ */
+#recipes-page [data-chip="filters"],
+#recipes-page [data-chip="actions"]{
+  display: flex; align-items: center;
+  background: var(--layer-2);
+  border: 2px solid var(--border-strong);
+  border-radius: 999px;
+  padding: .25rem .5rem;
+  gap: .5rem;
+  flex: 0 0 auto;
+}
+#recipes-page [data-chip="filters"] .icon-btn,
+#recipes-page [data-chip="actions"] .icon-btn{
+  inline-size: 32px; block-size: 32px; padding: 0; display: grid; place-items: center;
+}
+
+/* Matte style for TABS & real icon buttons (NOT the gear) */
+#recipes-page .nav-chip .tab,
+#recipes-page .nav-chip .icon-btn{
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab, var(--layer-0), white 22%);
+  background:
+    linear-gradient(to bottom,
+      color-mix(in oklab, var(--layer-0), white 8%) 0%,
+      color-mix(in oklab, var(--layer-0), black 2%) 100%);
+  color: var(--text);
+  box-shadow: inset 0 1px 0 color-mix(in oklab, var(--layer-0), white 10%), 0 1px 1px rgba(0,0,0,.25);
+  transition: background .15s, border-color .15s, transform .06s;
+}
+
+/* ================= CLEAR STRAY BACKGROUNDS AROUND CHIPS ================= */
+#recipes-page .topbar{ background: var(--layer-0) !important; border: 0 !important; box-shadow: none !important; padding: .5rem .75rem !important; }
+#recipes-page .topbar__row{ display: flex; align-items: center; gap: .75rem; flex-wrap: wrap; background: transparent !important; border: 0 !important; }
+#recipes-page .toolbar, #recipes-page .header-shelf, #recipes-page .chip-shelf,
+#recipes-page .quick-filters, #recipes-page .actions-mini,
+#recipes-page .quick-filters > *, #recipes-page .actions-mini > *{
+  background: transparent !important; border: 0 !important; box-shadow: none !important; padding: 0 !important;
+}
+
+/* ================= SETTINGS MENU PANEL BACKGROUND ====================== */
+#recipes-page .settings-menu,
+#recipes-page .settings-panel,
+#recipes-page .settings-dropdown,
+#recipes-page .settings-popover,
+#recipes-page [role="menu"].settings,
+#recipes-page .popover.settings,
+#recipes-page .dropdown-menu.settings{
+  background: var(--layer-0) !important;     /* page background */
+  color: var(--text) !important;
+  border: 1px solid var(--border-strong) !important;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-2) !important;
+}
+#recipes-page .settings-menu .menu-item:hover,
+#recipes-page .settings-panel .menu-item:hover,
+#recipes-page .settings-dropdown .menu-item:hover{
+  background: var(--layer-1);
+}


### PR DESCRIPTION
## Summary
- clip the recipes tabs list to a rounded container so adjacent buttons show straight edges with no background bleed
- normalize the tab button border radii so interior seams are vertical while preserving rounded outer corners
- lock the settings gear trigger to the same 32px footprint as neighboring controls while keeping the icon-only treatment

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3e7fde4e88325875384134011f31c