### PR TITLE
Annotate layer depths and diversify layer palette

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -3,6 +3,21 @@
   const recipes = Array.isArray(window.BLISSFUL_RECIPES) ? window.BLISSFUL_RECIPES : [];
   const ingredients = Array.isArray(window.BLISSFUL_INGREDIENTS) ? window.BLISSFUL_INGREDIENTS : [];
 
+  const assignLayerAttributes = (node, depth = 1) => {
+    if (!node || node.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
+    node.setAttribute('data-layer', depth);
+    const nextDepth = depth + 1;
+    for (const child of node.children) {
+      assignLayerAttributes(child, nextDepth);
+    }
+  };
+
+  if (document?.documentElement) {
+    assignLayerAttributes(document.documentElement, 1);
+  }
+
   if (!recipes.length || !ingredients.length) {
     console.error('Blissful Reverie data could not be loaded.');
     return;

--- a/styles/app.css
+++ b/styles/app.css
@@ -6,8 +6,8 @@
   color-scheme: light;
 
   /* Core */
-  --neutral: #121314;
-  --brand: #7A2236;
+  --neutral: #05060F;
+  --brand: #5F0F40;
   --accent-1: #C2B280;
   --accent-2: #8DA397;
 
@@ -16,11 +16,11 @@
   --text-muted: #D0D5DA;
   --text-inverse: #111315;
 
-  /* LAYERS (distance from bg) */
+  /* LAYERS (distance from bg, intentionally contrasting) */
   --layer-0: var(--neutral);
-  --layer-1: color-mix(in oklab, var(--neutral), white 6%);
+  --layer-1: #0F3D3E;
   --layer-2: var(--brand);
-  --layer-3: color-mix(in oklab, var(--brand), black 8%);
+  --layer-3: #6A3D13;
 
   /* Borders (may NEVER match adjacent fill) */
   --border-strong: var(--accent-2);
@@ -4192,10 +4192,10 @@ textarea:focus {
   --text-muted: #C8CED3;
   --text-inverse: #0E1012;
 
-  --layer-0: #0E0F11;
-  --layer-1: #15171A;
-  --layer-2: #651C2C;
-  --layer-3: #541725;
+  --layer-0: #03070D;
+  --layer-1: #0D3246;
+  --layer-2: #4A123F;
+  --layer-3: #7A3F12;
 
   --border-strong: #7E9E93;
   --border-soft: #6B8C81;


### PR DESCRIPTION
## Summary
- assign a computed data-layer attribute to every element so nested objects expose their depth
- refresh the layer color tokens for light and dark themes so adjacent tiers use contrasting hues

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e820e7bef88325bb40a79e8a17c23e