### PR TITLE
Fix settings gear placement and stabilize primary nav chip

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
       <header class="topbar">
         <div class="topbar__row">
           <div class="nav-chip nav-chip--settings" data-chip="settings">
+            <svg class="nav-chip__settings-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M19.14 12.94a7.9 7.9 0 0 0 .05-.94 7.9 7.9 0 0 0-.05-.94l2.02-1.57a.6.6 0 0 0 .14-.77l-1.91-3.3a.6.6 0 0 0-.72-.27l-2.38.96a7.53 7.53 0 0 0-1.63-.95l-.36-2.54A.6.6 0 0 0 13.1 1h-3.2a.6.6 0 0 0-.59.52l-.36 2.54c-.58.24-1.13.55-1.63.95l-2.38-.96a.6.6 0 0 0-.72.27L2.31 8.12a.6.6 0 0 0 .14.77l2.02 1.57c-.03.31-.05.62-.05.94s.02.63.05.94L2.45 14.9a.6.6 0 0 0-.14.77l1.91 3.3c.16.28.5.4.8.27l2.38-.96c.5.4 1.05.71 1.63.95l.36 2.54c.05.29.3.53.59.53h3.2c.29 0 .54-.24.59-.53l.36-2.54c.58-.24 1.13-.55 1.63-.95l2.38.96c.3.13.64.01.8-.27l1.91-3.3a.6.6 0 0 0-.14-.77l-2.02-1.57Z"
+              />
+              <circle class="gear-hole" cx="12" cy="12" r="3.2" />
+            </svg>
             <details class="settings-panel nav-chip__settings" id="settings-panel">
               <summary
                 class="settings-panel__summary settings-btn"
@@ -19,12 +25,7 @@
                 aria-haspopup="true"
                 title="Display and unit settings"
               >
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <path
-                    d="M19.14 12.94a7.9 7.9 0 0 0 .05-.94 7.9 7.9 0 0 0-.05-.94l2.02-1.57a.6.6 0 0 0 .14-.77l-1.91-3.3a.6.6 0 0 0-.72-.27l-2.38.96a7.53 7.53 0 0 0-1.63-.95l-.36-2.54A.6.6 0 0 0 13.1 1h-3.2a.6.6 0 0 0-.59.52l-.36 2.54c-.58.24-1.13.55-1.63.95l-2.38-.96a.6.6 0 0 0-.72.27L2.31 8.12a.6.6 0 0 0 .14.77l2.02 1.57c-.03.31-.05.62-.05.94s.02.63.05.94L2.45 14.9a.6.6 0 0 0-.14.77l1.91 3.3c.16.28.5.4.8.27l2.38-.96c.5.4 1.05.71 1.63.95l.36 2.54c.05.29.3.53.59.53h3.2c.29 0 .54-.24.59-.53l.36-2.54c.58-.24 1.13-.55 1.63-.95l2.38.96c.3.13.64.01.8-.27l1.91-3.3a.6.6 0 0 0-.14-.77l-2.02-1.57Z"
-                  />
-                  <circle class="gear-hole" cx="12" cy="12" r="3.2" />
-                </svg>
+                <span class="sr-only">Display and unit settings</span>
               </summary>
               <div class="settings-panel__content settings-menu">
                 <div class="theme-toolbar" id="theme-toolbar">

--- a/styles/app.css
+++ b/styles/app.css
@@ -420,8 +420,8 @@ select {
 }
 
 #recipes-page .topbar__row > .nav-chip--tabs {
-  flex: 1 1 20rem;
-  min-inline-size: min(100%, 18rem);
+  flex: 0 0 auto;
+  margin-inline-end: auto;
 }
 
 /* Header row: invisible container, consistent spacing */
@@ -4604,22 +4604,40 @@ textarea:focus {
 
 /* ===== reset <details> container inside chip (no bg box!) ===== */
 #recipes-page .nav-chip--settings {
-  padding: 0;
-  width: 50px;
-  justify-content: center;
+  position: relative;
+  display: grid;
+  place-items: center;
+  padding: 0.25rem;
+  inline-size: 2.75rem;
+  min-inline-size: 2.75rem;
+}
+
+#recipes-page .nav-chip--settings .nav-chip__settings-icon {
+  width: 20px;
+  height: 20px;
+  display: block;
+  fill: var(--layer-0) !important;
+  stroke: none !important;
+  filter: none !important;
+  transition: transform 0.15s ease;
+}
+
+#recipes-page .nav-chip--settings .nav-chip__settings-icon .gear-hole {
+  fill: var(--layer-2) !important;
+}
+
+#recipes-page .nav-chip--settings:hover .nav-chip__settings-icon,
+#recipes-page .nav-chip--settings:focus-within .nav-chip__settings-icon {
+  transform: rotate(12deg);
 }
 
 #recipes-page .nav-chip__settings {
   background: transparent !important;
   border: 0 !important;
   padding: 0 !important;
