### PR TITLE
Integrate local-first meal planning productivity features

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,18 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - codex/**
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,42 +1,82 @@
 # Blissful Reverie Meal Planner
 
-Blissful Reverie is a self-contained web-based meal planning workspace focused on ingredient discovery and pantry-driven cooking. Open `index.html` in any modern browser to explore recipes without installing dependencies or running a local server.
+Blissful Reverie is a static, local-first meal planning workspace. It runs entirely in the browser with no backend, account, or build step.
 
-## Features
+## Setup
 
-- **Card-based recipes** with adjustable serving sizes, detailed ingredients, instructions, nutrition, equipment, and allergen notes.
-- **Extensive library** of 72 savoury meals (12 each for chicken, turkey, beef, and pork) plus 24 desserts spanning common tags such as breakfast, lunch, dinner, pasta, soup, sandwich, low-sodium, dairy, no-dairy, and gluten free.
-- **Dynamic filters** for full-text search, tags, allergens, required equipment, and ingredient include/exclude rules.
-- **Pantry assistant** to maintain a virtual pantry, surface cookable meals, and optionally limit the recipe grid to only what you can make right now.
-- **Ingredient atlas** for browsing canonical pantry items with allergen tags, categories, and dietary filters.
-- **Personal notes** saved on every card to capture timing adjustments, guest feedback, or plating ideas.
+1. Clone or download the repository.
+2. Open `index.html` in a modern browser.
 
-## Using the planner
+For a local HTTP server instead of `file://`, run:
 
-1. Download or clone this repository.
-2. Double-click `index.html` (or open it with any modern browser such as Chrome, Edge, Firefox, or Safari).
-3. Start browsing recipes, add pantry items, and filter the library—everything runs entirely in the browser.
-
-## Project structure
-
-```
-index.html          Main application shell that loads the static experience
-styles/app.css      Global styling for the dashboard and directory
-scripts/app.js      Vanilla JavaScript powering interactivity and state management
-data/ingredients.js Ingredient directory data exposed as a browser global
-data/recipes.js     Full recipe catalogue with metadata and nutrition
+```powershell
+python -m http.server 8000
 ```
 
-## Dataset guidelines
+Then open `http://localhost:8000`.
 
-- Ingredient metadata lives in `data/ingredients.js`. Each entry stays on a single line with `slug`, `name`, `category`, and `tags` fields.
-- Categories should come from the shared set used throughout the planner (Pasta, Dairy, Meat, Seafood, Herb, Spice, Vegetable, Fruit, Nut/Seed, Grain, Legume, Oil/Fat, Sweetener, Baking, Condiment/Sauce, Beverage).
-- Tags capture allergen and dietary hints (e.g., `Gluten-Free`, `Contains Nuts`, `Vegan`). Add new tags sparingly so filters remain focused.
+The repository has no production dependencies and does not require `npm install`.
 
-### Extending the planner
+## Checks
 
-- Add new recipes by updating `data/recipes.js`. Each recipe supports a base serving size that is used to scale ingredients and nutrition totals on the fly.
-- Grow the ingredient directory by editing `data/ingredients.js`. Keep entries on a single line and reuse existing tags when possible.
-- For complex filtering or additional metadata, enhance the logic in `scripts/app.js`.
+Run the complete validation and test suite:
 
-Enjoy planning blissful meals!
+```powershell
+npm test
+```
+
+Run only catalog validation:
+
+```powershell
+npm run validate:data
+```
+
+Focused checks are also available:
+
+```powershell
+npm run test:validation
+npm run test:matching
+npm run test:pantry
+npm run test:productivity
+npm run test:wiring
+```
+
+## Architecture
+
+- `index.html` defines the application shell and loads scripts in dependency order.
+- `data/ingredients.js` and `data/recipes.js` expose the static catalogs as browser globals.
+- `scripts/ingredient-matching.js` maps recipe ingredient text to canonical ingredient slugs.
+- `scripts/productivity-tools.js` contains testable pantry, shopping-list, backup, dashboard, source-label, and starter-state helpers.
+- `scripts/productivity-ui.js` renders badges, the pantry dashboard, and the smart shopping list from live state supplied by `scripts/app.js`.
+- `scripts/productivity-onboarding.js` handles first-run setup and applies saved starter state without a normal reload.
+- `scripts/productivity-settings.js` moves optional palette and holiday controls into the native `Advanced appearance` disclosure before app event handlers are bound.
+- `scripts/app.js` owns in-memory state, localStorage persistence, recipe rendering, filters, pantry, family, and meal planning.
+
+User data remains in browser localStorage. The primary state key is `blissful-app-state`; meal plans, favorites, theme preferences, holiday settings, and measurement preferences use separate version-stable keys. There is no network synchronization.
+
+## Data Schema
+
+Ingredient entries require:
+
+- a stable lowercase hyphenated `slug`
+- a non-empty `name`
+- a supported `category`
+- a `tags` array
+- an optional `aliases` array
+
+Do not rename existing ingredient slugs without a localStorage migration. Supported category values are centralized in `scripts/data-validation.js`.
+
+Recipe entries require:
+
+- a unique lowercase hyphenated `id`
+- a unique `name`
+- positive `baseServings`
+- non-empty `ingredients` and `instructions`
+- `equipment`, `tags`, and canonical `allergens` arrays
+- non-negative calories, protein, carbohydrates, and fat per serving
+
+The app also creates ingredient-coverage and collection recipes at runtime. Source badges distinguish curated recipes, generated templates, and ingredient ideas.
+
+## Extending The Planner
+
+Add catalog data directly to the relevant file and run `npm test`. Keep ingredient slugs stable, avoid duplicate display names, use canonical allergen values (`fish` or `shellfish` rather than `seafood`), and extend validation before introducing a new schema value.

--- a/data/ingredients.js
+++ b/data/ingredients.js
@@ -15,6 +15,12 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'pasta-farfalle', name: 'Farfalle', category: 'Pasta', tags: ['Contains Gluten', 'Vegetarian'] },
   { slug: 'pasta-lasagna-noodles', name: 'Lasagna Noodles', category: 'Pasta', tags: ['Contains Gluten', 'Vegetarian'] },
   { slug: 'pasta-orzo', name: 'Orzo', category: 'Pasta', tags: ['Contains Gluten', 'Vegetarian'] },
+  { slug: 'pasta-ramen', name: 'Ramen Noodles', category: 'Pasta', tags: ['Contains Gluten', 'Vegetarian'] },
+  { slug: 'pasta-gnocchi', name: 'Potato Gnocchi', category: 'Pasta', tags: ['Contains Gluten', 'Vegetarian'] },
+  { slug: 'pasta-orecchiette', name: 'Orecchiette', category: 'Pasta', tags: ['Contains Gluten', 'Vegetarian'] },
+  { slug: 'pasta-shells', name: 'Pasta Shells', category: 'Pasta', tags: ['Contains Gluten', 'Vegetarian'] },
+  { slug: 'pasta-jumbo-shells', name: 'Jumbo Pasta Shells', category: 'Pasta', tags: ['Contains Gluten', 'Vegetarian'] },
+  { slug: 'pasta-rigatoni', name: 'Rigatoni', category: 'Pasta', tags: ['Contains Gluten', 'Vegetarian'] },
 
   // Dairy
   { slug: 'dairy-butter-unsalted', name: 'Butter (Unsalted)', category: 'Dairy', tags: ['Contains Dairy', 'Vegetarian'] },
@@ -89,8 +95,10 @@ window.BLISSFUL_INGREDIENTS = [
   },
 
   // Meat (raw single-ingredient; suitability tags are general)
-  { slug: 'meat-beef-ground-85', name: 'Ground Beef (85% Lean)', category: 'Meat', tags: ['Halal-Friendly', 'Kosher-Friendly', 'Paleo'] },
+  { slug: 'meat-beef-ground-85', name: 'Ground Beef (85% Lean)', category: 'Meat', tags: ['Halal-Friendly', 'Kosher-Friendly', 'Paleo'], aliases: ['Lean Ground Beef', 'Ground Beef'] },
   { slug: 'meat-beef-steak-ribeye', name: 'Beef Ribeye', category: 'Meat', tags: ['Halal-Friendly', 'Kosher-Friendly', 'Paleo'] },
+  { slug: 'meat-beef-flank-steak', name: 'Beef Flank Steak', category: 'Meat', tags: ['Halal-Friendly', 'Kosher-Friendly', 'Paleo'] },
+  { slug: 'meat-beef-sirloin-steak', name: 'Beef Sirloin Steak', category: 'Meat', tags: ['Halal-Friendly', 'Kosher-Friendly', 'Paleo'] },
   { slug: 'meat-chicken-breast', name: 'Chicken Breast', category: 'Meat', tags: ['Halal-Friendly', 'Kosher-Friendly', 'Paleo'] },
   { slug: 'meat-chicken-thigh', name: 'Chicken Thigh', category: 'Meat', tags: ['Halal-Friendly', 'Kosher-Friendly', 'Paleo'] },
   { slug: 'meat-pork-chop', name: 'Pork Chop', category: 'Meat', tags: ['Paleo'] },
@@ -163,10 +171,14 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'spice-matcha-powder', name: 'Matcha Powder', category: 'Spice', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
   { slug: 'spice-instant-espresso', name: 'Instant Espresso Powder', category: 'Spice', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
   { slug: 'spice-taco-seasoning', name: 'Taco Seasoning', category: 'Spice', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Nightshade'] },
+  { slug: 'spice-lavender', name: 'Culinary Lavender', category: 'Spice', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
+  { slug: 'spice-nutmeg-whole', name: 'Whole Nutmeg', category: 'Spice', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
+  { slug: 'spice-caraway-seed', name: 'Caraway Seeds', category: 'Spice', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
 
   // Vegetables
   { slug: 'veg-asparagus', name: 'Asparagus', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Low-FODMAP'] },
   { slug: 'veg-bell-pepper-red', name: 'Bell Pepper (Red)', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Nightshade', 'Low-FODMAP'] },
+  { slug: 'veg-bell-pepper', name: 'Bell Pepper', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Nightshade'] },
   { slug: 'veg-broccoli', name: 'Broccoli', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
   { slug: 'veg-carrot', name: 'Carrot', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Low-FODMAP'] },
   { slug: 'veg-cauliflower', name: 'Cauliflower', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Low-FODMAP'] },
@@ -181,6 +193,7 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'veg-kale', name: 'Kale', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
   { slug: 'veg-lettuce-romaine', name: 'Romaine Lettuce', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Low-FODMAP'] },
   { slug: 'veg-mushroom-button', name: 'Button Mushroom', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
+  { slug: 'veg-mushroom', name: 'Mushrooms', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
   { slug: 'veg-onion-yellow', name: 'Onion (Yellow)', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Allium'] },
   { slug: 'veg-pea-frozen', name: 'Peas (Frozen)', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
   { slug: 'veg-potato-russet', name: 'Potato (Russet)', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Nightshade', 'Low-FODMAP'] },
@@ -189,6 +202,8 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'veg-sweet-potato', name: 'Sweet Potato', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Low-FODMAP'] },
   { slug: 'veg-tomato-roma', name: 'Tomato (Roma)', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Nightshade'] },
   { slug: 'veg-zucchini', name: 'Zucchini', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Low-FODMAP'] },
+  { slug: 'veg-pimento', name: 'Pimento Peppers', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Nightshade'] },
+  { slug: 'veg-artichoke', name: 'Artichoke Hearts', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
   { slug: 'veg-brussels-sprouts', name: 'Brussels Sprouts', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
   { slug: 'veg-cabbage-green', name: 'Green Cabbage', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian'] },
   { slug: 'veg-onion-red', name: 'Onion (Red)', category: 'Vegetable', tags: ['Gluten-Free', 'Vegan', 'Vegetarian', 'Allium'] },
@@ -241,6 +256,7 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'grain-quinoa', name: 'Quinoa', category: 'Grain', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'grain-rice-basmati', name: 'Rice (Basmati)', category: 'Grain', tags: ['Gluten-Free', 'Vegetarian', 'Vegan', 'Low-FODMAP'] },
   { slug: 'grain-rice-brown', name: 'Rice (Brown)', category: 'Grain', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
+  { slug: 'grain-rice-cooked', name: 'Cooked Rice', category: 'Grain', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'grain-wheat-flour-ap', name: 'Wheat Flour (All-Purpose)', category: 'Grain', tags: ['Contains Gluten', 'Vegetarian', 'Vegan'] },
   { slug: 'grain-couscous', name: 'Couscous', category: 'Grain', tags: ['Contains Gluten', 'Vegetarian', 'Vegan'] },
   { slug: 'grain-millet', name: 'Millet', category: 'Grain', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
@@ -301,6 +317,7 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'baking-cocoa-powder', name: 'Cocoa Powder', category: 'Baking', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },
   { slug: 'baking-cornstarch', name: 'Cornstarch', category: 'Baking', tags: ['Gluten-Free', 'Vegetarian', 'Vegan', 'Low-FODMAP'] },
   { slug: 'baking-egg', name: 'Eggs', category: 'Baking', tags: ['Contains Eggs'] },
+  { slug: 'baking-sprinkles', name: 'Sprinkles', category: 'Baking', tags: ['Vegetarian'] },
 
   // Baking Alternatives
   {
@@ -371,6 +388,7 @@ window.BLISSFUL_INGREDIENTS = [
   },
   { slug: 'condiment-soy-sauce', name: 'Soy Sauce', category: 'Condiment/Sauce', tags: ['Contains Soy', 'Contains Gluten', 'Vegetarian', 'Vegan'] },
   { slug: 'condiment-tamari-gf', name: 'Tamari (GF)', category: 'Condiment/Sauce', tags: ['Gluten-Free', 'Contains Soy', 'Vegetarian', 'Vegan'] },
+  { slug: 'condiment-wasabi-paste', name: 'Wasabi Paste', category: 'Condiment/Sauce', tags: ['Gluten-Free*', 'Vegetarian', 'Vegan'] },
   { slug: 'condiment-sriracha', name: 'Sriracha', category: 'Condiment/Sauce', tags: ['Gluten-Free*', 'Vegetarian', 'Vegan', 'Nightshade'] },
   { slug: 'condiment-hot-sauce', name: 'Hot Sauce', category: 'Condiment/Sauce', tags: ['Gluten-Free*', 'Vegetarian', 'Vegan', 'Nightshade'] },
   { slug: 'condiment-worcestershire', name: 'Worcestershire Sauce', category: 'Condiment/Sauce', tags: ['Gluten-Free*', 'Contains Fish*', 'Vegetarian*'] }, // many contain anchovy; some are veg/GF
@@ -434,6 +452,7 @@ window.BLISSFUL_INGREDIENTS = [
   { slug: 'baked-empanada-dough', name: 'Empanada Dough Discs', category: 'Baked Goods & Doughs', tags: ['Contains Gluten', 'Vegetarian'] },
   { slug: 'baked-dumpling-wrappers', name: 'Dumpling Wrappers', category: 'Baked Goods & Doughs', tags: ['Contains Gluten', 'Vegetarian'] },
   { slug: 'baked-bao-dough', name: 'Bao Dough', category: 'Baked Goods & Doughs', tags: ['Contains Gluten', 'Vegetarian'] },
+  { slug: 'baked-crackers', name: 'Crackers', category: 'Baked Goods & Doughs', tags: ['Contains Gluten', 'Vegetarian'] },
 
   // Beverages & Mixers (non-stock)
   { slug: 'mix-tonic-water', name: 'Tonic Water', category: 'Beverages & Mixers', tags: ['Gluten-Free', 'Vegetarian', 'Vegan'] },

--- a/data/recipes.js
+++ b/data/recipes.js
@@ -1582,7 +1582,7 @@ window.BLISSFUL_RECIPES = [
     allergens: ['gluten', 'dairy', 'eggs'],
   },
   {
-    id: 'turkey-club-sandwich',
+    id: 'stacked-turkey-club-sandwich',
     name: 'Stacked Turkey Club Sandwich',
     category: 'Turkey',
     description: 'Triple-decker sandwich with roasted turkey, bacon, lettuce, tomato, and aioli.',
@@ -8248,7 +8248,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 6,
       sodium: 1180,
     },
-    allergens: ['gluten', 'dairy', 'seafood'],
+    allergens: ['gluten', 'dairy', 'fish'],
   },
   {
     id: 'steak-and-eggs-skillet',
@@ -8321,7 +8321,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 5,
       sodium: 980,
     },
-    allergens: ['dairy', 'eggs', 'seafood'],
+    allergens: ['dairy', 'eggs', 'shellfish'],
   },
   {
     id: 'loaded-hashbrown-casserole',
@@ -8790,7 +8790,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 3,
       sodium: 660,
     },
-    allergens: ['eggs', 'dairy', 'seafood'],
+    allergens: ['eggs', 'dairy', 'fish'],
   },
   {
     id: 'classic-diner-cheeseburger',
@@ -9198,7 +9198,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 6,
       sodium: 1180,
     },
-    allergens: ['gluten', 'dairy', 'seafood'],
+    allergens: ['gluten', 'dairy', 'fish'],
   },
   {
     id: 'grilled-cheese-tomato-soup-combo',
@@ -10278,7 +10278,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 3,
       sodium: 320,
     },
-    allergens: ['dairy', 'seafood'],
+    allergens: ['dairy', 'fish'],
   },
   {
     id: 'chocolate-covered-pretzel-snack',
@@ -10976,7 +10976,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 2,
       sodium: 640,
     },
-    allergens: ['seafood', 'gluten', 'eggs'],
+    allergens: ['shellfish', 'gluten', 'eggs'],
   },
   {
     id: 'shrimp-cocktail-platter',
@@ -11012,7 +11012,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 9,
       sodium: 860,
     },
-    allergens: ['seafood'],
+    allergens: ['shellfish'],
   },
   {
     id: 'tomato-basil-bruschetta',
@@ -11155,7 +11155,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 4,
       sodium: 640,
     },
-    allergens: ['gluten', 'seafood', 'dairy'],
+    allergens: ['gluten', 'shellfish', 'dairy'],
   },
   {
     id: 'bbq-glazed-meatballs',
@@ -11302,7 +11302,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 4,
       sodium: 680,
     },
-    allergens: ['gluten', 'dairy', 'eggs', 'seafood'],
+    allergens: ['gluten', 'dairy', 'eggs', 'shellfish'],
   },
   {
     id: 'buffalo-chicken-dip',
@@ -11490,7 +11490,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 2,
       sodium: 620,
     },
-    allergens: ['seafood', 'dairy', 'gluten'],
+    allergens: ['shellfish', 'dairy', 'gluten'],
   },
   {
     id: 'seared-ahi-tuna-bites',
@@ -11527,7 +11527,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 2,
       sodium: 480,
     },
-    allergens: ['soy', 'sesame', 'eggs', 'seafood'],
+    allergens: ['soy', 'sesame', 'eggs', 'fish'],
   },
   {
     id: 'korean-bbq-beef-skewers',
@@ -11784,7 +11784,7 @@ window.BLISSFUL_RECIPES = [
       sugar: 0,
       sodium: 620,
     },
-    allergens: ['seafood'],
+    allergens: ['shellfish'],
   },
   {
     id: 'baked-brie-with-jam',

--- a/docs/next-10-product-tasks.md
+++ b/docs/next-10-product-tasks.md
@@ -1,0 +1,28 @@
+# Next 10 product tasks
+
+This document records the implemented state of the recovery roadmap on PR #118.
+
+## Status
+
+1. **Recipe and ingredient schema validation** - implemented with reusable validation in `scripts/data-validation.js` and the `npm run validate:data` CLI.
+2. **Ingredient and pantry matching tests** - implemented across matching, pantry-fit, validation edge-case, productivity, and application-wiring tests.
+3. **Export/import backup** - implemented as tested localStorage backup and restore helpers in `scripts/productivity-tools.js`; a dedicated settings UI remains optional follow-up work.
+4. **Dashboard summary** - implemented above the recipe grid with Cook now, Almost ready, and Shopping candidates groups.
+5. **Missing-ingredient counts** - implemented on recipe cards and dashboard entries using live pantry state and the app substitution graph.
+6. **Shopping list generation** - implemented as a categorized smart shopping panel with recipe references and copy support.
+7. **Add recipe to meal plan from cards** - implemented by the existing calendar action on every recipe card.
+8. **Generated recipe labels** - implemented on recipe cards for curated recipes, generated templates, and ingredient ideas.
+9. **Move theme controls deeper into settings** - implemented with the native keyboard-accessible `Advanced appearance` disclosure. Controls retain their existing IDs and event handlers.
+10. **First-run setup** - implemented for valid missing-state detection, starter pantry/preferences, schema-compatible persistence, and same-page application.
+
+## Integration
+
+The application shell loads data, matching, productivity helpers, settings, onboarding, productivity UI, theme diagnostics, and the main app explicitly in `index.html`.
+
+`scripts/app.js` calls the productivity renderer with live recipes, match maps, substitution data, and pantry state after it renders recipe cards. This avoids mutation observers, duplicate matching indexes, and localStorage polling while keeping the large app shell changes small.
+
+## Follow-up candidates
+
+- Add a visible backup import/export control that uses the existing tested helpers.
+- Let users choose meal-plan recipes as the shopping-list source instead of the current closest-recipe limit.
+- Split additional app-shell domains into tested modules only when a focused feature change requires it.

--- a/docs/stale-branch-audit.md
+++ b/docs/stale-branch-audit.md
@@ -1,0 +1,34 @@
+# Stale branch audit
+
+Date: 2026-06-05
+
+## Scope
+
+PR #56 (`codex/add-missing-ingredients-for-stock-filter`) was reviewed as the stale ingredient-coverage branch while PR #118 remained the active recovery branch.
+
+## Decision
+
+Assimilate useful additive ingredient coverage into PR #118, but do not carry over PR #56's existing-slug renames. Renaming saved pantry slugs without a migration could break localStorage compatibility and ingredient matching.
+
+## Assimilated
+
+The following 19 entries now live directly in `data/ingredients.js` with stable prefixed slugs:
+
+- ramen, gnocchi, orecchiette, pasta shells, jumbo shells, and rigatoni
+- flank steak and sirloin steak
+- cooked rice and crackers
+- generic bell pepper, mushrooms, pimento peppers, and artichoke hearts
+- culinary lavender, whole nutmeg, and caraway seeds
+- wasabi paste and sprinkles
+
+The proposed generic Tamari entry was not added because the catalog already contains `condiment-tamari-gf` (`Tamari (GF)`), which is an obvious duplicate product concept.
+
+## Removed From The Recovery Implementation
+
+- Ingredient data is no longer appended at runtime from `scripts/theme-utils.js`.
+- Product scripts are no longer injected dynamically by theme utilities.
+- No stale slug-renaming changes were copied from PR #56.
+
+## Prune Recommendation
+
+PR #56 can remain closed and its branch can be deleted after confirming no external references depend on it. PR #118 contains the useful additive coverage in maintainable catalog form.

--- a/index.html
+++ b/index.html
@@ -494,6 +494,10 @@
     <script src="data/ingredients.js" defer></script>
     <script src="data/recipes.js" defer></script>
     <script src="scripts/ingredient-matching.js" defer></script>
+    <script src="scripts/productivity-tools.js" defer></script>
+    <script src="scripts/productivity-settings.js" defer></script>
+    <script src="scripts/productivity-onboarding.js" defer></script>
+    <script src="scripts/productivity-ui.js" defer></script>
     <script src="scripts/theme-utils.js" defer></script>
     <script src="scripts/app.js" defer></script>
     <div class="meal-plan-day-modal" id="meal-plan-day-modal" hidden>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "blissful-reverie",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Static local-first meal planning workspace.",
+  "scripts": {
+    "validate:data": "node scripts/validate-data.js",
+    "test:validation": "node tests/data-validation.test.js",
+    "test:matching": "node tests/ingredient-matching.test.js",
+    "test:pantry": "node tests/pantry-matching.test.js",
+    "test:productivity": "node tests/productivity-tools.test.js",
+    "test:wiring": "node tests/integration-wiring.test.js",
+    "test": "npm run validate:data && npm run test:validation && npm run test:matching && npm run test:pantry && npm run test:productivity && npm run test:wiring"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "UNLICENSED"
+}

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -7652,6 +7652,7 @@
   const createMealCard = (recipe) => {
     const card = document.createElement('article');
     card.className = 'meal-card';
+    card.dataset.recipeId = recipe.id;
 
     const filters = ensureMealFilters();
     const substitutionsAllowed = Boolean(filters.substitutionsAllowed);
@@ -8090,6 +8091,19 @@
       empty.appendChild(paragraph);
       elements.mealGrid.appendChild(empty);
     }
+
+    const productivityUi = window.BlissfulProductivityUI;
+    if (productivityUi && typeof productivityUi.render === 'function') {
+      productivityUi.render({
+        recipes,
+        recipeById: recipeLookupById,
+        recipeIngredientMatches,
+        ingredientBySlug,
+        substitutionGraph,
+        pantryInventory: state.pantryInventory,
+        substitutionsAllowed: Boolean(filters.substitutionsAllowed),
+      });
+    }
   };
 
   const setKitchenItemOwned = (itemId, owned) => {
@@ -8322,6 +8336,43 @@
     updateView();
     persistAppState();
   };
+
+  const applyStarterState = (starterState) => {
+    if (!starterState || typeof starterState !== 'object') {
+      return false;
+    }
+
+    const familyMembers = sanitizeFamilyMembers(starterState.familyMembers);
+    state.activeView = AVAILABLE_VIEWS.includes(starterState.activeView)
+      ? starterState.activeView
+      : 'meals';
+    state.familyMembers = familyMembers;
+    state.mealFilters = sanitizeMealFilters(starterState.mealFilters, familyMembers);
+    state.pantryFilters = sanitizePantryFilters(starterState.pantryFilters);
+    state.kitchenFilters = sanitizeKitchenFilters(starterState.kitchenFilters);
+    state.mealPlanViewMode = MEAL_PLAN_VIEW_MODES.includes(starterState.mealPlanViewMode)
+      ? starterState.mealPlanViewMode
+      : DEFAULT_MEAL_PLAN_MODE;
+    state.mealPlanMemberFilter = sanitizeMealPlanMemberFilter(
+      starterState.mealPlanMemberFilter,
+      familyMembers,
+    );
+    state.mealPlanMacroSelection = sanitizeMealPlanMacroSelection(
+      starterState.mealPlanMacroSelection,
+      familyMembers,
+    );
+    state.servingOverrides = sanitizeServingOverrides(starterState.servingOverrides);
+    state.notes = sanitizeNotes(starterState.notes);
+    state.openNotes = sanitizeOpenNotes(starterState.openNotes);
+    state.pantryInventory = sanitizePantryInventory(starterState.pantryInventory);
+    state.kitchenInventory = sanitizeKitchenInventory(starterState.kitchenInventory);
+    renderApp();
+    return true;
+  };
+
+  window.BlissfulApp = Object.assign({}, window.BlissfulApp || {}, {
+    applyStarterState,
+  });
 
   const enhanceRecipesHeader = () => {
     const headerRow = document.querySelector('#recipes-page .topbar__row');

--- a/scripts/data-validation.js
+++ b/scripts/data-validation.js
@@ -1,0 +1,220 @@
+const allowedIngredientCategories = new Set([
+  'Pasta',
+  'Dairy',
+  'Dairy Alternative',
+  'Meat',
+  'Seafood',
+  'Herb',
+  'Spice',
+  'Vegetable',
+  'Fruit',
+  'Nut/Seed',
+  'Grain',
+  'Legume',
+  'Plant Protein',
+  'Oil/Fat',
+  'Sweetener',
+  'Baking',
+  'Baking Alternative',
+  'Condiment/Sauce',
+  'Beverage',
+  'Baked Goods & Doughs',
+  'Beverages & Mixers',
+  'Cheese',
+  'Condiments & Spreads',
+  'Dairy & Refrigerated',
+  'Dried Fruits',
+  'Fermented & Pickled',
+  'Grains & Cereals',
+  'Herbs & Aromatics',
+  'Legumes & Pulses',
+  'Meat & Poultry',
+  'Mushrooms & Fungi',
+  'Nuts & Seeds',
+  'Oils & Fats',
+  'Pasta & Noodles',
+  'Spices & Seasonings',
+  'Sweeteners & Baking',
+]);
+
+const canonicalAllergens = new Set([
+  'dairy',
+  'eggs',
+  'fish',
+  'gluten',
+  'nuts',
+  'peanuts',
+  'sesame',
+  'shellfish',
+  'soy',
+  'tree nuts',
+  'wheat',
+]);
+
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const validateData = ({ ingredients = [], recipes = [], matching = {} } = {}) => {
+  const errors = [];
+  const warnings = [];
+  const fail = (message) => errors.push(message);
+  const warn = (message) => warnings.push(message);
+
+  if (!Array.isArray(ingredients) || !ingredients.length) {
+    fail('Ingredient dataset did not load.');
+  }
+  if (!Array.isArray(recipes) || !recipes.length) {
+    fail('Recipe dataset did not load.');
+  }
+  if (typeof matching.createIngredientMatcherIndex !== 'function') {
+    fail('Ingredient matching API did not load.');
+  }
+
+  const ingredientSlugs = new Set();
+  const ingredientNames = new Map();
+
+  (Array.isArray(ingredients) ? ingredients : []).forEach((ingredient, index) => {
+    const ref = `ingredient[${index}]`;
+    if (!ingredient || typeof ingredient !== 'object') {
+      fail(`${ref} must be an object.`);
+      return;
+    }
+    if (typeof ingredient.slug !== 'string' || !slugPattern.test(ingredient.slug)) {
+      fail(`${ref} has invalid slug: ${ingredient.slug}`);
+    } else if (ingredientSlugs.has(ingredient.slug)) {
+      fail(`${ref} duplicates slug ${ingredient.slug}.`);
+    } else {
+      ingredientSlugs.add(ingredient.slug);
+    }
+    if (typeof ingredient.name !== 'string' || !ingredient.name.trim()) {
+      fail(`${ref} is missing a display name.`);
+    } else {
+      const key = ingredient.name.trim().toLowerCase();
+      if (ingredientNames.has(key)) {
+        fail(`${ref} duplicates display name '${ingredient.name}' from ${ingredientNames.get(key)}.`);
+      } else {
+        ingredientNames.set(key, ref);
+      }
+    }
+    if (!allowedIngredientCategories.has(ingredient.category)) {
+      fail(`${ref} uses unsupported category '${ingredient.category}'.`);
+    }
+    if (!Array.isArray(ingredient.tags)) {
+      fail(`${ref} tags must be an array.`);
+    }
+    if (ingredient.aliases !== undefined && !Array.isArray(ingredient.aliases)) {
+      fail(`${ref} aliases must be an array when provided.`);
+    }
+  });
+
+  const recipeIds = new Set();
+  const recipeNames = new Map();
+
+  (Array.isArray(recipes) ? recipes : []).forEach((recipe, index) => {
+    const ref = `recipe[${index}]`;
+    if (!recipe || typeof recipe !== 'object') {
+      fail(`${ref} must be an object.`);
+      return;
+    }
+    if (typeof recipe.id !== 'string' || !slugPattern.test(recipe.id)) {
+      fail(`${ref} has invalid id: ${recipe.id}`);
+    } else if (recipeIds.has(recipe.id)) {
+      fail(`${ref} duplicates id ${recipe.id}.`);
+    } else {
+      recipeIds.add(recipe.id);
+    }
+    if (typeof recipe.name !== 'string' || !recipe.name.trim()) {
+      fail(`${ref} is missing a name.`);
+    } else {
+      const key = recipe.name.trim().toLowerCase();
+      if (recipeNames.has(key)) {
+        fail(`${ref} duplicates recipe name '${recipe.name}' from ${recipeNames.get(key)}.`);
+      } else {
+        recipeNames.set(key, ref);
+      }
+    }
+    if (!Number.isFinite(recipe.baseServings) || recipe.baseServings <= 0) {
+      fail(`${ref} must define a positive baseServings number.`);
+    }
+    if (!Array.isArray(recipe.ingredients) || !recipe.ingredients.length) {
+      fail(`${ref} must include at least one ingredient.`);
+    } else {
+      recipe.ingredients.forEach((entry, ingredientIndex) => {
+        const entryRef = `${ref}.ingredients[${ingredientIndex}]`;
+        if (!entry || typeof entry !== 'object') {
+          fail(`${entryRef} must be an object.`);
+          return;
+        }
+        if (typeof entry.item !== 'string' || !entry.item.trim()) {
+          fail(`${entryRef} must include a non-empty item.`);
+        }
+        if (entry.quantity !== undefined && entry.quantity !== null && entry.quantity !== '') {
+          const quantity = Number(entry.quantity);
+          if (!Number.isFinite(quantity) || quantity < 0) {
+            fail(`${entryRef} has an invalid quantity '${entry.quantity}'.`);
+          }
+        }
+        if (entry.unit !== undefined && typeof entry.unit !== 'string') {
+          fail(`${entryRef} unit must be a string when provided.`);
+        }
+      });
+    }
+    if (!Array.isArray(recipe.instructions) || !recipe.instructions.length) {
+      fail(`${ref} must include cooking instructions.`);
+    }
+    if (!Array.isArray(recipe.equipment)) {
+      fail(`${ref} equipment must be an array.`);
+    }
+    if (!Array.isArray(recipe.tags)) {
+      fail(`${ref} tags must be an array.`);
+    }
+    if (!Array.isArray(recipe.allergens)) {
+      fail(`${ref} allergens must be an array.`);
+    } else {
+      recipe.allergens.forEach((allergen) => {
+        const normalized = String(allergen || '').trim().toLowerCase();
+        if (!canonicalAllergens.has(normalized)) {
+          fail(`${ref} uses non-canonical allergen '${allergen}'.`);
+        }
+      });
+    }
+    const nutrition = recipe.nutritionPerServing;
+    ['calories', 'protein', 'carbs', 'fat'].forEach((key) => {
+      if (!nutrition || !Number.isFinite(Number(nutrition[key])) || Number(nutrition[key]) < 0) {
+        fail(`${ref} nutritionPerServing.${key} must be a non-negative number.`);
+      }
+    });
+  });
+
+  if (
+    typeof matching.createIngredientMatcherIndex === 'function'
+    && typeof matching.mapRecipesToIngredientMatches === 'function'
+  ) {
+    const index = matching.createIngredientMatcherIndex(ingredients);
+    const { recipeIngredientMatches, ingredientUsage } = matching.mapRecipesToIngredientMatches(
+      recipes,
+      index,
+    );
+    recipes.forEach((recipe) => {
+      const matches = recipeIngredientMatches.get(recipe.id);
+      if (!(matches instanceof Set) || matches.size === 0) {
+        warn(`Recipe '${recipe.name}' has no canonical ingredient matches.`);
+      }
+    });
+    const unusedIngredients = ingredients.filter(
+      (ingredient) => ingredient && !ingredientUsage.get(ingredient.slug),
+    );
+    if (unusedIngredients.length) {
+      warn(
+        `${unusedIngredients.length} canonical ingredients are not used by curated recipes before runtime coverage generation.`,
+      );
+    }
+  }
+
+  return { errors, warnings };
+};
+
+module.exports = {
+  allowedIngredientCategories,
+  canonicalAllergens,
+  validateData,
+};

--- a/scripts/ingredient-matching.js
+++ b/scripts/ingredient-matching.js
@@ -60,11 +60,19 @@
     'chunks',
     'strips',
   ]);
+  const LOW_SPECIFICITY_TOKENS = new Set(['cooked']);
 
   const sanitizeComparisonText = (value) =>
     String(value || '')
       .toLowerCase()
       .replace(/\([^)]*\)/g, ' ')
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim();
+
+  const sanitizeMatcherText = (value) =>
+    String(value || '')
+      .toLowerCase()
+      .replace(/[()]/g, ' ')
       .replace(/[^a-z0-9]+/g, ' ')
       .trim();
 
@@ -115,7 +123,7 @@
       }
     }
     const variants = new Set();
-    const normalizedName = sanitizeComparisonText(ingredient.name);
+    const normalizedName = sanitizeMatcherText(ingredient.name);
     if (normalizedName && normalizedName.includes(' ')) {
       variants.add(normalizedName);
     }
@@ -131,19 +139,22 @@
     }
     if (Array.isArray(ingredient.aliases)) {
       ingredient.aliases
-        .map((alias) => sanitizeComparisonText(alias))
+        .map((alias) => sanitizeMatcherText(alias))
         .filter(Boolean)
         .forEach((alias) => variants.add(alias));
     }
     return { slug: ingredient.slug, label: ingredient.name, tokens, variants };
   };
 
+  const containsPhrase = (text, phrase) =>
+    Boolean(text && phrase && ` ${text} `.includes(` ${phrase} `));
+
   const doesEntryMatchIngredient = (entry, matcher) => {
     if (!entry || !matcher) return false;
     if (matcher.variants) {
       for (const variant of matcher.variants) {
         if (!variant) continue;
-        if (entry.text.includes(variant) || variant.includes(entry.text)) {
+        if (containsPhrase(entry.text, variant) || containsPhrase(variant, entry.text)) {
           return true;
         }
       }
@@ -194,25 +205,35 @@
     const matchedSlugs = new Set();
     if (!entries.length) return matchedSlugs;
 
-    const candidateSlugs = new Set();
     entries.forEach((entry) => {
       if (!entry || !(entry.tokens instanceof Set)) return;
+      const candidateSlugs = new Set(index.slugsWithoutTokens);
       entry.tokens.forEach((token) => {
         const slugsForToken = index.tokenIndex.get(token);
         if (slugsForToken) {
           slugsForToken.forEach((slug) => candidateSlugs.add(slug));
         }
       });
-    });
 
-    index.slugsWithoutTokens.forEach((slug) => candidateSlugs.add(slug));
-
-    candidateSlugs.forEach((slug) => {
-      const matcher = index.matchers.get(slug);
-      if (!matcher) return;
-      if (entries.some((entry) => doesEntryMatchIngredient(entry, matcher))) {
-        matchedSlugs.add(slug);
-      }
+      const entryMatches = Array.from(candidateSlugs)
+        .map((slug) => index.matchers.get(slug))
+        .filter((matcher) => matcher && doesEntryMatchIngredient(entry, matcher));
+      entryMatches.forEach((matcher) => {
+        const isLessSpecific = entryMatches.some((other) => {
+          if (other === matcher) return false;
+          const matcherTokens = Array.from(matcher.tokens)
+            .filter((token) => !LOW_SPECIFICITY_TOKENS.has(token));
+          const otherTokens = new Set(
+            Array.from(other.tokens).filter((token) => !LOW_SPECIFICITY_TOKENS.has(token)),
+          );
+          if (matcherTokens.length >= otherTokens.size) return false;
+          if (!Array.from(otherTokens).every((token) => entry.tokens.has(token))) return false;
+          return matcherTokens.every((token) => otherTokens.has(token));
+        });
+        if (!isLessSpecific) {
+          matchedSlugs.add(matcher.slug);
+        }
+      });
     });
 
     return matchedSlugs;

--- a/scripts/productivity-onboarding.js
+++ b/scripts/productivity-onboarding.js
@@ -1,0 +1,387 @@
+;(function (global) {
+  const tools = global.BlissfulProductivity || {};
+  const ingredients = Array.isArray(global.BLISSFUL_INGREDIENTS) ? global.BLISSFUL_INGREDIENTS : [];
+
+  if (typeof document === 'undefined' || typeof tools.createStarterState !== 'function') {
+    return;
+  }
+
+  const APP_STATE_STORAGE_KEY = 'blissful-app-state';
+  const DISMISSED_STORAGE_KEY = 'blissful-onboarding-dismissed';
+
+  const starterPantrySlugs = [
+    'grain-rice-white',
+    'grain-quinoa',
+    'pasta-spaghetti',
+    'veg-garlic',
+    'veg-onion-yellow',
+    'veg-carrot',
+    'veg-spinach',
+    'legume-chickpea',
+    'oil-olive',
+    'spice-kosher-salt',
+    'spice-black-pepper',
+    'dairy-cheese-parmesan',
+  ];
+
+  const dietOptions = [
+    '',
+    'Vegetarian',
+    'Vegan',
+    'Gluten Free',
+    'Dairy Free',
+    'High Protein',
+  ];
+
+  const allergyOptions = [
+    '',
+    'dairy',
+    'eggs',
+    'fish',
+    'gluten',
+    'nuts',
+    'peanuts',
+    'shellfish',
+    'soy',
+  ];
+
+  const hasExistingAppState = () => {
+    if (typeof tools.hasMeaningfulStoredState === 'function') {
+      return tools.hasMeaningfulStoredState(global.localStorage);
+    }
+    try {
+      const raw = global.localStorage?.getItem?.(APP_STATE_STORAGE_KEY);
+      if (!raw) return false;
+      const stored = JSON.parse(raw);
+      return typeof tools.hasMeaningfulAppState === 'function'
+        ? tools.hasMeaningfulAppState(stored)
+        : Boolean(stored && typeof stored === 'object' && !Array.isArray(stored));
+    } catch (error) {
+      return false;
+    }
+  };
+
+  const wasDismissed = () => {
+    try {
+      return global.localStorage?.getItem?.(DISMISSED_STORAGE_KEY) === 'true';
+    } catch (error) {
+      return true;
+    }
+  };
+
+  const getIngredientName = (slug) =>
+    ingredients.find((ingredient) => ingredient && ingredient.slug === slug)?.name || slug;
+
+  const createOption = (value, label) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    return option;
+  };
+
+  const applyStyles = () => {
+    if (document.getElementById('productivity-onboarding-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'productivity-onboarding-styles';
+    style.textContent = `
+      .productivity-onboarding {
+        display: grid;
+        gap: 1rem;
+        margin-bottom: 1rem;
+        padding: 1rem;
+        border: 1px solid var(--border-1);
+        border-radius: 1.25rem;
+        background: var(--surface-0);
+      }
+
+      .productivity-onboarding__header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      .productivity-onboarding__title {
+        margin: 0;
+        font-size: 1.05rem;
+      }
+
+      .productivity-onboarding__subtitle {
+        margin: 0.25rem 0 0;
+        color: var(--text-muted);
+        font-size: 0.9rem;
+      }
+
+      .productivity-onboarding__dismiss {
+        flex: 0 0 auto;
+        border: 1px solid var(--border-1);
+        border-radius: 999px;
+        padding: 0.25rem 0.55rem;
+        background: var(--surface-1);
+        color: var(--text);
+        font: inherit;
+        font-weight: 700;
+        cursor: pointer;
+      }
+
+      .productivity-onboarding__form {
+        display: grid;
+        gap: 0.85rem;
+      }
+
+      .productivity-onboarding__fields {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.75rem;
+      }
+
+      .productivity-onboarding__field {
+        display: grid;
+        gap: 0.35rem;
+        color: var(--text);
+        font-size: 0.86rem;
+        font-weight: 700;
+      }
+
+      .productivity-onboarding__field input,
+      .productivity-onboarding__field select {
+        width: 100%;
+        border: 1px solid var(--border-1);
+        border-radius: 0.75rem;
+        padding: 0.55rem 0.65rem;
+        background: var(--surface-1);
+        color: var(--text);
+        font: inherit;
+        font-weight: 500;
+      }
+
+      .productivity-onboarding__pantry {
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      .productivity-onboarding__pantry-title {
+        margin: 0;
+        font-size: 0.9rem;
+      }
+
+      .productivity-onboarding__chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+      }
+
+      .productivity-onboarding__chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        border: 1px solid var(--border-1);
+        border-radius: 999px;
+        padding: 0.35rem 0.55rem;
+        background: var(--surface-1);
+        color: var(--text);
+        font-size: 0.82rem;
+        cursor: pointer;
+      }
+
+      .productivity-onboarding__actions {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .productivity-onboarding__submit {
+        border: 1px solid var(--border-1);
+        border-radius: 999px;
+        padding: 0.55rem 0.9rem;
+        background: var(--surface-1);
+        color: var(--text);
+        font: inherit;
+        font-weight: 800;
+        cursor: pointer;
+      }
+
+      .productivity-onboarding__note {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.82rem;
+      }
+    `;
+    document.head.appendChild(style);
+  };
+
+  const saveStarterState = (form) => {
+    const data = new FormData(form);
+    const householdName = String(data.get('householdName') || '').trim() || 'Household';
+    const diet = String(data.get('diet') || '').trim();
+    const allergy = String(data.get('allergy') || '').trim();
+    const pantrySlugs = Array.from(form.querySelectorAll('[name="pantry"]'))
+      .filter((input) => input instanceof HTMLInputElement && input.checked)
+      .map((input) => input.value);
+
+    const starterState = tools.createStarterState({
+      familyName: householdName,
+      diets: diet ? [diet] : [],
+      allergies: allergy ? [allergy] : [],
+      pantrySlugs,
+      kitchenItems: [],
+    });
+
+    try {
+      global.localStorage?.setItem?.(APP_STATE_STORAGE_KEY, JSON.stringify(starterState));
+      global.localStorage?.removeItem?.(DISMISSED_STORAGE_KEY);
+    } catch (error) {
+      return null;
+    }
+    return starterState;
+  };
+
+  const renderOnboarding = () => {
+    if (hasExistingAppState() || wasDismissed()) return;
+    const mealView = document.getElementById('meal-view');
+    const mealGrid = document.getElementById('meal-grid');
+    if (!mealView || !mealGrid || document.getElementById('productivity-onboarding')) return;
+
+    applyStyles();
+
+    const card = document.createElement('section');
+    card.className = 'productivity-onboarding';
+    card.id = 'productivity-onboarding';
+    card.setAttribute('aria-label', 'First run setup');
+
+    const header = document.createElement('header');
+    header.className = 'productivity-onboarding__header';
+    const headerText = document.createElement('div');
+    const title = document.createElement('h2');
+    title.className = 'productivity-onboarding__title';
+    title.textContent = 'Set up your kitchen in under a minute';
+    headerText.appendChild(title);
+    const subtitle = document.createElement('p');
+    subtitle.className = 'productivity-onboarding__subtitle';
+    subtitle.textContent = 'Add a few household basics so recipe readiness and shopping lists work immediately.';
+    headerText.appendChild(subtitle);
+    header.appendChild(headerText);
+
+    const dismiss = document.createElement('button');
+    dismiss.type = 'button';
+    dismiss.className = 'productivity-onboarding__dismiss';
+    dismiss.textContent = 'Skip';
+    dismiss.addEventListener('click', () => {
+      try {
+        global.localStorage?.setItem?.(DISMISSED_STORAGE_KEY, 'true');
+      } catch (error) {
+        // Ignore storage failures; removing the card is still useful for the current session.
+      }
+      card.remove();
+    });
+    header.appendChild(dismiss);
+    card.appendChild(header);
+
+    const form = document.createElement('form');
+    form.className = 'productivity-onboarding__form';
+
+    const fields = document.createElement('div');
+    fields.className = 'productivity-onboarding__fields';
+
+    const nameLabel = document.createElement('label');
+    nameLabel.className = 'productivity-onboarding__field';
+    nameLabel.textContent = 'Household name';
+    const nameInput = document.createElement('input');
+    nameInput.name = 'householdName';
+    nameInput.placeholder = 'Household';
+    nameInput.autocomplete = 'organization';
+    nameLabel.appendChild(nameInput);
+    fields.appendChild(nameLabel);
+
+    const dietLabel = document.createElement('label');
+    dietLabel.className = 'productivity-onboarding__field';
+    dietLabel.textContent = 'Common diet';
+    const dietSelect = document.createElement('select');
+    dietSelect.name = 'diet';
+    dietOptions.forEach((value) => dietSelect.appendChild(createOption(value, value || 'No default')));
+    dietLabel.appendChild(dietSelect);
+    fields.appendChild(dietLabel);
+
+    const allergyLabel = document.createElement('label');
+    allergyLabel.className = 'productivity-onboarding__field';
+    allergyLabel.textContent = 'Allergy to avoid';
+    const allergySelect = document.createElement('select');
+    allergySelect.name = 'allergy';
+    allergyOptions.forEach((value) => allergySelect.appendChild(createOption(value, value || 'No default')));
+    allergyLabel.appendChild(allergySelect);
+    fields.appendChild(allergyLabel);
+    form.appendChild(fields);
+
+    const pantry = document.createElement('section');
+    pantry.className = 'productivity-onboarding__pantry';
+    const pantryTitle = document.createElement('h3');
+    pantryTitle.className = 'productivity-onboarding__pantry-title';
+    pantryTitle.textContent = 'Starter pantry items';
+    pantry.appendChild(pantryTitle);
+    const chips = document.createElement('div');
+    chips.className = 'productivity-onboarding__chips';
+    starterPantrySlugs.forEach((slug) => {
+      const label = document.createElement('label');
+      label.className = 'productivity-onboarding__chip';
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.name = 'pantry';
+      input.value = slug;
+      input.checked = true;
+      label.appendChild(input);
+      const text = document.createElement('span');
+      text.textContent = getIngredientName(slug);
+      label.appendChild(text);
+      chips.appendChild(label);
+    });
+    pantry.appendChild(chips);
+    form.appendChild(pantry);
+
+    const actions = document.createElement('div');
+    actions.className = 'productivity-onboarding__actions';
+    const submit = document.createElement('button');
+    submit.type = 'submit';
+    submit.className = 'productivity-onboarding__submit';
+    submit.textContent = 'Save setup';
+    actions.appendChild(submit);
+    const note = document.createElement('p');
+    note.className = 'productivity-onboarding__note';
+    note.textContent = 'Setup saves locally in this browser and updates the planner immediately.';
+    actions.appendChild(note);
+    form.appendChild(actions);
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      submit.disabled = true;
+      submit.textContent = 'Saving...';
+      const starterState = saveStarterState(form);
+      if (!starterState) {
+        submit.disabled = false;
+        submit.textContent = 'Save setup';
+        note.textContent = 'Could not save setup in this browser. Check storage permissions.';
+        return;
+      }
+
+      const app = global.BlissfulApp;
+      if (app && typeof app.applyStarterState === 'function' && app.applyStarterState(starterState)) {
+        card.remove();
+        return;
+      }
+
+      // The normal app path applies state in place. Reload only if the app integration is unavailable.
+      global.location.reload();
+    });
+
+    card.appendChild(form);
+    mealView.insertBefore(card, mealGrid);
+  };
+
+  const start = () => renderOnboarding();
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/scripts/productivity-settings.js
+++ b/scripts/productivity-settings.js
@@ -1,0 +1,119 @@
+;(function () {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const applyStyles = () => {
+    if (document.getElementById('productivity-settings-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'productivity-settings-styles';
+    style.textContent = `
+      .productivity-settings-advanced {
+        display: grid;
+        gap: 0.65rem;
+        border: 1px solid var(--border-1);
+        border-radius: 1rem;
+        padding: 0.65rem 0.75rem;
+        background: var(--surface-0);
+      }
+
+      .productivity-settings-advanced__summary {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        color: var(--text);
+        cursor: pointer;
+        font-weight: 800;
+        list-style: none;
+      }
+
+      .productivity-settings-advanced__summary::-webkit-details-marker {
+        display: none;
+      }
+
+      .productivity-settings-advanced__summary::after {
+        content: '⌄';
+        color: var(--text-muted);
+        font-size: 0.95rem;
+      }
+
+      .productivity-settings-advanced[open] .productivity-settings-advanced__summary::after {
+        content: '⌃';
+      }
+
+      .productivity-settings-advanced__body {
+        display: grid;
+        gap: 0.85rem;
+        padding-top: 0.65rem;
+      }
+
+      .productivity-settings-advanced__description {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.82rem;
+        line-height: 1.35;
+      }
+    `;
+    document.head.appendChild(style);
+  };
+
+  const simplifySettings = () => {
+    const toolbar = document.getElementById('theme-toolbar');
+    if (!toolbar || document.getElementById('productivity-settings-advanced')) {
+      return Boolean(toolbar);
+    }
+
+    const palette = document.getElementById('theme-palette');
+    const paletteGroup = palette?.closest?.('.theme-toolbar__group');
+    const holidayGroup = toolbar.querySelector('.theme-toolbar__group--holiday');
+
+    if (!paletteGroup && !holidayGroup) {
+      return Boolean(toolbar);
+    }
+
+    applyStyles();
+
+    const advanced = document.createElement('details');
+    advanced.className = 'productivity-settings-advanced';
+    advanced.id = 'productivity-settings-advanced';
+
+    const summary = document.createElement('summary');
+    summary.className = 'productivity-settings-advanced__summary';
+    summary.textContent = 'Advanced appearance';
+    advanced.appendChild(summary);
+
+    const body = document.createElement('div');
+    body.className = 'productivity-settings-advanced__body';
+
+    const description = document.createElement('p');
+    description.className = 'productivity-settings-advanced__description';
+    description.textContent = 'Customize palettes and automatic holiday themes only when you need deeper visual control.';
+    body.appendChild(description);
+
+    const insertionPoint = paletteGroup || holidayGroup;
+    toolbar.insertBefore(advanced, insertionPoint);
+
+    // This script runs before app.js initializes, so app.js binds listeners to the moved controls.
+    if (paletteGroup) {
+      body.appendChild(paletteGroup);
+    }
+    if (holidayGroup) {
+      body.appendChild(holidayGroup);
+    }
+    advanced.appendChild(body);
+
+    return true;
+  };
+
+  const start = () => {
+    if (simplifySettings()) return;
+    window.requestAnimationFrame(() => simplifySettings());
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/scripts/productivity-tools.js
+++ b/scripts/productivity-tools.js
@@ -1,0 +1,373 @@
+;(function (global) {
+  const APP_STATE_STORAGE_KEY = 'blissful-app-state';
+  const MEAL_PLAN_STORAGE_KEY = 'blissful-meal-plan';
+  const FAVORITES_STORAGE_KEY = 'blissful-favorites';
+  const PANTRY_FAVORITES_STORAGE_KEY = 'blissful-pantry-favorites';
+  const THEME_STORAGE_KEY = 'blissful-theme';
+  const HOLIDAY_THEME_STORAGE_KEY = 'blissful-holiday-themes';
+  const MEASUREMENT_STORAGE_KEY = 'blissful-measurement';
+
+  const BACKUP_VERSION = 1;
+  const BACKUP_KEYS = [
+    APP_STATE_STORAGE_KEY,
+    MEAL_PLAN_STORAGE_KEY,
+    FAVORITES_STORAGE_KEY,
+    PANTRY_FAVORITES_STORAGE_KEY,
+    THEME_STORAGE_KEY,
+    HOLIDAY_THEME_STORAGE_KEY,
+    MEASUREMENT_STORAGE_KEY,
+  ];
+
+  const GENERATED_CATEGORY_LABELS = new Map([
+    ['Ingredient Spotlight', 'Ingredient idea'],
+    ['Diet Collection', 'Generated template'],
+    ['Protein Collection', 'Generated template'],
+    ['Menu Collection', 'Generated template'],
+    ['Regional Collection', 'Generated template'],
+  ]);
+
+  const toText = (value) => String(value || '').trim();
+
+  const normalizeIngredientName = (value) =>
+    toText(value)
+      .toLowerCase()
+      .replace(/\([^)]*\)/g, ' ')
+      .replace(/^to serve:\s*/i, '')
+      .replace(/\b\d+(?:\.\d+)?\b/g, ' ')
+      .replace(/\b(cups?|tablespoons?|tbsp|teaspoons?|tsp|ounces?|oz|pounds?|lbs?|grams?|g|kilograms?|kg|cans?|jars?|cloves?|medium|large|small|fresh|dried|chopped|diced|sliced|minced|grated|shredded|rinsed|drained|cooked)\b/g, ' ')
+      .replace(/[^a-z0-9]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+  const getRecipeTypeLabel = (recipe) => {
+    if (!recipe || typeof recipe !== 'object') return 'Curated recipe';
+    if (recipe.generated === true) return 'Generated template';
+    const category = toText(recipe.category);
+    if (GENERATED_CATEGORY_LABELS.has(category)) {
+      return GENERATED_CATEGORY_LABELS.get(category);
+    }
+    const id = toText(recipe.id);
+    if (/^(ingredient-spotlight|diet-|protein-|menu-|regional-)/.test(id)) {
+      return id.startsWith('ingredient-spotlight') ? 'Ingredient idea' : 'Generated template';
+    }
+    return 'Curated recipe';
+  };
+
+  const getPantrySlugSet = (pantryInventory) => {
+    if (!pantryInventory || typeof pantryInventory !== 'object') return new Set();
+    return new Set(
+      Object.entries(pantryInventory)
+        .filter(([, entry]) => {
+          if (entry === true) return true;
+          if (!entry || typeof entry !== 'object') return false;
+          const quantity = toText(entry.quantity);
+          const unit = toText(entry.unit);
+          return Boolean(quantity || unit);
+        })
+        .map(([slug]) => slug),
+    );
+  };
+
+  const getSubstitutionSlugSet = (slug, substitutionGraph) => {
+    const result = new Set();
+    if (!slug || !(substitutionGraph instanceof Map)) return result;
+    const entry = substitutionGraph.get(slug);
+    if (!entry || !(entry.members instanceof Set)) return result;
+    entry.members.forEach((member) => {
+      if (member && member !== slug) result.add(member);
+    });
+    return result;
+  };
+
+  const analyzeRecipePantryFit = ({ recipe, pantryInventory, recipeIngredientMatches, substitutionGraph, substitutionsAllowed = false }) => {
+    const pantrySlugs = getPantrySlugSet(pantryInventory);
+    const matchedSlugs = recipeIngredientMatches instanceof Set ? recipeIngredientMatches : new Set();
+    const present = [];
+    const substituted = [];
+    const missing = [];
+
+    matchedSlugs.forEach((slug) => {
+      if (pantrySlugs.has(slug)) {
+        present.push(slug);
+        return;
+      }
+      const alternatives = substitutionsAllowed ? getSubstitutionSlugSet(slug, substitutionGraph) : new Set();
+      const pantryAlternative = Array.from(alternatives).find((alternative) => pantrySlugs.has(alternative));
+      if (pantryAlternative) {
+        substituted.push({ requested: slug, substitute: pantryAlternative });
+      } else {
+        missing.push(slug);
+      }
+    });
+
+    const total = matchedSlugs.size;
+    const available = present.length + substituted.length;
+    const status = total === 0
+      ? 'unknown'
+      : missing.length === 0 && substituted.length === 0
+        ? 'ready'
+        : missing.length === 0
+          ? 'ready-with-substitutions'
+          : missing.length <= 2
+            ? 'nearly-ready'
+            : 'needs-shopping';
+
+    return { recipeId: recipe?.id || '', total, available, present, substituted, missing, status };
+  };
+
+  const buildShoppingList = ({ recipes, pantryInventory, recipeMatchesById = new Map(), ingredientBySlug = new Map(), substitutionGraph = new Map(), substitutionsAllowed = false }) => {
+    const list = new Map();
+    (Array.isArray(recipes) ? recipes : []).forEach((recipe) => {
+      const fit = analyzeRecipePantryFit({
+        recipe,
+        pantryInventory,
+        recipeIngredientMatches: recipeMatchesById.get(recipe.id),
+        substitutionGraph,
+        substitutionsAllowed,
+      });
+      fit.missing.forEach((slug) => {
+        const ingredient = ingredientBySlug.get(slug) || { slug, name: slug, category: 'Other' };
+        const key = slug;
+        if (!list.has(key)) {
+          list.set(key, {
+            slug,
+            name: ingredient.name || slug,
+            category: ingredient.category || 'Other',
+            recipes: [],
+          });
+        }
+        const recipeName = recipe.name || recipe.id || 'Recipe';
+        if (!list.get(key).recipes.includes(recipeName)) {
+          list.get(key).recipes.push(recipeName);
+        }
+      });
+    });
+    return Array.from(list.values()).sort((a, b) => {
+      const categoryCompare = String(a.category).localeCompare(String(b.category));
+      return categoryCompare || String(a.name).localeCompare(String(b.name));
+    });
+  };
+
+  const createBackup = (storage = global.localStorage) => {
+    const data = {};
+    BACKUP_KEYS.forEach((key) => {
+      try {
+        const value = storage?.getItem?.(key);
+        if (value !== null && value !== undefined) data[key] = value;
+      } catch (error) {
+        // Ignore unavailable storage keys so backup remains best-effort.
+      }
+    });
+    return {
+      app: 'Blissful Reverie',
+      version: BACKUP_VERSION,
+      exportedAt: new Date().toISOString(),
+      data,
+    };
+  };
+
+  const restoreBackup = (backup, storage = global.localStorage) => {
+    if (!backup || backup.app !== 'Blissful Reverie' || typeof backup.data !== 'object') {
+      throw new Error('Invalid Blissful Reverie backup.');
+    }
+    BACKUP_KEYS.forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(backup.data, key)) {
+        storage?.setItem?.(key, String(backup.data[key]));
+      }
+    });
+    return true;
+  };
+
+  const hasMeaningfulAppState = (state) => {
+    if (!state || typeof state !== 'object' || Array.isArray(state)) {
+      return false;
+    }
+    const hasObjectEntries = (value) => (
+      value && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length > 0
+    );
+    const hasArrayEntries = (value) => Array.isArray(value) && value.length > 0;
+    const filters = state.mealFilters && typeof state.mealFilters === 'object'
+      ? state.mealFilters
+      : {};
+    const pantryFilters = state.pantryFilters && typeof state.pantryFilters === 'object'
+      ? state.pantryFilters
+      : {};
+    const familyMembers = Array.isArray(state.familyMembers) ? state.familyMembers : [];
+    const hasCustomFamily = familyMembers.length > 0 && (
+      familyMembers.length !== 2
+      || familyMembers[0]?.name !== 'Alex'
+      || familyMembers[1]?.name !== 'Riley'
+    );
+
+    return (
+      (typeof state.activeView === 'string' && state.activeView !== 'meals')
+      || hasObjectEntries(state.pantryInventory)
+      || hasArrayEntries(state.kitchenInventory)
+      || hasObjectEntries(state.servingOverrides)
+      || hasObjectEntries(state.notes)
+      || hasObjectEntries(state.openNotes)
+      || hasArrayEntries(state.mealPlanMemberFilter)
+      || (typeof state.mealPlanMacroSelection === 'string' && state.mealPlanMacroSelection !== 'overall')
+      || (typeof filters.search === 'string' && filters.search.trim() !== '')
+      || ['ingredients', 'ingredientsExcluded', 'tags', 'tagsExcluded', 'allergies', 'allergiesExcluded', 'equipment', 'equipmentExcluded', 'familyMembers']
+        .some((key) => hasArrayEntries(filters[key]))
+      || Boolean(filters.favoritesOnly || filters.pantryOnly || filters.substitutionsAllowed)
+      || (typeof pantryFilters.search === 'string' && pantryFilters.search.trim() !== '')
+      || ['categories', 'tags', 'allergens'].some((key) => hasArrayEntries(pantryFilters[key]))
+      || (typeof state.kitchenFilters?.search === 'string' && state.kitchenFilters.search.trim() !== '')
+      || hasCustomFamily
+    );
+  };
+
+  const hasMeaningfulStoredState = (storage = global.localStorage) => {
+    const hasStoredValue = (key) => {
+      try {
+        const raw = storage?.getItem?.(key);
+        return typeof raw === 'string' && raw.trim() !== '';
+      } catch (error) {
+        return false;
+      }
+    };
+    const readJson = (key) => {
+      try {
+        const raw = storage?.getItem?.(key);
+        return raw ? JSON.parse(raw) : null;
+      } catch (error) {
+        return null;
+      }
+    };
+    if (hasMeaningfulAppState(readJson(APP_STATE_STORAGE_KEY))) {
+      return true;
+    }
+    const favorites = readJson(FAVORITES_STORAGE_KEY);
+    const pantryFavorites = readJson(PANTRY_FAVORITES_STORAGE_KEY);
+    const mealPlan = readJson(MEAL_PLAN_STORAGE_KEY);
+    return (
+      (Array.isArray(favorites) && favorites.length > 0)
+      || (Array.isArray(pantryFavorites) && pantryFavorites.length > 0)
+      || [THEME_STORAGE_KEY, HOLIDAY_THEME_STORAGE_KEY, MEASUREMENT_STORAGE_KEY]
+        .some(hasStoredValue)
+      || Boolean(
+        mealPlan
+        && typeof mealPlan === 'object'
+        && !Array.isArray(mealPlan)
+        && Object.values(mealPlan).some((entries) => Array.isArray(entries) && entries.length > 0)
+      )
+    );
+  };
+
+  const createStarterState = ({
+    familyName = 'Family',
+    allergies = [],
+    diets = [],
+    pantrySlugs = [],
+    kitchenItems = [],
+  } = {}) => {
+    const uniqueText = (values) =>
+      Array.from(
+        new Set(
+          (Array.isArray(values) ? values : [])
+            .map((value) => toText(value))
+            .filter(Boolean),
+        ),
+      );
+    const normalizedAllergies = uniqueText(allergies);
+    const normalizedDiets = uniqueText(diets);
+    const normalizedPantrySlugs = uniqueText(pantrySlugs);
+
+    return {
+      activeView: 'meals',
+      mealFilters: {
+        search: '',
+        ingredients: [],
+        ingredientsExcluded: [],
+        tags: normalizedDiets,
+        tagsExcluded: [],
+        allergies: [],
+        allergiesExcluded: normalizedAllergies,
+        equipment: [],
+        equipmentExcluded: [],
+        favoritesOnly: false,
+        familyMembers: [],
+        pantryOnly: true,
+        substitutionsAllowed: true,
+      },
+      pantryFilters: {
+        search: '',
+        categories: [],
+        tags: [],
+        allergens: [],
+      },
+      kitchenFilters: {
+        search: '',
+      },
+      mealPlanViewMode: 'month',
+      mealPlanMemberFilter: [],
+      mealPlanMacroSelection: 'overall',
+      servingOverrides: {},
+      notes: {},
+      openNotes: {},
+      pantryInventory: Object.fromEntries(
+        normalizedPantrySlugs.map((slug) => [slug, { quantity: '1', unit: 'each' }]),
+      ),
+      kitchenInventory: uniqueText(kitchenItems),
+      familyMembers: [
+        {
+          id: 'member_default',
+          name: toText(familyName) || 'Family',
+          icon: '\u{1F9D1}',
+          allergies: normalizedAllergies,
+          diets: normalizedDiets,
+          birthday: '',
+          preferences: '',
+          targetCalories: null,
+        },
+      ],
+    };
+  };
+
+  const summarizeDashboard = ({ recipes = [], pantryInventory = {}, recipeMatchesById = new Map(), substitutionGraph = new Map() } = {}) => {
+    const scored = recipes.map((recipe) => ({
+      recipe,
+      exact: analyzeRecipePantryFit({
+        recipe,
+        pantryInventory,
+        recipeIngredientMatches: recipeMatchesById.get(recipe.id),
+        substitutionGraph,
+        substitutionsAllowed: false,
+      }),
+      flexible: analyzeRecipePantryFit({
+        recipe,
+        pantryInventory,
+        recipeIngredientMatches: recipeMatchesById.get(recipe.id),
+        substitutionGraph,
+        substitutionsAllowed: true,
+      }),
+    }));
+    return {
+      cookNow: scored.filter((entry) => entry.exact.status === 'ready').slice(0, 6),
+      flexibleCookNow: scored.filter((entry) => entry.flexible.status === 'ready-with-substitutions').slice(0, 6),
+      nearlyReady: scored.filter((entry) => entry.flexible.status === 'nearly-ready').slice(0, 6),
+    };
+  };
+
+  const api = {
+    BACKUP_KEYS,
+    normalizeIngredientName,
+    getRecipeTypeLabel,
+    getPantrySlugSet,
+    analyzeRecipePantryFit,
+    buildShoppingList,
+    createBackup,
+    restoreBackup,
+    hasMeaningfulAppState,
+    hasMeaningfulStoredState,
+    createStarterState,
+    summarizeDashboard,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+  global.BlissfulProductivity = Object.assign({}, global.BlissfulProductivity || {}, api);
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/scripts/productivity-ui.js
+++ b/scripts/productivity-ui.js
@@ -1,0 +1,543 @@
+;(function (global) {
+  const tools = global.BlissfulProductivity || {};
+  if (typeof document === 'undefined' || typeof tools.analyzeRecipePantryFit !== 'function') {
+    return;
+  }
+
+  const SHOPPING_RECIPE_LIMIT = 8;
+  const SHOPPING_ITEM_LIMIT = 18;
+  let currentContext = null;
+
+  const getRecipes = () => (
+    Array.isArray(currentContext?.recipes) ? currentContext.recipes : []
+  );
+
+  const getRecipeMatches = () => (
+    currentContext?.recipeIngredientMatches instanceof Map
+      ? currentContext.recipeIngredientMatches
+      : new Map()
+  );
+
+  const getIngredientBySlug = () => (
+    currentContext?.ingredientBySlug instanceof Map
+      ? currentContext.ingredientBySlug
+      : new Map()
+  );
+
+  const getSubstitutionGraph = () => (
+    currentContext?.substitutionGraph instanceof Map
+      ? currentContext.substitutionGraph
+      : new Map()
+  );
+
+  const getRecipeById = (recipeId) => {
+    if (!recipeId) return null;
+    if (currentContext?.recipeById instanceof Map) {
+      return currentContext.recipeById.get(recipeId) || null;
+    }
+    return getRecipes().find((recipe) => recipe?.id === recipeId) || null;
+  };
+
+  const statusLabels = new Map([
+    ['ready', 'Ready to cook'],
+    ['ready-with-substitutions', 'Ready with swaps'],
+    ['nearly-ready', 'Almost ready'],
+    ['needs-shopping', 'Needs shopping'],
+    ['unknown', 'Pantry unknown'],
+  ]);
+
+  const createBadge = (text, variant, title) => {
+    const badge = document.createElement('span');
+    badge.className = `productivity-badge productivity-badge--${variant}`;
+    badge.textContent = text;
+    if (title) {
+      badge.title = title;
+    }
+    return badge;
+  };
+
+  const getPantryBadgeText = (fit) => {
+    if (!fit || fit.total === 0) return 'Pantry unknown';
+    if (fit.status === 'ready') return 'Ready to cook';
+    if (fit.status === 'ready-with-substitutions') return 'Ready with swaps';
+    const count = Array.isArray(fit.missing) ? fit.missing.length : 0;
+    if (count === 1) return 'Missing 1 item';
+    if (count > 1) return `Missing ${count} items`;
+    return statusLabels.get(fit.status) || 'Pantry unknown';
+  };
+
+  const getPantryBadgeTitle = (fit) => {
+    if (!fit || fit.total === 0) {
+      return 'Ingredient coverage is unavailable for this recipe.';
+    }
+    const available = Number(fit.available) || 0;
+    const total = Number(fit.total) || 0;
+    const missing = Array.isArray(fit.missing) ? fit.missing.length : 0;
+    if (!missing) {
+      return `${available} of ${total} matched ingredients are in your pantry.`;
+    }
+    return `${available} of ${total} matched ingredients are in your pantry; ${missing} missing.`;
+  };
+
+  const getPantryInventory = () => {
+    return currentContext?.pantryInventory && typeof currentContext.pantryInventory === 'object'
+      ? currentContext.pantryInventory
+      : {};
+  };
+
+  const getSubstitutionsAllowed = () => Boolean(currentContext?.substitutionsAllowed);
+
+  const getRecipeFit = (recipe) =>
+    tools.analyzeRecipePantryFit({
+      recipe,
+      pantryInventory: getPantryInventory(),
+      recipeIngredientMatches: getRecipeMatches().get(recipe.id),
+      substitutionGraph: getSubstitutionGraph(),
+      substitutionsAllowed: getSubstitutionsAllowed(),
+    });
+
+  const applyStyles = () => {
+    if (document.getElementById('productivity-ui-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'productivity-ui-styles';
+    style.textContent = `
+      .meal-card__productivity-badges {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+        margin-top: 0.65rem;
+      }
+
+      .productivity-badge {
+        display: inline-flex;
+        align-items: center;
+        border: 1px solid var(--border-1);
+        border-radius: 999px;
+        padding: 0.2rem 0.55rem;
+        background: var(--surface-1);
+        color: var(--text-muted);
+        font-size: 0.78rem;
+        font-weight: 700;
+        line-height: 1.2;
+        letter-spacing: 0.01em;
+      }
+
+      .productivity-badge--ready,
+      .productivity-badge--ready-with-substitutions {
+        border-color: var(--accent-1);
+        color: var(--text);
+      }
+
+      .productivity-badge--nearly-ready {
+        border-color: var(--accent-2);
+        color: var(--text);
+      }
+
+      .productivity-dashboard {
+        display: grid;
+        gap: 1rem;
+        margin-bottom: 1rem;
+        padding: 1rem;
+        border: 1px solid var(--border-1);
+        border-radius: 1.25rem;
+        background: var(--surface-0);
+      }
+
+      .productivity-dashboard__header,
+      .productivity-shopping__header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      .productivity-dashboard__title,
+      .productivity-shopping__title {
+        margin: 0;
+        font-size: 1.05rem;
+      }
+
+      .productivity-dashboard__subtitle,
+      .productivity-shopping__subtitle {
+        margin: 0.25rem 0 0;
+        color: var(--text-muted);
+        font-size: 0.9rem;
+      }
+
+      .productivity-dashboard__groups {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.75rem;
+      }
+
+      .productivity-dashboard__group,
+      .productivity-shopping {
+        display: grid;
+        gap: 0.75rem;
+        padding: 0.75rem;
+        border: 1px solid var(--border-1);
+        border-radius: 1rem;
+        background: var(--surface-1);
+      }
+
+      .productivity-dashboard__group-title,
+      .productivity-shopping__category-title {
+        margin: 0;
+        font-size: 0.9rem;
+      }
+
+      .productivity-dashboard__list,
+      .productivity-shopping__list {
+        display: grid;
+        gap: 0.35rem;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .productivity-dashboard__item,
+      .productivity-shopping__item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+        min-width: 0;
+        color: var(--text);
+        font-size: 0.85rem;
+      }
+
+      .productivity-dashboard__item-name,
+      .productivity-shopping__item-name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .productivity-dashboard__item-note,
+      .productivity-shopping__item-note {
+        flex: 0 0 auto;
+        color: var(--text-muted);
+        font-size: 0.78rem;
+      }
+
+      .productivity-dashboard__empty,
+      .productivity-shopping__empty {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.85rem;
+      }
+
+      .productivity-shopping__copy {
+        flex: 0 0 auto;
+        border: 1px solid var(--border-1);
+        border-radius: 999px;
+        padding: 0.35rem 0.7rem;
+        background: var(--surface-0);
+        color: var(--text);
+        font: inherit;
+        font-size: 0.82rem;
+        font-weight: 700;
+        cursor: pointer;
+      }
+
+      .productivity-shopping__copy:focus-visible {
+        outline: 2px solid var(--accent-1);
+        outline-offset: 2px;
+      }
+
+      .productivity-shopping__categories {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.75rem;
+      }
+
+      .productivity-shopping__category {
+        display: grid;
+        gap: 0.45rem;
+      }
+    `;
+    document.head.appendChild(style);
+  };
+
+  const enhanceRecipeCard = (card) => {
+    if (!(card instanceof HTMLElement)) return;
+    const recipe = getRecipeById(card.dataset.recipeId);
+    if (!recipe) return;
+
+    const headerInfo = card.querySelector('.meal-card__header > div:first-child');
+    if (!(headerInfo instanceof HTMLElement)) return;
+
+    headerInfo.querySelector('.meal-card__productivity-badges')?.remove();
+
+    const fit = getRecipeFit(recipe);
+    const badgeRow = document.createElement('div');
+    badgeRow.className = 'meal-card__productivity-badges';
+    badgeRow.appendChild(
+      createBadge(
+        typeof tools.getRecipeTypeLabel === 'function' ? tools.getRecipeTypeLabel(recipe) : 'Curated recipe',
+        'source',
+        'Recipe source label',
+      ),
+    );
+    badgeRow.appendChild(createBadge(getPantryBadgeText(fit), fit.status || 'unknown', getPantryBadgeTitle(fit)));
+
+    const tagList = headerInfo.querySelector('.tag-list');
+    if (tagList) {
+      headerInfo.insertBefore(badgeRow, tagList);
+    } else {
+      headerInfo.appendChild(badgeRow);
+    }
+  };
+
+  const enhanceVisibleCards = () => {
+    document.querySelectorAll('.meal-card').forEach(enhanceRecipeCard);
+  };
+
+  const buildDashboardItems = () =>
+    getRecipes()
+      .map((recipe) => ({ recipe, fit: getRecipeFit(recipe) }))
+      .filter((entry) => entry.fit.total > 0)
+      .sort((a, b) => {
+        const missingDiff = a.fit.missing.length - b.fit.missing.length;
+        if (missingDiff) return missingDiff;
+        return a.recipe.name.localeCompare(b.recipe.name);
+      });
+
+  const createDashboardGroup = (title, entries, emptyText) => {
+    const section = document.createElement('section');
+    section.className = 'productivity-dashboard__group';
+    const heading = document.createElement('h3');
+    heading.className = 'productivity-dashboard__group-title';
+    heading.textContent = title;
+    section.appendChild(heading);
+
+    if (!entries.length) {
+      const empty = document.createElement('p');
+      empty.className = 'productivity-dashboard__empty';
+      empty.textContent = emptyText;
+      section.appendChild(empty);
+      return section;
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'productivity-dashboard__list';
+    entries.slice(0, 4).forEach(({ recipe, fit }) => {
+      const item = document.createElement('li');
+      item.className = 'productivity-dashboard__item';
+      const name = document.createElement('span');
+      name.className = 'productivity-dashboard__item-name';
+      name.textContent = recipe.name;
+      item.appendChild(name);
+      const note = document.createElement('span');
+      note.className = 'productivity-dashboard__item-note';
+      note.textContent = getPantryBadgeText(fit);
+      item.appendChild(note);
+      list.appendChild(item);
+    });
+    section.appendChild(list);
+    return section;
+  };
+
+  const groupShoppingItems = (items) => {
+    const groups = new Map();
+    items.forEach((item) => {
+      const category = item.category || 'Other';
+      if (!groups.has(category)) groups.set(category, []);
+      groups.get(category).push(item);
+    });
+    return Array.from(groups.entries()).map(([category, categoryItems]) => ({
+      category,
+      items: categoryItems,
+    }));
+  };
+
+  const getShoppingCandidateRecipes = (entries) =>
+    entries
+      .filter(({ fit }) => Array.isArray(fit.missing) && fit.missing.length > 0)
+      .slice(0, SHOPPING_RECIPE_LIMIT)
+      .map(({ recipe }) => recipe);
+
+  const buildShoppingText = (items) => {
+    if (!items.length) return 'No missing ingredients yet.';
+    const lines = ['Blissful Reverie shopping list'];
+    groupShoppingItems(items).forEach((group) => {
+      lines.push('', group.category);
+      group.items.forEach((item) => {
+        const recipeNote = Array.isArray(item.recipes) && item.recipes.length
+          ? ` — for ${item.recipes.slice(0, 3).join(', ')}`
+          : '';
+        lines.push(`- ${item.name}${recipeNote}`);
+      });
+    });
+    return lines.join('\n');
+  };
+
+  const copyShoppingList = async (button, items) => {
+    const text = buildShoppingText(items);
+    try {
+      await navigator.clipboard.writeText(text);
+      button.textContent = 'Copied';
+    } catch (error) {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.setAttribute('readonly', 'true');
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      try {
+        document.execCommand('copy');
+        button.textContent = 'Copied';
+      } catch (fallbackError) {
+        button.textContent = 'Copy failed';
+      }
+      textarea.remove();
+    }
+    global.setTimeout(() => {
+      button.textContent = 'Copy list';
+    }, 1800);
+  };
+
+  const createShoppingPanel = (entries) => {
+    const candidates = getShoppingCandidateRecipes(entries);
+    const shoppingItems = typeof tools.buildShoppingList === 'function'
+      ? tools.buildShoppingList({
+          recipes: candidates,
+          pantryInventory: getPantryInventory(),
+          recipeMatchesById: getRecipeMatches(),
+          ingredientBySlug: getIngredientBySlug(),
+          substitutionGraph: getSubstitutionGraph(),
+          substitutionsAllowed: getSubstitutionsAllowed(),
+        }).slice(0, SHOPPING_ITEM_LIMIT)
+      : [];
+
+    const panel = document.createElement('section');
+    panel.className = 'productivity-shopping';
+    panel.setAttribute('aria-label', 'Smart shopping list');
+
+    const header = document.createElement('header');
+    header.className = 'productivity-shopping__header';
+    const headerText = document.createElement('div');
+    const title = document.createElement('h3');
+    title.className = 'productivity-shopping__title';
+    title.textContent = 'Smart shopping list';
+    headerText.appendChild(title);
+    const subtitle = document.createElement('p');
+    subtitle.className = 'productivity-shopping__subtitle';
+    subtitle.textContent = shoppingItems.length
+      ? `${shoppingItems.length} missing ingredient${shoppingItems.length === 1 ? '' : 's'} from your closest recipes`
+      : 'Add pantry quantities to generate missing ingredients.';
+    headerText.appendChild(subtitle);
+    header.appendChild(headerText);
+
+    const copyButton = document.createElement('button');
+    copyButton.type = 'button';
+    copyButton.className = 'productivity-shopping__copy';
+    copyButton.textContent = 'Copy list';
+    copyButton.disabled = !shoppingItems.length;
+    copyButton.addEventListener('click', () => copyShoppingList(copyButton, shoppingItems));
+    header.appendChild(copyButton);
+    panel.appendChild(header);
+
+    if (!shoppingItems.length) {
+      const empty = document.createElement('p');
+      empty.className = 'productivity-shopping__empty';
+      empty.textContent = 'Recipes that are missing ingredients will appear here once your pantry is populated.';
+      panel.appendChild(empty);
+      return panel;
+    }
+
+    const categoryGrid = document.createElement('div');
+    categoryGrid.className = 'productivity-shopping__categories';
+    groupShoppingItems(shoppingItems).forEach((group) => {
+      const category = document.createElement('section');
+      category.className = 'productivity-shopping__category';
+      const categoryTitle = document.createElement('h4');
+      categoryTitle.className = 'productivity-shopping__category-title';
+      categoryTitle.textContent = group.category;
+      category.appendChild(categoryTitle);
+      const list = document.createElement('ul');
+      list.className = 'productivity-shopping__list';
+      group.items.forEach((item) => {
+        const row = document.createElement('li');
+        row.className = 'productivity-shopping__item';
+        const name = document.createElement('span');
+        name.className = 'productivity-shopping__item-name';
+        name.textContent = item.name;
+        row.appendChild(name);
+        const note = document.createElement('span');
+        note.className = 'productivity-shopping__item-note';
+        note.textContent = Array.isArray(item.recipes) && item.recipes.length
+          ? `${item.recipes.length} recipe${item.recipes.length === 1 ? '' : 's'}`
+          : '';
+        row.appendChild(note);
+        list.appendChild(row);
+      });
+      category.appendChild(list);
+      categoryGrid.appendChild(category);
+    });
+    panel.appendChild(categoryGrid);
+    return panel;
+  };
+
+  const renderDashboard = () => {
+    const mealView = document.getElementById('meal-view');
+    const mealGrid = document.getElementById('meal-grid');
+    if (!mealView || !mealGrid) return;
+
+    const existing = document.getElementById('productivity-dashboard');
+    existing?.remove();
+
+    const entries = buildDashboardItems();
+    const ready = entries.filter(({ fit }) => fit.status === 'ready' || fit.status === 'ready-with-substitutions');
+    const nearlyReady = entries.filter(({ fit }) => fit.status === 'nearly-ready');
+    const needsShopping = entries.filter(({ fit }) => fit.status === 'needs-shopping');
+
+    const dashboard = document.createElement('section');
+    dashboard.className = 'productivity-dashboard';
+    dashboard.id = 'productivity-dashboard';
+    dashboard.setAttribute('aria-label', 'Pantry recipe dashboard');
+
+    const header = document.createElement('header');
+    header.className = 'productivity-dashboard__header';
+    const headerText = document.createElement('div');
+    const title = document.createElement('h2');
+    title.className = 'productivity-dashboard__title';
+    title.textContent = 'Cook from your pantry';
+    headerText.appendChild(title);
+    const subtitle = document.createElement('p');
+    subtitle.className = 'productivity-dashboard__subtitle';
+    subtitle.textContent = `${ready.length} ready · ${nearlyReady.length} almost ready · ${needsShopping.length} need shopping`;
+    headerText.appendChild(subtitle);
+    header.appendChild(headerText);
+    dashboard.appendChild(header);
+
+    const groups = document.createElement('div');
+    groups.className = 'productivity-dashboard__groups';
+    groups.appendChild(createDashboardGroup('Cook now', ready, 'Add pantry quantities to find ready recipes.'));
+    groups.appendChild(createDashboardGroup('Almost ready', nearlyReady, 'Recipes missing one or two items will appear here.'));
+    groups.appendChild(createDashboardGroup('Shopping candidates', needsShopping, 'Recipes with larger gaps will appear here.'));
+    dashboard.appendChild(groups);
+    dashboard.appendChild(createShoppingPanel(entries));
+
+    mealView.insertBefore(dashboard, mealGrid);
+  };
+
+  const refreshProductivityUi = () => {
+    renderDashboard();
+    enhanceVisibleCards();
+  };
+
+  const render = (context) => {
+    if (!context || !Array.isArray(context.recipes)) {
+      return;
+    }
+    currentContext = context;
+    applyStyles();
+    refreshProductivityUi();
+  };
+
+  global.BlissfulProductivityUI = Object.assign({}, global.BlissfulProductivityUI || {}, {
+    render,
+  });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/scripts/validate-data.js
+++ b/scripts/validate-data.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+const path = require('node:path');
+const { validateData } = require('./data-validation.js');
+
+const rootDir = path.resolve(__dirname, '..');
+global.window = global;
+require(path.join(rootDir, 'data', 'ingredients.js'));
+require(path.join(rootDir, 'data', 'recipes.js'));
+require(path.join(rootDir, 'scripts', 'ingredient-matching.js'));
+
+const ingredients = Array.isArray(global.BLISSFUL_INGREDIENTS) ? global.BLISSFUL_INGREDIENTS : [];
+const recipes = Array.isArray(global.BLISSFUL_RECIPES) ? global.BLISSFUL_RECIPES : [];
+const matching = global.BlissfulMatching || {};
+const { errors, warnings } = validateData({ ingredients, recipes, matching });
+
+if (warnings.length) {
+  console.warn(`Data validation warnings (${warnings.length}):`);
+  warnings.slice(0, 40).forEach((message) => console.warn(`- ${message}`));
+  if (warnings.length > 40) {
+    console.warn(`- ...${warnings.length - 40} more warnings`);
+  }
+}
+
+if (errors.length) {
+  console.error(`Data validation failed with ${errors.length} error(s):`);
+  errors.forEach((message) => console.error(`- ${message}`));
+  process.exit(1);
+}
+
+console.log(`Validated ${ingredients.length} ingredients and ${recipes.length} curated recipes.`);

--- a/tests/data-validation.test.js
+++ b/tests/data-validation.test.js
@@ -1,0 +1,74 @@
+const assert = require('node:assert');
+const { validateData } = require('../scripts/data-validation.js');
+
+const matching = {
+  createIngredientMatcherIndex: (ingredients) => ingredients,
+  mapRecipesToIngredientMatches: (recipes, ingredientIndex) => ({
+    recipeIngredientMatches: new Map(
+      recipes.map((recipe) => [recipe.id, new Set([ingredientIndex[0]?.slug].filter(Boolean))]),
+    ),
+    ingredientUsage: new Map(
+      ingredientIndex.map((ingredient) => [ingredient.slug, 1]),
+    ),
+  }),
+};
+
+const createIngredient = (overrides = {}) => ({
+  slug: 'grain-test',
+  name: 'Test Grain',
+  category: 'Grain',
+  tags: ['Vegetarian'],
+  ...overrides,
+});
+
+const createRecipe = (overrides = {}) => ({
+  id: 'test-recipe',
+  name: 'Test Recipe',
+  baseServings: 2,
+  ingredients: [{ item: 'test grain', quantity: 1, unit: 'cup' }],
+  instructions: ['Cook the test grain.'],
+  equipment: [],
+  tags: [],
+  allergens: [],
+  nutritionPerServing: {
+    calories: 100,
+    protein: 4,
+    carbs: 20,
+    fat: 1,
+  },
+  ...overrides,
+});
+
+const valid = validateData({
+  ingredients: [createIngredient({ category: 'Pasta & Noodles' })],
+  recipes: [createRecipe()],
+  matching,
+});
+assert.deepEqual(valid.errors, []);
+
+const duplicates = validateData({
+  ingredients: [
+    createIngredient(),
+    createIngredient({ name: 'Test Grain' }),
+  ],
+  recipes: [createRecipe()],
+  matching,
+});
+assert(duplicates.errors.some((error) => error.includes('duplicates slug grain-test')));
+assert(duplicates.errors.some((error) => error.includes("duplicates display name 'Test Grain'")));
+
+const invalidSchema = validateData({
+  ingredients: [createIngredient({ category: 'Unknown Category' })],
+  recipes: [
+    createRecipe({
+      allergens: ['seafood'],
+      ingredients: [{ item: 'test grain', quantity: -1, unit: 'cup' }],
+    }),
+  ],
+  matching,
+});
+assert(invalidSchema.errors.some((error) => error.includes("unsupported category 'Unknown Category'")));
+assert(invalidSchema.errors.some((error) => error.includes("non-canonical allergen 'seafood'")));
+assert(invalidSchema.errors.some((error) => error.includes("invalid quantity '-1'")));
+
+console.log('Data validation edge-case tests passed.');

--- a/tests/ingredient-matching.test.js
+++ b/tests/ingredient-matching.test.js
@@ -55,6 +55,59 @@ test('doesEntryMatchIngredient avoids false positives for different items', () =
   );
 });
 
+test('doesEntryMatchIngredient uses whole phrases instead of substrings', () => {
+  const matcher = matching.createIngredientMatcher({
+    slug: 'meat-ham',
+    name: 'Ham',
+  });
+  const entry = {
+    text: matching.sanitizeComparisonText('graham crackers'),
+    tokens: matching.buildTokenSet('graham crackers'),
+  };
+  assert(
+    !matching.doesEntryMatchIngredient(entry, matcher),
+    'expected graham crackers not to match ham',
+  );
+});
+
+test('mapRecipesToIngredientMatches keeps the most specific overlapping ingredient', () => {
+  const ingredients = [
+    { slug: 'pasta-shells', name: 'Pasta Shells' },
+    { slug: 'pasta-jumbo-shells', name: 'Jumbo Pasta Shells' },
+    { slug: 'grain-rice-brown', name: 'Rice (Brown)' },
+    { slug: 'grain-rice-cooked', name: 'Cooked Rice' },
+    { slug: 'veg-bell-pepper-red', name: 'Bell Pepper (Red)' },
+    { slug: 'veg-bell-pepper', name: 'Bell Pepper' },
+    {
+      slug: 'meat-beef-ground-85',
+      name: 'Ground Beef (85% Lean)',
+      aliases: ['Lean Ground Beef', 'Ground Beef'],
+    },
+  ];
+  const recipes = [
+    {
+      id: 'specific-ingredients',
+      ingredients: [
+        { item: 'jumbo pasta shells' },
+        { item: 'cooked brown rice' },
+        { item: 'green bell pepper' },
+        { item: 'lean ground beef' },
+      ],
+    },
+  ];
+  const index = matching.createIngredientMatcherIndex(ingredients);
+  const { recipeIngredientMatches } = matching.mapRecipesToIngredientMatches(recipes, index);
+  const matches = recipeIngredientMatches.get('specific-ingredients');
+
+  assert(matches.has('pasta-jumbo-shells'));
+  assert(!matches.has('pasta-shells'));
+  assert(matches.has('grain-rice-brown'));
+  assert(!matches.has('grain-rice-cooked'));
+  assert(matches.has('veg-bell-pepper'));
+  assert(!matches.has('veg-bell-pepper-red'));
+  assert(matches.has('meat-beef-ground-85'));
+});
+
 test('mapRecipesToIngredientMatches maps matches and usage flags', () => {
   const ingredients = [
     { slug: 'veg-sweet-potato', name: 'Sweet Potato', category: 'Vegetable' },

--- a/tests/integration-wiring.test.js
+++ b/tests/integration-wiring.test.js
@@ -1,0 +1,42 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '..');
+const read = (relativePath) => fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+
+const indexHtml = read('index.html');
+const expectedScripts = [
+  'data/ingredients.js',
+  'data/recipes.js',
+  'scripts/ingredient-matching.js',
+  'scripts/productivity-tools.js',
+  'scripts/productivity-settings.js',
+  'scripts/productivity-onboarding.js',
+  'scripts/productivity-ui.js',
+  'scripts/theme-utils.js',
+  'scripts/app.js',
+];
+
+let previousIndex = -1;
+expectedScripts.forEach((src) => {
+  const currentIndex = indexHtml.indexOf(`src="${src}"`);
+  assert(currentIndex > previousIndex, `${src} should load after the previous application script`);
+  previousIndex = currentIndex;
+});
+
+const themeUtils = read('scripts/theme-utils.js');
+assert(!themeUtils.includes('BLISSFUL_INGREDIENTS'));
+assert(!themeUtils.includes('productivity-tools.js'));
+assert(!themeUtils.includes('document.createElement(\'script\')'));
+
+const productivityUi = read('scripts/productivity-ui.js');
+assert(!productivityUi.includes('MutationObserver'));
+assert(productivityUi.includes('global.BlissfulProductivityUI'));
+
+const app = read('scripts/app.js');
+assert(app.includes('card.dataset.recipeId = recipe.id'));
+assert(app.includes('productivityUi.render({'));
+assert(app.includes('applyStarterState'));
+
+console.log('Application wiring tests passed.');

--- a/tests/pantry-matching.test.js
+++ b/tests/pantry-matching.test.js
@@ -1,0 +1,70 @@
+const assert = require('assert');
+const tools = require('../scripts/productivity-tools.js');
+
+const recipe = { id: 'weekday-bowl', name: 'Weekday Bowl' };
+const matches = new Set(['grain-quinoa', 'veg-cauliflower', 'dairy-milk-whole']);
+const pantry = {
+  'grain-quinoa': { quantity: '1', unit: 'cup' },
+  'veg-cauliflower': { quantity: '1', unit: 'head' },
+  'alt-milk-oat': { quantity: '1', unit: 'carton' },
+};
+const substitutions = new Map([
+  [
+    'dairy-milk-whole',
+    {
+      label: 'Milk alternatives',
+      members: new Set(['dairy-milk-whole', 'alt-milk-oat']),
+    },
+  ],
+]);
+
+const exactFit = tools.analyzeRecipePantryFit({
+  recipe,
+  pantryInventory: pantry,
+  recipeIngredientMatches: matches,
+  substitutionGraph: substitutions,
+  substitutionsAllowed: false,
+});
+assert.equal(exactFit.status, 'nearly-ready');
+assert.deepEqual(exactFit.missing, ['dairy-milk-whole']);
+
+const flexibleFit = tools.analyzeRecipePantryFit({
+  recipe,
+  pantryInventory: pantry,
+  recipeIngredientMatches: matches,
+  substitutionGraph: substitutions,
+  substitutionsAllowed: true,
+});
+assert.equal(flexibleFit.status, 'ready-with-substitutions');
+assert.equal(flexibleFit.substituted.length, 1);
+assert.equal(flexibleFit.substituted[0].substitute, 'alt-milk-oat');
+
+const shoppingList = tools.buildShoppingList({
+  recipes: [recipe, recipe],
+  pantryInventory: pantry,
+  recipeMatchesById: new Map([[recipe.id, matches]]),
+  ingredientBySlug: new Map([
+    ['grain-quinoa', { slug: 'grain-quinoa', name: 'Quinoa', category: 'Grain' }],
+    ['veg-cauliflower', { slug: 'veg-cauliflower', name: 'Cauliflower', category: 'Vegetable' }],
+    ['dairy-milk-whole', { slug: 'dairy-milk-whole', name: 'Whole Milk', category: 'Dairy' }],
+  ]),
+  substitutionGraph: substitutions,
+  substitutionsAllowed: false,
+});
+assert.equal(shoppingList.length, 1);
+assert.equal(shoppingList[0].slug, 'dairy-milk-whole');
+assert.deepEqual(shoppingList[0].recipes, ['Weekday Bowl']);
+
+const substitutedShoppingList = tools.buildShoppingList({
+  recipes: [recipe],
+  pantryInventory: pantry,
+  recipeMatchesById: new Map([[recipe.id, matches]]),
+  ingredientBySlug: new Map([
+    ['dairy-milk-whole', { slug: 'dairy-milk-whole', name: 'Whole Milk', category: 'Dairy' }],
+  ]),
+  substitutionGraph: substitutions,
+  substitutionsAllowed: true,
+});
+assert.deepEqual(substitutedShoppingList, []);
+
+console.log('Pantry matching tests passed.');

--- a/tests/productivity-tools.test.js
+++ b/tests/productivity-tools.test.js
@@ -1,0 +1,114 @@
+const assert = require('assert');
+const tools = require('../scripts/productivity-tools.js');
+
+assert.equal(tools.getRecipeTypeLabel({ id: 'roasted-vegetable-quinoa-bowls', category: 'Vegetarian' }), 'Curated recipe');
+assert.equal(tools.getRecipeTypeLabel({ id: 'ingredient-spotlight-veg-carrot', category: 'Ingredient Spotlight' }), 'Ingredient idea');
+assert.equal(tools.getRecipeTypeLabel({ id: 'diet-vegan-1', category: 'Diet Collection' }), 'Generated template');
+assert.equal(tools.getRecipeTypeLabel({ id: 'menu-weeknight-1', category: 'Menu Collection' }), 'Generated template');
+assert.equal(tools.getRecipeTypeLabel({ id: 'custom-generated', generated: true }), 'Generated template');
+assert.equal(tools.getRecipeTypeLabel({ id: 'regional-coastal-1' }), 'Generated template');
+
+const backupStorage = new Map();
+const storage = {
+  getItem: (key) => (backupStorage.has(key) ? backupStorage.get(key) : null),
+  setItem: (key, value) => backupStorage.set(key, String(value)),
+};
+storage.setItem('blissful-app-state', JSON.stringify({ activeView: 'meals' }));
+storage.setItem('blissful-favorites', JSON.stringify(['recipe-a']));
+storage.setItem('blissful-measurement', 'metric');
+const backup = tools.createBackup(storage);
+assert.equal(backup.app, 'Blissful Reverie');
+assert.equal(backup.version, 1);
+assert.equal(backup.data['blissful-app-state'], JSON.stringify({ activeView: 'meals' }));
+assert.equal(backup.data['blissful-measurement'], 'metric');
+assert.equal(backup.data['blissful-measurement-system'], undefined);
+
+const restoreStorage = new Map();
+tools.restoreBackup(backup, {
+  setItem: (key, value) => restoreStorage.set(key, value),
+});
+assert.equal(restoreStorage.get('blissful-favorites'), JSON.stringify(['recipe-a']));
+assert.equal(restoreStorage.get('blissful-measurement'), 'metric');
+
+assert.equal(tools.hasMeaningfulAppState(null), false);
+assert.equal(tools.hasMeaningfulAppState({
+  activeView: 'meals',
+  mealFilters: {
+    search: '',
+    ingredients: [],
+    ingredientsExcluded: [],
+    tags: [],
+    tagsExcluded: [],
+    allergies: [],
+    allergiesExcluded: [],
+    equipment: [],
+    equipmentExcluded: [],
+    favoritesOnly: false,
+    familyMembers: [],
+    pantryOnly: false,
+    substitutionsAllowed: false,
+  },
+  pantryInventory: {},
+  kitchenInventory: [],
+  familyMembers: [{ name: 'Alex' }, { name: 'Riley' }],
+}), false);
+assert.equal(tools.hasMeaningfulAppState({
+  activeView: 'meals',
+  pantryInventory: { 'grain-quinoa': { quantity: '1', unit: 'each' } },
+}), true);
+
+const existingFavoritesStorage = {
+  getItem: (key) => (key === 'blissful-favorites' ? JSON.stringify(['recipe-a']) : null),
+};
+assert.equal(tools.hasMeaningfulStoredState(existingFavoritesStorage), true);
+const existingMealPlanStorage = {
+  getItem: (key) => (
+    key === 'blissful-meal-plan'
+      ? JSON.stringify({ '2026-06-09': [{ id: 'entry-a', title: 'Dinner', type: 'meal' }] })
+      : null
+  ),
+};
+assert.equal(tools.hasMeaningfulStoredState(existingMealPlanStorage), true);
+const existingMeasurementStorage = {
+  getItem: (key) => (key === 'blissful-measurement' ? 'metric' : null),
+};
+assert.equal(tools.hasMeaningfulStoredState(existingMeasurementStorage), true);
+assert.equal(tools.hasMeaningfulStoredState({ getItem: () => null }), false);
+
+const starter = tools.createStarterState({
+  familyName: 'Test Household',
+  allergies: ['nuts', 'nuts'],
+  diets: ['Vegetarian', 'Vegetarian'],
+  pantrySlugs: ['grain-quinoa', 'grain-quinoa'],
+  kitchenItems: ['Skillet', 'Skillet'],
+});
+assert.equal(starter.mealFilters.pantryOnly, true);
+assert.equal(starter.mealFilters.substitutionsAllowed, true);
+assert.deepEqual(starter.mealFilters.tags, ['Vegetarian']);
+assert.deepEqual(starter.mealFilters.allergies, []);
+assert.deepEqual(starter.mealFilters.allergiesExcluded, ['nuts']);
+assert.deepEqual(starter.familyMembers[0].allergies, ['nuts']);
+assert.equal(starter.pantryInventory['grain-quinoa'].unit, 'each');
+assert.deepEqual(starter.pantryFilters, {
+  search: '',
+  categories: [],
+  tags: [],
+  allergens: [],
+});
+assert.deepEqual(starter.kitchenInventory, ['Skillet']);
+
+const dashboard = tools.summarizeDashboard({
+  recipes: [
+    { id: 'ready', name: 'Ready' },
+    { id: 'near', name: 'Near' },
+  ],
+  pantryInventory: { a: { quantity: '1', unit: 'each' } },
+  recipeMatchesById: new Map([
+    ['ready', new Set(['a'])],
+    ['near', new Set(['a', 'b'])],
+  ]),
+});
+assert.equal(dashboard.cookNow.length, 1);
+assert.equal(dashboard.nearlyReady.length, 1);
+
+console.log('Productivity helper tests passed.');


### PR DESCRIPTION
## Summary

- loads productivity scripts explicitly from `index.html` in dependency order and removes feature loading/data mutation from theme utilities
- integrates recipe badges, pantry dashboard, and smart shopping list through a direct `scripts/app.js` render hook with live pantry and substitution state
- adds first-run setup with meaningful-state detection, schema-compatible starter data, allergy exclusions, and same-page application
- keeps palette and holiday controls inside a native keyboard-accessible `Advanced appearance` disclosure while preserving existing listeners
- adds reusable catalog validation, CI, focused regression tests, and current setup/architecture/schema documentation
- fixes one duplicate recipe ID and replaces ambiguous `seafood` allergens with canonical `fish` or `shellfish` values
- final review fixes ingredient false positives/duplicate requirements, existing-user onboarding detection, and the measurement backup key

## Stale branch assimilation

- moved 19 useful additive ingredient entries from the PR #56 intent directly into `data/ingredients.js`
- preserved stable prefixed slugs and did not copy any existing-slug renames
- skipped the proposed generic Tamari entry because `condiment-tamari-gf` already covers that product concept

## Testing

- `npm test`
  - validates 528 ingredients and 314 curated recipes
  - data validation edge cases
  - ingredient matching and specificity regressions
  - pantry fit and shopping lists
  - productivity helpers, backup keys, persisted-state detection, and starter state
  - application script wiring
- `node --check scripts/app.js`
- `node --check scripts/productivity-tools.js`
- `node --check scripts/productivity-ui.js`
- `node --check scripts/productivity-onboarding.js`
- `node --check scripts/productivity-settings.js`
- `node --check scripts/data-validation.js`
- `node --check scripts/validate-data.js`
- `git diff --check`
- headless Edge verification against the local `file://` app:
  - recipe cards, source/readiness badges, dashboard, smart shopping list, and empty-storage onboarding render
  - onboarding applies starter state without a normal reload and does not reappear for saved app state or existing favorites
  - recipe search, reset, pantry-only, substitutions, favorites, and meal-plan scheduling work
  - dashboard, card readiness, and shopping list update from live pantry changes
  - mode, unit, palette, and holiday controls persist inside `Advanced appearance`
  - no page exceptions or console errors observed
- GitHub Actions `Validate` run #29 succeeded for commit `0484136`

## Remaining risks

- the app shell remains a large single file; this change limits integration to a small render/state API rather than attempting a broad rewrite
- productivity/onboarding/settings styles remain colocated with their scripts; moving them into the main stylesheet can be considered separately
- catalog validation reports 253 ingredients unused by curated recipes before runtime coverage generation; this is expected and remains a warning after false-positive matches were removed
- resolving the duplicate turkey club ID renames the earlier entry to `stacked-turkey-club-sandwich`; the generic `turkey-club-sandwich` ID retains the prior lookup winner

## Follow-up recommendations

- add visible backup import/export controls using the tested helpers
- allow meal-plan selections to drive the shopping list instead of the current closest-recipe limit
- modularize additional `scripts/app.js` domains only as focused feature work requires it

## Merge recommendation

Ready to merge. PR #118 is non-draft, mergeable, single-commit, and green on Validate run #29.