### PR TITLE
Add local backup import and export controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm run test:validation
 npm run test:matching
 npm run test:pantry
 npm run test:productivity
+npm run test:backup
 npm run test:wiring
 ```
 
@@ -50,6 +51,7 @@ npm run test:wiring
 - `scripts/productivity-ui.js` renders badges, the pantry dashboard, and the smart shopping list from live state supplied by `scripts/app.js`.
 - `scripts/productivity-onboarding.js` handles first-run setup and applies saved starter state without a normal reload.
 - `scripts/productivity-settings.js` moves optional palette and holiday controls into the native `Advanced appearance` disclosure before app event handlers are bound.
+- `scripts/productivity-backup.js` adds compact local JSON backup import and export controls inside Settings.
 - `scripts/app.js` owns in-memory state, localStorage persistence, recipe rendering, filters, pantry, family, and meal planning.
 
 User data remains in browser localStorage. The primary state key is `blissful-app-state`; meal plans, favorites, theme preferences, holiday settings, and measurement preferences use separate version-stable keys. There is no network synchronization.

--- a/index.html
+++ b/index.html
@@ -496,6 +496,7 @@
     <script src="scripts/ingredient-matching.js" defer></script>
     <script src="scripts/productivity-tools.js" defer></script>
     <script src="scripts/productivity-settings.js" defer></script>
+    <script src="scripts/productivity-backup.js" defer></script>
     <script src="scripts/productivity-onboarding.js" defer></script>
     <script src="scripts/productivity-ui.js" defer></script>
     <script src="scripts/theme-utils.js" defer></script>

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "test:matching": "node tests/ingredient-matching.test.js",
     "test:pantry": "node tests/pantry-matching.test.js",
     "test:productivity": "node tests/productivity-tools.test.js",
+    "test:backup": "node tests/productivity-backup.test.js",
     "test:wiring": "node tests/integration-wiring.test.js",
-    "test": "npm run validate:data && npm run test:validation && npm run test:matching && npm run test:pantry && npm run test:productivity && npm run test:wiring"
+    "test": "npm run validate:data && npm run test:validation && npm run test:matching && npm run test:pantry && npm run test:productivity && npm run test:backup && npm run test:wiring"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/productivity-backup.js
+++ b/scripts/productivity-backup.js
@@ -1,0 +1,283 @@
+;(function (global) {
+  const IMPORT_SUCCESS_KEY = 'blissful-backup-import-success';
+
+  const buildBackupFilename = (date = new Date()) => {
+    const value = date instanceof Date && !Number.isNaN(date.getTime()) ? date : new Date();
+    return `blissful-reverie-backup-${value.toISOString().slice(0, 10)}.json`;
+  };
+
+  const serializeBackup = (backup) => `${JSON.stringify(backup, null, 2)}\n`;
+
+  const parseBackupText = (text) => {
+    try {
+      return JSON.parse(String(text || ''));
+    } catch (error) {
+      throw new Error('Backup file is not valid JSON.');
+    }
+  };
+
+  const restoreBackupText = (
+    text,
+    {
+      tools = global.BlissfulProductivity,
+      storage = global.localStorage,
+    } = {},
+  ) => {
+    if (!tools || typeof tools.restoreBackup !== 'function') {
+      throw new Error('Backup restore is unavailable.');
+    }
+    const backup = parseBackupText(text);
+    tools.restoreBackup(backup, storage);
+    return backup;
+  };
+
+  const downloadBackup = (
+    backup,
+    {
+      documentRef = global.document,
+      urlApi = global.URL,
+      BlobCtor = global.Blob,
+      date = new Date(),
+    } = {},
+  ) => {
+    if (!documentRef || !urlApi?.createObjectURL || typeof BlobCtor !== 'function') {
+      throw new Error('Backup download is unavailable.');
+    }
+    const blob = new BlobCtor([serializeBackup(backup)], { type: 'application/json' });
+    const objectUrl = urlApi.createObjectURL(blob);
+    const link = documentRef.createElement('a');
+    link.href = objectUrl;
+    link.download = buildBackupFilename(date);
+    link.hidden = true;
+    documentRef.body.appendChild(link);
+    link.click();
+    link.remove();
+    global.setTimeout(() => urlApi.revokeObjectURL(objectUrl), 0);
+    return link.download;
+  };
+
+  const api = {
+    buildBackupFilename,
+    serializeBackup,
+    parseBackupText,
+    restoreBackupText,
+    downloadBackup,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const tools = global.BlissfulProductivity || {};
+
+  const applyStyles = () => {
+    if (document.getElementById('productivity-backup-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'productivity-backup-styles';
+    style.textContent = `
+      .productivity-backup {
+        border: 1px solid var(--border-1);
+        border-radius: 1rem;
+        padding: 0.65rem 0.75rem;
+        background: var(--surface-0);
+      }
+
+      .productivity-backup__summary {
+        color: var(--text);
+        cursor: pointer;
+        font-weight: 800;
+      }
+
+      .productivity-backup__body {
+        display: grid;
+        gap: 0.7rem;
+        padding-top: 0.65rem;
+      }
+
+      .productivity-backup__description,
+      .productivity-backup__status {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.82rem;
+        line-height: 1.35;
+      }
+
+      .productivity-backup__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.55rem;
+      }
+
+      .productivity-backup__button {
+        border: 1px solid var(--btn-secondary-br);
+        border-radius: calc(var(--radius) - 6px);
+        padding: 0.5rem 0.75rem;
+        background: var(--btn-secondary-bg);
+        color: var(--text);
+        cursor: pointer;
+        font: inherit;
+        font-size: 0.82rem;
+        font-weight: 700;
+      }
+
+      .productivity-backup__button:hover,
+      .productivity-backup__button:focus-visible {
+        background: color-mix(in oklab, var(--layer-3), white 12%);
+      }
+
+      .productivity-backup__button:disabled {
+        cursor: wait;
+        opacity: 0.6;
+      }
+
+      .productivity-backup__status[data-state='success'] {
+        color: var(--color-success, #26734d);
+      }
+
+      .productivity-backup__status[data-state='error'] {
+        color: var(--color-danger, #a53b32);
+      }
+    `;
+    document.head.appendChild(style);
+  };
+
+  const renderBackupControls = () => {
+    const toolbar = document.getElementById('theme-toolbar');
+    if (!toolbar || document.getElementById('productivity-settings-backup')) {
+      return Boolean(toolbar);
+    }
+    if (
+      typeof tools.createBackup !== 'function'
+      || typeof tools.restoreBackup !== 'function'
+    ) {
+      return false;
+    }
+
+    applyStyles();
+
+    const details = document.createElement('details');
+    details.className = 'productivity-backup';
+    details.id = 'productivity-settings-backup';
+
+    const summary = document.createElement('summary');
+    summary.className = 'productivity-backup__summary';
+    summary.textContent = 'Local backup';
+    details.appendChild(summary);
+
+    const body = document.createElement('div');
+    body.className = 'productivity-backup__body';
+
+    const description = document.createElement('p');
+    description.className = 'productivity-backup__description';
+    description.textContent = 'Download this browser\'s planner data or restore it from a Blissful Reverie JSON backup.';
+    body.appendChild(description);
+
+    const actions = document.createElement('div');
+    actions.className = 'productivity-backup__actions';
+
+    const exportButton = document.createElement('button');
+    exportButton.type = 'button';
+    exportButton.className = 'productivity-backup__button';
+    exportButton.textContent = 'Export backup';
+    actions.appendChild(exportButton);
+
+    const importButton = document.createElement('button');
+    importButton.type = 'button';
+    importButton.className = 'productivity-backup__button';
+    importButton.textContent = 'Import backup';
+    importButton.setAttribute('aria-controls', 'productivity-backup-file');
+    actions.appendChild(importButton);
+
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.id = 'productivity-backup-file';
+    fileInput.className = 'sr-only';
+    fileInput.accept = '.json,application/json';
+    fileInput.tabIndex = -1;
+    actions.appendChild(fileInput);
+    body.appendChild(actions);
+
+    const status = document.createElement('p');
+    status.className = 'productivity-backup__status';
+    status.hidden = true;
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    body.appendChild(status);
+
+    const setStatus = (message, state) => {
+      status.textContent = message;
+      status.dataset.state = state;
+      status.hidden = false;
+    };
+
+    const setBusy = (busy) => {
+      exportButton.disabled = busy;
+      importButton.disabled = busy;
+    };
+
+    exportButton.addEventListener('click', () => {
+      try {
+        const backup = tools.createBackup(global.localStorage);
+        const filename = downloadBackup(backup);
+        setStatus(`Backup downloaded as ${filename}.`, 'success');
+      } catch (error) {
+        setStatus(error?.message || 'Backup export failed.', 'error');
+      }
+    });
+
+    importButton.addEventListener('click', () => fileInput.click());
+
+    fileInput.addEventListener('change', async () => {
+      const file = fileInput.files?.[0];
+      if (!file) return;
+
+      setBusy(true);
+      setStatus('Importing backup...', 'pending');
+      try {
+        const text = await file.text();
+        restoreBackupText(text, { tools, storage: global.localStorage });
+        try {
+          global.sessionStorage?.setItem?.(IMPORT_SUCCESS_KEY, 'true');
+        } catch (error) {
+          // The current status still confirms success if session storage is unavailable.
+        }
+        setStatus('Backup imported. Reloading planner...', 'success');
+        global.setTimeout(() => global.location.reload(), 350);
+      } catch (error) {
+        setStatus(error?.message || 'Backup import failed.', 'error');
+        setBusy(false);
+      } finally {
+        fileInput.value = '';
+      }
+    });
+
+    try {
+      if (global.sessionStorage?.getItem?.(IMPORT_SUCCESS_KEY) === 'true') {
+        global.sessionStorage.removeItem(IMPORT_SUCCESS_KEY);
+        setStatus('Backup imported successfully.', 'success');
+        details.open = true;
+      }
+    } catch (error) {
+      // Import already succeeded; a missing confirmation is non-fatal.
+    }
+
+    details.appendChild(body);
+    toolbar.appendChild(details);
+    return true;
+  };
+
+  const start = () => {
+    if (renderBackupControls()) return;
+    global.requestAnimationFrame(() => renderBackupControls());
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/scripts/productivity-tools.js
+++ b/scripts/productivity-tools.js
@@ -17,6 +17,18 @@
     HOLIDAY_THEME_STORAGE_KEY,
     MEASUREMENT_STORAGE_KEY,
   ];
+  const isRecord = (value) => (
+    value && typeof value === 'object' && !Array.isArray(value)
+  );
+  const BACKUP_DATA_VALIDATORS = new Map([
+    [APP_STATE_STORAGE_KEY, isRecord],
+    [MEAL_PLAN_STORAGE_KEY, isRecord],
+    [FAVORITES_STORAGE_KEY, Array.isArray],
+    [PANTRY_FAVORITES_STORAGE_KEY, Array.isArray],
+    [THEME_STORAGE_KEY, isRecord],
+    [HOLIDAY_THEME_STORAGE_KEY, isRecord],
+    [MEASUREMENT_STORAGE_KEY, (value) => value === 'imperial' || value === 'metric'],
+  ]);
 
   const GENERATED_CATEGORY_LABELS = new Map([
     ['Ingredient Spotlight', 'Ingredient idea'],
@@ -166,15 +178,77 @@
     };
   };
 
-  const restoreBackup = (backup, storage = global.localStorage) => {
-    if (!backup || backup.app !== 'Blissful Reverie' || typeof backup.data !== 'object') {
+  const getBackupEntries = (backup) => {
+    if (!backup || typeof backup !== 'object' || Array.isArray(backup)) {
       throw new Error('Invalid Blissful Reverie backup.');
     }
-    BACKUP_KEYS.forEach((key) => {
-      if (Object.prototype.hasOwnProperty.call(backup.data, key)) {
-        storage?.setItem?.(key, String(backup.data[key]));
+    if (backup.app !== 'Blissful Reverie') {
+      throw new Error('Backup is not for Blissful Reverie.');
+    }
+    if (backup.version !== BACKUP_VERSION) {
+      throw new Error('Unsupported Blissful Reverie backup version.');
+    }
+    if (!backup.data || typeof backup.data !== 'object' || Array.isArray(backup.data)) {
+      throw new Error('Backup data is missing or invalid.');
+    }
+
+    return BACKUP_KEYS
+      .filter((key) => Object.prototype.hasOwnProperty.call(backup.data, key))
+      .map((key) => {
+        const value = backup.data[key];
+        if (typeof value !== 'string') {
+          throw new Error(`Backup data for ${key} is invalid.`);
+        }
+        const validator = BACKUP_DATA_VALIDATORS.get(key);
+        try {
+          const parsedValue = key === MEASUREMENT_STORAGE_KEY ? value : JSON.parse(value);
+          if (!validator?.(parsedValue)) {
+            throw new Error('Invalid backup value.');
+          }
+        } catch (error) {
+          throw new Error(`Backup data for ${key} is invalid.`);
+        }
+        return [key, value];
+      });
+  };
+
+  const restoreBackup = (backup, storage = global.localStorage) => {
+    const entries = getBackupEntries(backup);
+    if (!storage || typeof storage.setItem !== 'function') {
+      throw new Error('Backup storage is unavailable.');
+    }
+
+    const previousValues = new Map();
+    entries.forEach(([key]) => {
+      try {
+        previousValues.set(key, typeof storage.getItem === 'function' ? storage.getItem(key) : null);
+      } catch (error) {
+        previousValues.set(key, null);
       }
     });
+
+    const writtenKeys = [];
+    try {
+      entries.forEach(([key, value]) => {
+        storage.setItem(key, value);
+        writtenKeys.push(key);
+      });
+    } catch (error) {
+      writtenKeys.reverse().forEach((key) => {
+        try {
+          const previous = previousValues.get(key);
+          if (previous === null || previous === undefined) {
+            storage.removeItem?.(key);
+          } else {
+            storage.setItem(key, previous);
+          }
+        } catch (rollbackError) {
+          // Best effort only; the original storage error remains the useful failure.
+        }
+      });
+      throw new Error('Unable to restore backup.');
+    }
+
     return true;
   };
 

--- a/tests/integration-wiring.test.js
+++ b/tests/integration-wiring.test.js
@@ -12,6 +12,7 @@ const expectedScripts = [
   'scripts/ingredient-matching.js',
   'scripts/productivity-tools.js',
   'scripts/productivity-settings.js',
+  'scripts/productivity-backup.js',
   'scripts/productivity-onboarding.js',
   'scripts/productivity-ui.js',
   'scripts/theme-utils.js',

--- a/tests/productivity-backup.test.js
+++ b/tests/productivity-backup.test.js
@@ -1,0 +1,48 @@
+const assert = require('node:assert');
+const backupUi = require('../scripts/productivity-backup.js');
+const tools = require('../scripts/productivity-tools.js');
+
+assert.equal(
+  backupUi.buildBackupFilename(new Date('2026-06-09T18:00:00.000Z')),
+  'blissful-reverie-backup-2026-06-09.json',
+);
+
+const backup = {
+  app: 'Blissful Reverie',
+  version: 1,
+  exportedAt: '2026-06-09T18:00:00.000Z',
+  data: {
+    'blissful-favorites': JSON.stringify(['recipe-a']),
+    'blissful-measurement': 'metric',
+  },
+};
+const serialized = backupUi.serializeBackup(backup);
+assert(serialized.endsWith('\n'));
+assert.deepEqual(backupUi.parseBackupText(serialized), backup);
+
+const restored = new Map();
+backupUi.restoreBackupText(serialized, {
+  tools,
+  storage: {
+    getItem: (key) => restored.get(key) ?? null,
+    setItem: (key, value) => restored.set(key, value),
+    removeItem: (key) => restored.delete(key),
+  },
+});
+assert.equal(restored.get('blissful-favorites'), JSON.stringify(['recipe-a']));
+assert.equal(restored.get('blissful-measurement'), 'metric');
+
+assert.throws(
+  () => backupUi.restoreBackupText('{broken json', { tools, storage: {} }),
+  /Backup file is not valid JSON/,
+);
+assert.throws(
+  () => backupUi.restoreBackupText(JSON.stringify({
+    app: 'Unknown Planner',
+    version: 1,
+    data: {},
+  }), { tools, storage: {} }),
+  /not for Blissful Reverie/,
+);
+
+console.log('Productivity backup tests passed.');

--- a/tests/productivity-tools.test.js
+++ b/tests/productivity-tools.test.js
@@ -14,12 +14,23 @@ const storage = {
   setItem: (key, value) => backupStorage.set(key, String(value)),
 };
 storage.setItem('blissful-app-state', JSON.stringify({ activeView: 'meals' }));
+storage.setItem('blissful-meal-plan', JSON.stringify({ '2026-06-09': [] }));
 storage.setItem('blissful-favorites', JSON.stringify(['recipe-a']));
+storage.setItem('blissful-pantry-favorites', JSON.stringify(['grain-quinoa']));
+storage.setItem('blissful-theme', JSON.stringify({ mode: 'dark' }));
+storage.setItem('blissful-holiday-themes', JSON.stringify({ enabled: true }));
 storage.setItem('blissful-measurement', 'metric');
 const backup = tools.createBackup(storage);
 assert.equal(backup.app, 'Blissful Reverie');
 assert.equal(backup.version, 1);
+assert.equal(typeof backup.exportedAt, 'string');
+assert.deepEqual(Object.keys(backup.data).sort(), [...tools.BACKUP_KEYS].sort());
 assert.equal(backup.data['blissful-app-state'], JSON.stringify({ activeView: 'meals' }));
+assert.equal(backup.data['blissful-meal-plan'], JSON.stringify({ '2026-06-09': [] }));
+assert.equal(backup.data['blissful-favorites'], JSON.stringify(['recipe-a']));
+assert.equal(backup.data['blissful-pantry-favorites'], JSON.stringify(['grain-quinoa']));
+assert.equal(backup.data['blissful-theme'], JSON.stringify({ mode: 'dark' }));
+assert.equal(backup.data['blissful-holiday-themes'], JSON.stringify({ enabled: true }));
 assert.equal(backup.data['blissful-measurement'], 'metric');
 assert.equal(backup.data['blissful-measurement-system'], undefined);
 
@@ -29,6 +40,51 @@ tools.restoreBackup(backup, {
 });
 assert.equal(restoreStorage.get('blissful-favorites'), JSON.stringify(['recipe-a']));
 assert.equal(restoreStorage.get('blissful-measurement'), 'metric');
+
+assert.throws(
+  () => tools.restoreBackup({ app: 'Another Planner', version: 1, data: {} }, storage),
+  /not for Blissful Reverie/,
+);
+assert.throws(
+  () => tools.restoreBackup({ app: 'Blissful Reverie', version: 2, data: {} }, storage),
+  /Unsupported Blissful Reverie backup version/,
+);
+assert.throws(
+  () => tools.restoreBackup({ app: 'Blissful Reverie', version: 1 }, storage),
+  /Backup data is missing or invalid/,
+);
+
+let invalidBackupWrites = 0;
+const invalidBackupStorage = {
+  getItem: () => null,
+  setItem: () => {
+    invalidBackupWrites += 1;
+  },
+};
+assert.throws(
+  () => tools.restoreBackup({
+    app: 'Blissful Reverie',
+    version: 1,
+    data: {
+      'blissful-app-state': JSON.stringify({ activeView: 'meals' }),
+      'blissful-favorites': ['recipe-a'],
+    },
+  }, invalidBackupStorage),
+  /Backup data for blissful-favorites is invalid/,
+);
+assert.equal(invalidBackupWrites, 0);
+assert.throws(
+  () => tools.restoreBackup({
+    app: 'Blissful Reverie',
+    version: 1,
+    data: {
+      'blissful-app-state': JSON.stringify({ activeView: 'meals' }),
+      'blissful-favorites': '{broken json',
+    },
+  }, invalidBackupStorage),
+  /Backup data for blissful-favorites is invalid/,
+);
+assert.equal(invalidBackupWrites, 0);
 
 assert.equal(tools.hasMeaningfulAppState(null), false);
 assert.equal(tools.hasMeaningfulAppState({


### PR DESCRIPTION
## Summary

- adds a compact `Local backup` disclosure inside Settings with visible export and import controls
- exports `BlissfulProductivity.createBackup()` data as `blissful-reverie-backup-YYYY-MM-DD.json`
- imports JSON through `BlissfulProductivity.restoreBackup()`, reloads after success, and preserves a clear post-reload confirmation
- rejects malformed JSON, wrong app identifiers, unsupported versions, missing data, invalid known-key values, and unavailable storage before applying a restore
- preflights every known backup value before writing and rolls back completed writes if storage fails mid-restore
- loads the dedicated backup script explicitly from `index.html` without changing the static/local-first architecture

## Testing performed

- `npm test`
  - validates 528 ingredients and 314 curated recipes
  - backup export shape and all supported localStorage keys
  - successful JSON restore
  - malformed JSON rejection
  - wrong app identifier rejection
  - unsupported version and missing data rejection
  - invalid nested storage data rejection without partial writes
  - explicit application script order
- `node --check scripts/productivity-tools.js`
- `node --check scripts/productivity-backup.js`
- `node --check tests/productivity-tools.test.js`
- `node --check tests/productivity-backup.test.js`
- `git diff --check`
- headless Edge smoke test against local `index.html`
  - Settings renders compact backup controls
  - export downloads a valid dated JSON file containing favorites, meal plan, theme, and measurement data
  - valid import restores favorites, meal plan, and settings, reloads, and displays success messaging
  - malformed import displays an error and leaves existing state unchanged
  - existing mode and unit controls still persist
  - no browser console errors observed
- GitHub Actions `Validate` run #34 succeeded for commit `8e051ab`

## Risks / follow-ups

- import restores only recognized Blissful Reverie keys included in the backup; unknown keys are ignored and omitted known keys are left unchanged for compatibility with the existing helper behavior
- backups remain local JSON files with no encryption, cloud sync, account recovery, or merge preview

Closes #119