### PR TITLE
Adjust header chip layout and tab styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,39 +11,7 @@
     <div class="app-shell" id="recipes-page">
       <header class="topbar">
         <div class="topbar__row">
-          <nav
-            class="nav-chip nav-chip--tabs"
-            id="primary-nav"
-            aria-label="Primary"
-            data-chip="tabs"
-          >
-            <div class="tabs-list">
-              <button
-                type="button"
-                class="view-toggle__button tab view-toggle__button--active"
-                data-view-target="meals"
-                aria-current="page"
-              >
-                Recipes
-              </button>
-              <button type="button" class="view-toggle__button tab" data-view-target="kitchen">
-                Kitchen
-              </button>
-              <button type="button" class="view-toggle__button tab" data-view-target="pantry">
-                Pantry
-              </button>
-              <button type="button" class="view-toggle__button tab" data-view-target="meal-plan">
-                Meal Plan
-              </button>
-              <button
-                type="button"
-                class="view-toggle__button tab"
-                data-view-target="family"
-                id="family-button"
-              >
-                Family
-              </button>
-            </div>
+          <div class="nav-chip nav-chip--settings" data-chip="settings">
             <details class="settings-panel nav-chip__settings" id="settings-panel">
               <summary
                 class="settings-panel__summary settings-btn"
@@ -246,6 +214,40 @@
                 </div>
               </div>
             </details>
+          </div>
+          <nav
+            class="nav-chip nav-chip--tabs"
+            id="primary-nav"
+            aria-label="Primary"
+            data-chip="tabs"
+          >
+            <div class="tabs-list">
+              <button
+                type="button"
+                class="view-toggle__button tab view-toggle__button--active"
+                data-view-target="meals"
+                aria-current="page"
+              >
+                Recipes
+              </button>
+              <button type="button" class="view-toggle__button tab" data-view-target="kitchen">
+                Kitchen
+              </button>
+              <button type="button" class="view-toggle__button tab" data-view-target="pantry">
+                Pantry
+              </button>
+              <button type="button" class="view-toggle__button tab" data-view-target="meal-plan">
+                Meal Plan
+              </button>
+              <button
+                type="button"
+                class="view-toggle__button tab"
+                data-view-target="family"
+                id="family-button"
+              >
+                Family
+              </button>
+            </div>
           </nav>
           <div
             class="nav-chip nav-chip--filters recipe-family-filter"

--- a/styles/app.css
+++ b/styles/app.css
@@ -4520,8 +4520,8 @@ textarea:focus {
 }
 
 /* ================= CLEAR STRAY BACKGROUNDS AROUND CHIPS ================= */
-#recipes-page .topbar{ background: var(--layer-0) !important; border: 0 !important; box-shadow: none !important; padding: .5rem .75rem !important; }
-#recipes-page .topbar__row{ display: flex; align-items: center; gap: .75rem; flex-wrap: wrap; background: transparent !important; border: 0 !important; }
+#recipes-page .topbar{ background: var(--layer-0) !important; border: 0 !important; box-shadow: none !important; padding: 0 .75rem !important; height: 50px; }
+#recipes-page .topbar__row{ display: flex; align-items: stretch; gap: .75rem; flex-wrap: nowrap; background: transparent !important; border: 0 !important; height: 100%; overflow-x: auto; }
 #recipes-page .toolbar, #recipes-page .header-shelf, #recipes-page .chip-shelf,
 #recipes-page .quick-filters, #recipes-page .actions-mini,
 #recipes-page .quick-filters > *, #recipes-page .actions-mini > *{
@@ -4550,44 +4550,76 @@ textarea:focus {
 
 /* ===== height baseline so left chip matches others ===== */
 :root {
-  --chip-h: 42px;
+  --chip-h: 50px;
+}
+
+#recipes-page .topbar__row > * {
+  height: 100%;
+}
+
+#recipes-page .topbar .nav-chip {
+  height: 100%;
+  padding-block: 0;
 }
 
 #recipes-page [data-chip="tabs"] {
-  padding: 0.25rem 0.5rem;
-  gap: 0.5rem;
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
 }
 
 #recipes-page [data-chip="tabs"] .tabs-list {
   display: flex;
   gap: 0;
+  height: 100%;
+  width: 100%;
 }
 
 #recipes-page [data-chip="tabs"] .tabs-list .tab {
-  height: var(--chip-h);
+  height: 100%;
   padding: 0 0.95rem;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
   margin: 0;
   position: relative;
   z-index: 1;
+  border-radius: 0;
+  flex: 1 1 auto;
 }
 
 #recipes-page [data-chip="tabs"] .tabs-list .tab + .tab {
   margin-left: -1px;
 }
 
+#recipes-page [data-chip="tabs"] .tabs-list .tab:first-child {
+  border-top-left-radius: 999px;
+  border-bottom-left-radius: 999px;
+}
+
+#recipes-page [data-chip="tabs"] .tabs-list .tab:last-child {
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
+}
+
 /* ===== reset <details> container inside chip (no bg box!) ===== */
+#recipes-page .nav-chip--settings {
+  padding: 0;
+  width: 50px;
+  justify-content: center;
+}
+
 #recipes-page .nav-chip__settings {
   background: transparent !important;
   border: 0 !important;
   padding: 0 !important;
-  margin-left: 0.5rem;
+  margin-left: 0;
   position: relative;
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  height: var(--chip-h);
+  justify-content: center;
+  height: 100%;
+  width: 100%;
 }
 
 /* remove default marker/bullet from summary */
@@ -4602,12 +4634,11 @@ textarea:focus {
 /* ===== PURE gear trigger: no pill, no outline ===== */
 #recipes-page .nav-chip__settings > summary.settings-btn {
   all: unset;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  display: grid;
+  place-items: center;
   cursor: pointer;
-  width: 20px;
-  height: 20px;
+  width: 100%;
+  height: 100%;
 }
 
 #recipes-page .nav-chip__settings > summary:focus,


### PR DESCRIPTION
## Summary
- move the settings gear into a dedicated leftmost chip in the top header
- enforce a 50px height for the header chips and square off the adjacent recipe tab buttons

## Testing
- not run (static changes)

------
https://chatgpt.com/codex/tasks/task_e_68e48091aab08325845aa9b02611a26a