### PR TITLE
Polish smart shopping list UX after meal-plan source integration

### DIFF
--- a/scripts/productivity-ui.js
+++ b/scripts/productivity-ui.js
@@ -8,8 +8,10 @@
   const SHOPPING_ITEM_LIMIT = 18;
   const SHOPPING_SOURCE_MEAL_PLAN = 'meal-plan';
   const SHOPPING_SOURCE_CLOSEST = 'closest';
+  const COPY_RESET_DELAY_MS = 2200;
   let currentContext = null;
   let shoppingSource = SHOPPING_SOURCE_MEAL_PLAN;
+  let copyFeedbackTimer = null;
 
   const getRecipes = () => (
     Array.isArray(currentContext?.recipes) ? currentContext.recipes : []
@@ -86,11 +88,17 @@
     return `${available} of ${total} matched ingredients are in your pantry; ${missing} missing.`;
   };
 
-  const getPantryInventory = () => {
-    return currentContext?.pantryInventory && typeof currentContext.pantryInventory === 'object'
+  const getPantryInventory = () => (
+    currentContext?.pantryInventory && typeof currentContext.pantryInventory === 'object'
       ? currentContext.pantryInventory
-      : {};
-  };
+      : {}
+  );
+
+  const hasPantryData = () => Object.values(getPantryInventory()).some((entry) => {
+    if (!entry || typeof entry !== 'object') return false;
+    const quantity = Number(entry.quantity);
+    return Number.isFinite(quantity) ? quantity > 0 : Boolean(String(entry.quantity || '').trim());
+  });
 
   const getSubstitutionsAllowed = () => Boolean(currentContext?.substitutionsAllowed);
 
@@ -201,17 +209,31 @@
       .slice(0, SHOPPING_RECIPE_LIMIT)
       .map(({ recipe }) => recipe);
 
+  const getShoppingSourceMeta = (source) => (
+    source === SHOPPING_SOURCE_CLOSEST
+      ? {
+          label: 'Closest recipes',
+          pill: 'Closest recipes',
+          description: 'Pantry-fit recipes with missing ingredients.',
+        }
+      : {
+          label: 'From meal plan',
+          pill: 'From meal plan',
+          description: 'Missing ingredients from planned meals.',
+        }
+  );
+
   const createShoppingSourceControl = (selectedSource) => {
     const fieldset = document.createElement('fieldset');
     fieldset.className = 'productivity-shopping__source-control';
     const legend = document.createElement('legend');
     legend.className = 'productivity-shopping__source-legend';
-    legend.textContent = 'Shopping source';
+    legend.textContent = 'Source';
     fieldset.appendChild(legend);
 
     [
-      { value: SHOPPING_SOURCE_MEAL_PLAN, label: 'From meal plan' },
-      { value: SHOPPING_SOURCE_CLOSEST, label: 'Closest recipes' },
+      { value: SHOPPING_SOURCE_MEAL_PLAN, label: 'From meal plan', detail: 'Planned meals' },
+      { value: SHOPPING_SOURCE_CLOSEST, label: 'Closest recipes', detail: 'Pantry fit' },
     ].forEach((option) => {
       const label = document.createElement('label');
       label.className = 'productivity-shopping__source-option';
@@ -228,7 +250,15 @@
         renderDashboard();
       });
       const text = document.createElement('span');
-      text.textContent = option.label;
+      text.className = 'productivity-shopping__source-text';
+      const name = document.createElement('span');
+      name.className = 'productivity-shopping__source-name';
+      name.textContent = option.label;
+      const detail = document.createElement('span');
+      detail.className = 'productivity-shopping__source-detail';
+      detail.textContent = option.detail;
+      text.appendChild(name);
+      text.appendChild(detail);
       label.appendChild(input);
       label.appendChild(text);
       fieldset.appendChild(label);
@@ -251,11 +281,26 @@
     return lines.join('\n');
   };
 
