### PR TITLE
Set primary nav button height to 32px

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -4153,6 +4153,7 @@ textarea:focus {
   justify-content: center;
   border: 1px solid var(--border-1);
   border-radius: 999px;
+  height: 32px;
   padding: 0.45rem 1.15rem;
   background: var(--surface-0);
   color: var(--text);


### PR DESCRIPTION
## Summary
- set the primary navigation view toggle buttons to a fixed height of 32px to keep them vertically centered on their chip

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e93db717b88325bcbb4bd280364fed