### PR TITLE
Drive smart shopping list from meal-plan selections

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -3852,6 +3852,8 @@
     closeRecipeScheduleDialog();
     if (state.activeView === 'meal-plan') {
       renderMealPlan();
+    } else if (state.activeView === 'meals') {
+      renderMeals();
     }
   };
 
@@ -8094,8 +8096,13 @@
 
     const productivityUi = window.BlissfulProductivityUI;
     if (productivityUi && typeof productivityUi.render === 'function') {
+      const productivityTools = window.BlissfulProductivity || {};
+      const plannedRecipes = typeof productivityTools.resolvePlannedRecipes === 'function'
+        ? productivityTools.resolvePlannedRecipes(state.mealPlan, recipeLookupById)
+        : [];
       productivityUi.render({
         recipes,
+        plannedRecipes,
         recipeById: recipeLookupById,
         recipeIngredientMatches,
         ingredientBySlug,

--- a/scripts/productivity-tools.js
+++ b/scripts/productivity-tools.js
@@ -160,6 +160,60 @@
     });
   };
 
+  const hasRecipeId = (recipeLookup, recipeId) => {
+    if (!recipeId) return false;
+    if (recipeLookup instanceof Map || recipeLookup instanceof Set) {
+      return recipeLookup.has(recipeId);
+    }
+    if (Array.isArray(recipeLookup)) {
+      return recipeLookup.some((recipe) => recipe?.id === recipeId || recipe === recipeId);
+    }
+    if (recipeLookup && typeof recipeLookup === 'object') {
+      return Boolean(recipeLookup[recipeId]);
+    }
+    return true;
+  };
+
+  const getRecipeFromLookup = (recipeLookup, recipeId) => {
+    if (!hasRecipeId(recipeLookup, recipeId)) return null;
+    if (recipeLookup instanceof Map) {
+      return recipeLookup.get(recipeId) || null;
+    }
+    if (Array.isArray(recipeLookup)) {
+      return recipeLookup.find((recipe) => recipe?.id === recipeId) || null;
+    }
+    if (recipeLookup && typeof recipeLookup === 'object') {
+      return recipeLookup[recipeId] || null;
+    }
+    return null;
+  };
+
+  const getPlannedRecipeIds = (mealPlan, recipeLookup) => {
+    if (!mealPlan || typeof mealPlan !== 'object' || Array.isArray(mealPlan)) {
+      return [];
+    }
+    const ids = [];
+    const seen = new Set();
+    Object.values(mealPlan).forEach((entries) => {
+      if (!Array.isArray(entries)) return;
+      entries.forEach((entry) => {
+        if (!entry || typeof entry !== 'object') return;
+        const recipeId = typeof entry.recipeId === 'string' ? entry.recipeId.trim() : '';
+        if (!recipeId || seen.has(recipeId) || !hasRecipeId(recipeLookup, recipeId)) {
+          return;
+        }
+        seen.add(recipeId);
+        ids.push(recipeId);
+      });
+    });
+    return ids;
+  };
+
+  const resolvePlannedRecipes = (mealPlan, recipeLookup) =>
+    getPlannedRecipeIds(mealPlan, recipeLookup)
+      .map((recipeId) => getRecipeFromLookup(recipeLookup, recipeId))
+      .filter(Boolean);
+
   const createBackup = (storage = global.localStorage) => {
     const data = {};
     BACKUP_KEYS.forEach((key) => {
@@ -432,6 +486,8 @@
     getPantrySlugSet,
     analyzeRecipePantryFit,
     buildShoppingList,
+    getPlannedRecipeIds,
+    resolvePlannedRecipes,
     createBackup,
     restoreBackup,
     hasMeaningfulAppState,

--- a/scripts/productivity-ui.js
+++ b/scripts/productivity-ui.js
@@ -6,10 +6,17 @@
 
   const SHOPPING_RECIPE_LIMIT = 8;
   const SHOPPING_ITEM_LIMIT = 18;
+  const SHOPPING_SOURCE_MEAL_PLAN = 'meal-plan';
+  const SHOPPING_SOURCE_CLOSEST = 'closest';
   let currentContext = null;
+  let shoppingSource = SHOPPING_SOURCE_MEAL_PLAN;
 
   const getRecipes = () => (
     Array.isArray(currentContext?.recipes) ? currentContext.recipes : []
+  );
+
+  const getPlannedRecipes = () => (
+    Array.isArray(currentContext?.plannedRecipes) ? currentContext.plannedRecipes.filter(Boolean) : []
   );
 
   const getRecipeMatches = () => (
@@ -194,6 +201,41 @@
       .slice(0, SHOPPING_RECIPE_LIMIT)
       .map(({ recipe }) => recipe);
 
+  const createShoppingSourceControl = (selectedSource) => {
+    const fieldset = document.createElement('fieldset');
+    fieldset.className = 'productivity-shopping__source-control';
+    const legend = document.createElement('legend');
+    legend.className = 'productivity-shopping__source-legend';
+    legend.textContent = 'Shopping source';
+    fieldset.appendChild(legend);
+
+    [
+      { value: SHOPPING_SOURCE_MEAL_PLAN, label: 'From meal plan' },
+      { value: SHOPPING_SOURCE_CLOSEST, label: 'Closest recipes' },
+    ].forEach((option) => {
+      const label = document.createElement('label');
+      label.className = 'productivity-shopping__source-option';
+      if (selectedSource === option.value) {
+        label.classList.add('productivity-shopping__source-option--active');
+      }
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = 'productivity-shopping-source';
+      input.value = option.value;
+      input.checked = selectedSource === option.value;
+      input.addEventListener('change', () => {
+        shoppingSource = option.value;
+        renderDashboard();
+      });
+      const text = document.createElement('span');
+      text.textContent = option.label;
+      label.appendChild(input);
+      label.appendChild(text);
+      fieldset.appendChild(label);
+    });
+    return fieldset;
+  };
+
   const buildShoppingText = (items) => {
     if (!items.length) return 'No missing ingredients yet.';
     const lines = ['Blissful Reverie shopping list'];
@@ -236,7 +278,14 @@
   };
 
   const createShoppingPanel = (entries) => {
-    const candidates = getShoppingCandidateRecipes(entries);
+    const source = shoppingSource === SHOPPING_SOURCE_CLOSEST
+      ? SHOPPING_SOURCE_CLOSEST
+      : SHOPPING_SOURCE_MEAL_PLAN;
+    shoppingSource = source;
+    const plannedRecipes = getPlannedRecipes();
+    const candidates = source === SHOPPING_SOURCE_MEAL_PLAN
+      ? plannedRecipes
+      : getShoppingCandidateRecipes(entries);
     const shoppingItems = typeof tools.buildShoppingList === 'function'
       ? tools.buildShoppingList({
           recipes: candidates,
@@ -261,9 +310,16 @@
     headerText.appendChild(title);
     const subtitle = document.createElement('p');
     subtitle.className = 'productivity-shopping__subtitle';
-    subtitle.textContent = shoppingItems.length
-      ? `${shoppingItems.length} missing ingredient${shoppingItems.length === 1 ? '' : 's'} from your closest recipes`
-      : 'Add pantry quantities to generate missing ingredients.';
+    if (source === SHOPPING_SOURCE_MEAL_PLAN && !plannedRecipes.length) {
+      subtitle.textContent = 'No planned recipes yet.';
+    } else if (shoppingItems.length) {
+      const sourceLabel = source === SHOPPING_SOURCE_MEAL_PLAN ? 'planned recipes' : 'closest recipes';
+      subtitle.textContent = `${shoppingItems.length} missing ingredient${shoppingItems.length === 1 ? '' : 's'} from your ${sourceLabel}`;
+    } else if (source === SHOPPING_SOURCE_MEAL_PLAN) {
+      subtitle.textContent = 'Your planned recipes are covered by pantry items and substitutions.';
+    } else {
+      subtitle.textContent = 'Add pantry quantities to generate missing ingredients.';
+    }
     headerText.appendChild(subtitle);
     header.appendChild(headerText);
 
@@ -275,11 +331,18 @@
     copyButton.addEventListener('click', () => copyShoppingList(copyButton, shoppingItems));
     header.appendChild(copyButton);
     panel.appendChild(header);
+    panel.appendChild(createShoppingSourceControl(source));
 
     if (!shoppingItems.length) {
       const empty = document.createElement('p');
       empty.className = 'productivity-shopping__empty';
-      empty.textContent = 'Recipes that are missing ingredients will appear here once your pantry is populated.';
+      if (source === SHOPPING_SOURCE_MEAL_PLAN && !plannedRecipes.length) {
+        empty.textContent = 'Add recipes to your meal plan, or switch to closest recipes for pantry-based suggestions.';
+      } else if (source === SHOPPING_SOURCE_MEAL_PLAN) {
+        empty.textContent = 'Missing planned-meal ingredients will appear here as your pantry changes.';
+      } else {
+        empty.textContent = 'Recipes that are missing ingredients will appear here once your pantry is populated.';
+      }
       panel.appendChild(empty);
       return panel;
     }

--- a/styles/productivity.css
+++ b/styles/productivity.css
@@ -378,6 +378,52 @@
   outline-offset: 2px;
 }
 
+.productivity-shopping__source-control {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.productivity-shopping__source-legend {
+  margin-right: 0.1rem;
+  padding: 0;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.productivity-shopping__source-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: 1px solid var(--border-1);
+  border-radius: 999px;
+  padding: 0.3rem 0.55rem;
+  background: var(--surface-0);
+  color: var(--text);
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.productivity-shopping__source-option--active {
+  border-color: var(--accent-1);
+}
+
+.productivity-shopping__source-option input {
+  margin: 0;
+  accent-color: var(--accent-1);
+}
+
+.productivity-shopping__source-option:focus-within {
+  outline: 2px solid var(--accent-1);
+  outline-offset: 2px;
+}
+
 .productivity-shopping__categories {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/tests/integration-wiring.test.js
+++ b/tests/integration-wiring.test.js
@@ -36,8 +36,10 @@ assert(productivityStyles.includes('.productivity-dashboard'));
 assert(productivityStyles.includes('.productivity-onboarding'));
 assert(productivityStyles.includes('.productivity-backup'));
 assert(productivityStyles.includes('.productivity-settings-advanced'));
+assert(productivityStyles.includes('.productivity-shopping__source-control'));
 
 [
+  'scripts/productivity-tools.js',
   'scripts/productivity-settings.js',
   'scripts/productivity-backup.js',
   'scripts/productivity-onboarding.js',
@@ -53,10 +55,13 @@ assert(productivitySettings.includes('styles/productivity.css'));
 const productivityUi = read('scripts/productivity-ui.js');
 assert(!productivityUi.includes('MutationObserver'));
 assert(productivityUi.includes('global.BlissfulProductivityUI'));
+assert(productivityUi.includes('From meal plan'));
+assert(productivityUi.includes('Closest recipes'));
 
 const app = read('scripts/app.js');
 assert(app.includes('card.dataset.recipeId = recipe.id'));
 assert(app.includes('productivityUi.render({'));
+assert(app.includes('plannedRecipes'));
 assert(app.includes('applyStarterState'));
 
 console.log('Application wiring tests passed.');

--- a/tests/pantry-matching.test.js
+++ b/tests/pantry-matching.test.js
@@ -67,4 +67,34 @@ const substitutedShoppingList = tools.buildShoppingList({
 });
 assert.deepEqual(substitutedShoppingList, []);
 
+const plannedRecipes = [
+  { id: 'planned-a', name: 'Planned A' },
+  { id: 'planned-b', name: 'Planned B' },
+];
+const plannedShoppingList = tools.buildShoppingList({
+  recipes: plannedRecipes,
+  pantryInventory: { owned: { quantity: '1', unit: 'each' } },
+  recipeMatchesById: new Map([
+    ['planned-a', new Set(['owned', 'shared-missing'])],
+    ['planned-b', new Set(['shared-missing', 'second-missing'])],
+  ]),
+  ingredientBySlug: new Map([
+    ['owned', { slug: 'owned', name: 'Owned Ingredient', category: 'Pantry' }],
+    ['shared-missing', { slug: 'shared-missing', name: 'Shared Missing', category: 'Produce' }],
+    ['second-missing', { slug: 'second-missing', name: 'Second Missing', category: 'Produce' }],
+  ]),
+});
+assert.deepEqual(
+  plannedShoppingList.map((item) => item.slug),
+  ['second-missing', 'shared-missing'],
+);
+assert.deepEqual(
+  plannedShoppingList.find((item) => item.slug === 'shared-missing').recipes,
+  ['Planned A', 'Planned B'],
+);
+assert.equal(
+  plannedShoppingList.some((item) => item.slug === 'owned'),
+  false,
+);
+
 console.log('Pantry matching tests passed.');

--- a/tests/productivity-tools.test.js
+++ b/tests/productivity-tools.test.js
@@ -167,4 +167,30 @@ const dashboard = tools.summarizeDashboard({
 assert.equal(dashboard.cookNow.length, 1);
 assert.equal(dashboard.nearlyReady.length, 1);
 
+const plannedRecipeLookup = new Map([
+  ['recipe-a', { id: 'recipe-a', name: 'Recipe A' }],
+  ['recipe-b', { id: 'recipe-b', name: 'Recipe B' }],
+]);
+const mealPlan = {
+  '2026-06-09': [
+    { id: 'entry-a', type: 'meal', title: 'Recipe A', recipeId: 'recipe-a', time: '08:00' },
+    { id: 'entry-b', type: 'meal', title: 'Recipe A again', recipeId: 'recipe-a', time: '12:00' },
+    { id: 'entry-c', type: 'meal', title: 'Deleted recipe', recipeId: 'recipe-deleted', time: '18:00' },
+    { id: 'entry-d', type: 'snack', title: 'Loose snack', time: '20:00' },
+  ],
+  '2026-06-10': [
+    { id: 'entry-e', type: 'meal', title: 'Recipe B', recipeId: 'recipe-b', attendance: { guests: 2 } },
+  ],
+  broken: [
+    { id: 'entry-f', type: 'meal', title: 'Recipe A', recipeId: 'recipe-a' },
+  ],
+};
+assert.deepEqual(tools.getPlannedRecipeIds(mealPlan, plannedRecipeLookup), ['recipe-a', 'recipe-b']);
+assert.deepEqual(
+  tools.resolvePlannedRecipes(mealPlan, plannedRecipeLookup).map((recipe) => recipe.name),
+  ['Recipe A', 'Recipe B'],
+);
+assert.deepEqual(tools.getPlannedRecipeIds({}, plannedRecipeLookup), []);
+assert.deepEqual(tools.getPlannedRecipeIds(null, plannedRecipeLookup), []);
+
 console.log('Productivity helper tests passed.');


### PR DESCRIPTION
## Summary
- Drive the smart shopping list from valid recipes currently placed in the meal plan by resolving planned recipe IDs from live app state and passing those recipe objects through the existing `buildShoppingList()` helper.
- Preserve the existing pantry-based closest-recipes shopping list as an alternate source mode.
- Keep the app-to-productivity integration narrow: `scripts/app.js` resolves planned recipes and includes them in the existing productivity render context, while presentation stays in `styles/productivity.css`.

## Testing
- `node --check scripts/app.js`
- `node --check scripts/productivity-tools.js`
- `node --check scripts/productivity-ui.js`
- `node --check tests/productivity-tools.test.js`
- `node --check tests/pantry-matching.test.js`
- `node --check tests/integration-wiring.test.js`
- `npm.cmd test` (passes; existing data validation warning remains: 253 canonical ingredients are not used by curated recipes before runtime coverage generation)
- `git diff --check` (passes; Git reports LF-to-CRLF working-copy warnings)
- Focused tests added for planned recipe ID extraction/resolution, duplicate planned recipe handling, deleted/missing IDs, pantry-owned ingredient exclusion, duplicate missing ingredient combination, substitution behavior, closest-source availability, and no embedded productivity CSS strings.
- Browser smoke test on `http://localhost:4173/`: added two recipes to the meal plan, confirmed the planned source generated missing ingredients, confirmed pantry-owned Tahini dropped from the planned list, confirmed substitutions removed Eggs when a flax egg substitute was owned and substitutions were enabled, switched to Closest recipes and copied the list, removed all planned meals and confirmed the planned-source empty state, verified dashboard/badges remained rendered, and observed zero console errors.
- GitHub Actions result: `Validate / validate` passed for run `28202162803`.

## Risks / follow-ups
- Serving quantities are not aggregated; duplicate planned recipe IDs are deduplicated for predictable recipe-level shopping output.
- Malformed, missing, or deleted recipe references are ignored.
- Any future quantity-aware shopping-list work should be separate.

Closes #120