-  const copyShoppingList = async (button, items) => {
+  const setCopyFeedback = (button, status, message, state) => {
+    button.dataset.state = state;
+    button.textContent = state === 'error' ? 'Copy failed' : 'Copied';
+    status.textContent = message;
+    status.dataset.state = state;
+    if (copyFeedbackTimer) global.clearTimeout(copyFeedbackTimer);
+    copyFeedbackTimer = global.setTimeout(() => {
+      button.textContent = 'Copy list';
+      button.dataset.state = 'idle';
+      status.textContent = '';
+      status.dataset.state = 'idle';
+    }, COPY_RESET_DELAY_MS);
+  };
+
+  const copyShoppingList = async (button, status, items) => {
     const text = buildShoppingText(items);
     try {
       await navigator.clipboard.writeText(text);
-      button.textContent = 'Copied';
+      setCopyFeedback(button, status, 'Shopping list copied.', 'success');
+      return;
     } catch (error) {
       const textarea = document.createElement('textarea');
       textarea.value = text;
@@ -266,15 +311,42 @@
       textarea.select();
       try {
         document.execCommand('copy');
-        button.textContent = 'Copied';
+        setCopyFeedback(button, status, 'Shopping list copied.', 'success');
       } catch (fallbackError) {
-        button.textContent = 'Copy failed';
+        setCopyFeedback(button, status, 'Copy failed. Select the list manually.', 'error');
       }
       textarea.remove();
     }
-    global.setTimeout(() => {
-      button.textContent = 'Copy list';
-    }, 1800);
+  };
+
+  const getShoppingSummary = ({ source, shoppingItems, plannedRecipes, pantryHasItems }) => {
+    if (source === SHOPPING_SOURCE_MEAL_PLAN && !plannedRecipes.length) {
+      return 'No planned meals yet.';
+    }
+    if (shoppingItems.length) {
+      const sourceLabel = source === SHOPPING_SOURCE_MEAL_PLAN ? 'planned meals' : 'closest recipes';
+      return `${shoppingItems.length} missing ingredient${shoppingItems.length === 1 ? '' : 's'} from ${sourceLabel}.`;
+    }
+    if (source === SHOPPING_SOURCE_MEAL_PLAN) {
+      return 'Planned meals are covered by your pantry.';
+    }
+    if (!pantryHasItems) {
+      return 'Add pantry items to compare closest recipes.';
+    }
+    return 'Closest recipes do not need extra shopping right now.';
+  };
+
+  const getShoppingEmptyText = ({ source, plannedRecipes, pantryHasItems }) => {
+    if (source === SHOPPING_SOURCE_MEAL_PLAN && !plannedRecipes.length) {
+      return 'Add meals to your plan, then missing ingredients will appear here.';
+    }
+    if (source === SHOPPING_SOURCE_MEAL_PLAN) {
+      return 'All planned-meal ingredients are already covered by pantry items or substitutions.';
+    }
+    if (!pantryHasItems) {
+      return 'Add what you have in the pantry to see closest recipe gaps.';
+    }
+    return 'Closest recipe gaps will appear here when pantry-fit recipes need extra ingredients.';
   };
 
   const createShoppingPanel = (entries) => {
@@ -283,6 +355,7 @@
       : SHOPPING_SOURCE_MEAL_PLAN;
     shoppingSource = source;
     const plannedRecipes = getPlannedRecipes();
+    const pantryHasItems = hasPantryData();
     const candidates = source === SHOPPING_SOURCE_MEAL_PLAN
       ? plannedRecipes
       : getShoppingCandidateRecipes(entries);
@@ -296,53 +369,62 @@
           substitutionsAllowed: getSubstitutionsAllowed(),
         }).slice(0, SHOPPING_ITEM_LIMIT)
       : [];
+    const sourceMeta = getShoppingSourceMeta(source);
 
     const panel = document.createElement('section');
     panel.className = 'productivity-shopping';
     panel.setAttribute('aria-label', 'Smart shopping list');
+    panel.dataset.source = source;
 
     const header = document.createElement('header');
     header.className = 'productivity-shopping__header';
     const headerText = document.createElement('div');