-  margin-left: 0;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  width: 100%;
+  margin: 0;
+  position: absolute;
+  inset: 0;
 }
 
 /* remove default marker/bullet from summary */
@@ -4634,35 +4652,20 @@ textarea:focus {
 /* ===== PURE gear trigger: no pill, no outline ===== */
 #recipes-page .nav-chip__settings > summary.settings-btn {
   all: unset;
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  width: 100%;
-  height: 100%;
-}
-
-#recipes-page .nav-chip__settings > summary:focus,
-#recipes-page .nav-chip__settings > summary:focus-visible {
-  outline: none !important;
-}
-
-/* The gear itself: black on red chip; center hole shows chip red */
-#recipes-page .nav-chip__settings .settings-btn svg {
-  width: 20px;
-  height: 20px;
+  position: absolute;
+  inset: 0;
   display: block;
-  fill: var(--layer-0) !important;
-  stroke: none !important;
-  filter: none !important;
-  transition: transform 0.15s ease;
+  cursor: pointer;
+  border-radius: inherit;
 }
 
-#recipes-page .nav-chip__settings .settings-btn svg .gear-hole {
-  fill: var(--layer-2) !important;
+#recipes-page .nav-chip__settings > summary:focus {
+  outline: none;
 }
 
-#recipes-page .nav-chip__settings .settings-btn:hover svg {
-  transform: rotate(12deg);
+#recipes-page .nav-chip__settings > summary:focus-visible {
+  outline: 2px solid var(--border-strong);
+  outline-offset: 3px;
 }
 
 /* Defensive: nuke any inherited pill styles from libs/classes */
@@ -4751,30 +4754,28 @@ textarea:focus {
 
 /* === PURE GEAR (inside <details>) — NO pill, NO outline/background === */
 #recipes-page .nav-chip__settings{
-  background: transparent !important; border: 0 !important; padding: 0 !important;
-  display:inline-flex; align-items:center; height: var(--chip-h);
-  margin-left:.5rem; /* space away from overlapped tabs */
+  background: transparent !important;
+  border: 0 !important;
+  padding: 0 !important;
+  margin: 0;
+  position: absolute;
+  inset: 0;
 }
 #recipes-page .nav-chip__settings > summary::-webkit-details-marker{ display:none; }
 #recipes-page .nav-chip__settings > summary{ list-style:none; }
 
 #recipes-page .nav-chip__settings > summary.settings-btn{
-  all: unset;                                   /* obliterate inherited button styles */
-  display:inline-flex; align-items:center; justify-content:center;
+  all: unset;
+  position: absolute;
+  inset: 0;
+  display:block;
   cursor:pointer;
-  inline-size: 20px; block-size: 20px;          /* visible size; hit area from chip height */
+  border-radius: inherit;
 }
-#recipes-page .nav-chip__settings > summary:focus,
-#recipes-page .nav-chip__settings > summary:focus-visible{ outline:none !important; }
+#recipes-page .nav-chip__settings > summary:focus{ outline:none; }
+#recipes-page .nav-chip__settings > summary:focus-visible{ outline:2px solid var(--border-strong); outline-offset:3px; }
 
-/* Gear visual: teeth = page bg; center hole = chip red */
-#recipes-page .nav-chip__settings .settings-btn svg{
-  width: 20px; height: 20px; display:block;
-  fill: var(--layer-0) !important; stroke:none !important; filter:none !important;
-  transition: transform .15s ease;
-}
-#recipes-page .nav-chip__settings .settings-btn svg .gear-hole{ fill: var(--layer-2) !important; }
-#recipes-page .nav-chip__settings .settings-btn:hover svg{ transform: rotate(12deg); }
+/* Gear visual handled by .nav-chip__settings-icon on the chip container */
 
 /* In case some lib/class re-applies pill chrome to the gear, nuke it */
 #recipes-page .nav-chip__settings .icon-btn,


### PR DESCRIPTION
## Summary
- render the settings gear SVG as a direct child of the top bar settings chip so the icon sits on the chip itself
- overlay the summary trigger to keep the panel accessible while rotating the gear on hover/focus and ensuring keyboard focus styling
- stop the primary tabs chip from stretching by removing flex growth and letting surrounding spacing absorb layout changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e91ba506248325aad36b4a3b6813fb