+    headerText.className = 'productivity-shopping__header-text';
+    const titleRow = document.createElement('div');
+    titleRow.className = 'productivity-shopping__title-row';
     const title = document.createElement('h3');
     title.className = 'productivity-shopping__title';
     title.textContent = 'Smart shopping list';
-    headerText.appendChild(title);
+    const sourcePill = document.createElement('span');
+    sourcePill.className = 'productivity-shopping__source-pill';
+    sourcePill.textContent = sourceMeta.pill;
+    titleRow.appendChild(title);
+    titleRow.appendChild(sourcePill);
+    headerText.appendChild(titleRow);
     const subtitle = document.createElement('p');
     subtitle.className = 'productivity-shopping__subtitle';
-    if (source === SHOPPING_SOURCE_MEAL_PLAN && !plannedRecipes.length) {
-      subtitle.textContent = 'No planned recipes yet.';
-    } else if (shoppingItems.length) {
-      const sourceLabel = source === SHOPPING_SOURCE_MEAL_PLAN ? 'planned recipes' : 'closest recipes';
-      subtitle.textContent = `${shoppingItems.length} missing ingredient${shoppingItems.length === 1 ? '' : 's'} from your ${sourceLabel}`;
-    } else if (source === SHOPPING_SOURCE_MEAL_PLAN) {
-      subtitle.textContent = 'Your planned recipes are covered by pantry items and substitutions.';
-    } else {
-      subtitle.textContent = 'Add pantry quantities to generate missing ingredients.';
-    }
+    subtitle.textContent = getShoppingSummary({ source, shoppingItems, plannedRecipes, pantryHasItems });
     headerText.appendChild(subtitle);
+    const modeNote = document.createElement('p');
+    modeNote.className = 'productivity-shopping__mode-note';
+    modeNote.textContent = sourceMeta.description;
+    headerText.appendChild(modeNote);
     header.appendChild(headerText);
 
+    const copyWrap = document.createElement('div');
+    copyWrap.className = 'productivity-shopping__copy-wrap';
     const copyButton = document.createElement('button');
     copyButton.type = 'button';
     copyButton.className = 'productivity-shopping__copy';
     copyButton.textContent = 'Copy list';
+    copyButton.dataset.state = 'idle';
     copyButton.disabled = !shoppingItems.length;
-    copyButton.addEventListener('click', () => copyShoppingList(copyButton, shoppingItems));
-    header.appendChild(copyButton);
+    const copyStatus = document.createElement('span');
+    copyStatus.className = 'productivity-shopping__copy-status';
+    copyStatus.dataset.state = 'idle';
+    copyStatus.setAttribute('aria-live', 'polite');
+    copyStatus.setAttribute('role', 'status');
+    copyButton.addEventListener('click', () => copyShoppingList(copyButton, copyStatus, shoppingItems));
+    copyWrap.appendChild(copyButton);
+    copyWrap.appendChild(copyStatus);
+    header.appendChild(copyWrap);
     panel.appendChild(header);
     panel.appendChild(createShoppingSourceControl(source));
 
     if (!shoppingItems.length) {
       const empty = document.createElement('p');
       empty.className = 'productivity-shopping__empty';
-      if (source === SHOPPING_SOURCE_MEAL_PLAN && !plannedRecipes.length) {
-        empty.textContent = 'Add recipes to your meal plan, or switch to closest recipes for pantry-based suggestions.';
-      } else if (source === SHOPPING_SOURCE_MEAL_PLAN) {
-        empty.textContent = 'Missing planned-meal ingredients will appear here as your pantry changes.';
-      } else {
-        empty.textContent = 'Recipes that are missing ingredients will appear here once your pantry is populated.';
-      }
+      empty.textContent = getShoppingEmptyText({ source, plannedRecipes, pantryHasItems });
       panel.appendChild(empty);
       return panel;
     }
@@ -368,8 +450,11 @@
         const note = document.createElement('span');
         note.className = 'productivity-shopping__item-note';
         note.textContent = Array.isArray(item.recipes) && item.recipes.length
-          ? `${item.recipes.length} recipe${item.recipes.length === 1 ? '' : 's'}`
+          ? `For ${item.recipes.slice(0, 2).join(', ')}${item.recipes.length > 2 ? ` +${item.recipes.length - 2}` : ''}`
           : '';
+        if (note.textContent) {
+          note.title = item.recipes.join(', ');
+        }
         row.appendChild(note);
         list.appendChild(row);
       });

--- a/styles/productivity.css
+++ b/styles/productivity.css
@@ -291,10 +291,15 @@
 }
 
 .productivity-dashboard__subtitle,
-.productivity-shopping__subtitle {
+.productivity-shopping__subtitle,
+.productivity-shopping__mode-note {
   margin: 0.25rem 0 0;
   color: var(--text-muted);
   font-size: 0.9rem;
+}
+
+.productivity-shopping__mode-note {
+  font-size: 0.8rem;
 }
 
 .productivity-dashboard__groups {
@@ -360,8 +365,41 @@
   font-size: 0.85rem;
 }
 
-.productivity-shopping__copy {
+.productivity-shopping__empty {
+  border: 1px dashed var(--border-1);
+  border-radius: 0.85rem;
+  padding: 0.7rem 0.8rem;
+  background: color-mix(in oklab, var(--surface-0), transparent 20%);
+}
+
+.productivity-shopping__title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.productivity-shopping__source-pill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--accent-1);
+  border-radius: 999px;
+  padding: 0.18rem 0.5rem;
+  background: color-mix(in oklab, var(--accent-1), transparent 85%);
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.productivity-shopping__copy-wrap {
+  display: grid;
+  justify-items: end;
+  gap: 0.25rem;
   flex: 0 0 auto;
+}
+
+.productivity-shopping__copy {
   border: 1px solid var(--border-1);
   border-radius: 999px;
   padding: 0.35rem 0.7rem;
@@ -373,15 +411,49 @@
   cursor: pointer;
 }
 
+.productivity-shopping__copy:hover:not(:disabled),
+.productivity-shopping__copy:focus-visible {
+  background: color-mix(in oklab, var(--layer-3), white 12%);
+}
+
 .productivity-shopping__copy:focus-visible {
   outline: 2px solid var(--accent-1);
   outline-offset: 2px;
 }
 
+.productivity-shopping__copy:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.productivity-shopping__copy[data-state='success'] {
+  border-color: var(--accent-1);
+}
+
+.productivity-shopping__copy[data-state='error'] {
+  border-color: var(--color-danger, #a53b32);
+}
+
+.productivity-shopping__copy-status {
+  min-height: 1em;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  line-height: 1.2;
+  text-align: right;
+}
+
+.productivity-shopping__copy-status[data-state='success'] {
+  color: var(--color-success, #26734d);
+}
+
+.productivity-shopping__copy-status[data-state='error'] {
+  color: var(--color-danger, #a53b32);
+}
+
 .productivity-shopping__source-control {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: stretch;
   gap: 0.45rem;
   margin: 0;
   padding: 0;
@@ -389,6 +461,7 @@
 }
 
 .productivity-shopping__source-legend {
+  align-self: center;
   margin-right: 0.1rem;
   padding: 0;
   color: var(--text-muted);
@@ -399,10 +472,10 @@
 .productivity-shopping__source-option {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: 0.4rem;
   border: 1px solid var(--border-1);
   border-radius: 999px;
-  padding: 0.3rem 0.55rem;
+  padding: 0.32rem 0.6rem;
   background: var(--surface-0);
   color: var(--text);
   font-size: 0.8rem;
@@ -412,6 +485,7 @@
 
 .productivity-shopping__source-option--active {
   border-color: var(--accent-1);
+  background: color-mix(in oklab, var(--accent-1), transparent 90%);
 }
 
 .productivity-shopping__source-option input {
@@ -424,6 +498,22 @@
   outline-offset: 2px;
 }
 
+.productivity-shopping__source-text {
+  display: grid;
+  gap: 0.05rem;
+  line-height: 1.1;
+}
+
+.productivity-shopping__source-name {
+  white-space: nowrap;
+}
+
+.productivity-shopping__source-detail {
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
 .productivity-shopping__categories {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -433,4 +523,34 @@
 .productivity-shopping__category {
   display: grid;
   gap: 0.45rem;
+}
+
+@media (max-width: 640px) {
+  .productivity-dashboard__header,
+  .productivity-shopping__header {
+    display: grid;
+  }
+
+  .productivity-shopping__copy-wrap {
+    justify-items: start;
+  }
+
+  .productivity-shopping__source-control {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .productivity-shopping__source-option {
+    justify-content: flex-start;
+  }
+
+  .productivity-shopping__item {
+    align-items: flex-start;
+  }
+
+  .productivity-shopping__item-note {
+    max-width: 45%;
+    white-space: normal;
+    text-align: right;
+  }
 }

--- a/tests/integration-wiring.test.js
+++ b/tests/integration-wiring.test.js
@@ -37,6 +37,9 @@ assert(productivityStyles.includes('.productivity-onboarding'));
 assert(productivityStyles.includes('.productivity-backup'));
 assert(productivityStyles.includes('.productivity-settings-advanced'));
 assert(productivityStyles.includes('.productivity-shopping__source-control'));
+assert(productivityStyles.includes('.productivity-shopping__source-pill'));
+assert(productivityStyles.includes('.productivity-shopping__copy-status'));
+assert(productivityStyles.includes('@media (max-width: 640px)'));
 
 [
   'scripts/productivity-tools.js',
@@ -57,6 +60,11 @@ assert(!productivityUi.includes('MutationObserver'));
 assert(productivityUi.includes('global.BlissfulProductivityUI'));
 assert(productivityUi.includes('From meal plan'));
 assert(productivityUi.includes('Closest recipes'));
+assert(productivityUi.includes('Planned meals are covered by your pantry'));
+assert(productivityUi.includes('Add pantry items to compare closest recipes'));
+assert(productivityUi.includes('Shopping list copied.'));
+assert(productivityUi.includes('productivity-shopping__copy-status'));
+assert(productivityUi.includes('productivity-shopping__source-pill'));
 
 const app = read('scripts/app.js');
 assert(app.includes('card.dataset.recipeId = recipe.id'));


### PR DESCRIPTION
## Summary

* Polish the smart shopping list UI now that planned meals can drive list generation.
* Improve source-mode clarity, empty states, and copy feedback.
* Preserve existing shopping-list data flow, pantry matching, and substitution behavior.

## Testing

* `node --check scripts/app.js` — passed locally.
* `node --check scripts/productivity-tools.js` — passed locally.
* `node --check scripts/productivity-ui.js` — passed locally.
* `node --check tests/productivity-tools.test.js` — passed locally.
* `node --check tests/pantry-matching.test.js` — passed locally.
* `node --check tests/integration-wiring.test.js` — passed locally.
* `npm test` — passed locally via `cmd.exe` (`npm.ps1` is blocked by this machine's PowerShell execution policy); also passed in GitHub Actions Validate.
* `git diff --check` — passed locally.
* Browser smoke test — passed locally against `http://127.0.0.1:4173/`: added two planned recipes, verified From meal plan missing ingredients, added pantry coverage, verified substitutions with owned Quinoa, switched to Closest recipes, copied the list with visible feedback, removed planned meals, checked the planned-meal empty state, checked desktop and mobile widths, verified dashboard/recipe badges/onboarding/settings/backup/meal-plan surfaces, and confirmed zero console errors.
* GitHub Actions Validate — passed for head `c0f27e6ad345c4cc17ab2b1f01967001b07e999e` (run #54).

## Risks / follow-ups

* Quantity aggregation, serving-size policy, and meal-plan workflow limitations remain separate from this PR.
* Docs roadmap cleanup remains tracked separately in #126.
* No unrelated cleanup included.