### PR TITLE
Clean up completed meal-plan shopping-list roadmap item

### DIFF
--- a/docs/next-10-product-tasks.md
+++ b/docs/next-10-product-tasks.md
@@ -9,7 +9,7 @@ This document records the implemented state of the recovery roadmap on PR #118.
 3. **Export/import backup** - implemented as tested localStorage backup and restore helpers in `scripts/productivity-tools.js`; a dedicated settings UI remains optional follow-up work.
 4. **Dashboard summary** - implemented above the recipe grid with Cook now, Almost ready, and Shopping candidates groups.
 5. **Missing-ingredient counts** - implemented on recipe cards and dashboard entries using live pantry state and the app substitution graph.
-6. **Shopping list generation** - implemented as a categorized smart shopping panel with recipe references and copy support.
+6. **Shopping list generation** - implemented as a categorized smart shopping panel with planned-meal and closest-recipe source modes, recipe references, compact empty states, and copy feedback.
 7. **Add recipe to meal plan from cards** - implemented by the existing calendar action on every recipe card.
 8. **Generated recipe labels** - implemented on recipe cards for curated recipes, generated templates, and ingredient ideas.
 9. **Move theme controls deeper into settings** - implemented with the native keyboard-accessible `Advanced appearance` disclosure. Controls retain their existing IDs and event handlers.
@@ -24,5 +24,7 @@ The application shell loads data, matching, productivity helpers, settings, onbo
 ## Follow-up candidates
 
 - Add a visible backup import/export control that uses the existing tested helpers.
-- Let users choose meal-plan recipes as the shopping-list source instead of the current closest-recipe limit.
+- Define shopping-list quantity aggregation and serving-size policy before changing the shopping-list algorithm.
+- Audit meal-plan workflow friction after shopping-list integration before changing meal-plan behavior.
+- Create a repeatable browser smoke-test checklist for future productivity UI work.
 - Split additional app-shell domains into tested modules only when a focused feature change requires it.

--- a/docs/next-10-product-tasks.md
+++ b/docs/next-10-product-tasks.md
@@ -6,7 +6,7 @@ This document records the implemented state of the recovery roadmap on PR #118.
 
 1. **Recipe and ingredient schema validation** - implemented with reusable validation in `scripts/data-validation.js` and the `npm run validate:data` CLI.
 2. **Ingredient and pantry matching tests** - implemented across matching, pantry-fit, validation edge-case, productivity, and application-wiring tests.
-3. **Export/import backup** - implemented as tested localStorage backup and restore helpers in `scripts/productivity-tools.js`; a dedicated settings UI remains optional follow-up work.
+3. **Export/import backup** - implemented with tested localStorage backup and restore helpers plus compact Local backup import/export controls inside Settings.
 4. **Dashboard summary** - implemented above the recipe grid with Cook now, Almost ready, and Shopping candidates groups.
 5. **Missing-ingredient counts** - implemented on recipe cards and dashboard entries using live pantry state and the app substitution graph.
 6. **Shopping list generation** - implemented as a categorized smart shopping panel with planned-meal and closest-recipe source modes, recipe references, compact empty states, and copy feedback.
@@ -23,7 +23,6 @@ The application shell loads data, matching, productivity helpers, settings, onbo
 
 ## Follow-up candidates
 
-- Add a visible backup import/export control that uses the existing tested helpers.
 - Define shopping-list quantity aggregation and serving-size policy before changing the shopping-list algorithm.
 - Audit meal-plan workflow friction after shopping-list integration before changing meal-plan behavior.
 - Create a repeatable browser smoke-test checklist for future productivity UI work.


### PR DESCRIPTION
## Summary

* Update roadmap/planning docs so completed meal-plan shopping-list source integration is no longer listed as pending.
* Update backup status now that compact Local backup import/export controls exist in Settings.
* Keep remaining shopping-list follow-ups focused on open work such as quantity aggregation, serving-size policy, workflow polish, and repeatable browser smoke testing.

## Testing

* `git diff --check`
* Runtime tests not run; docs-only change.

## Risks / follow-ups

* Quantity aggregation / serving-size policy remains separate.
* Meal-plan workflow friction audit remains separate.
* Repeatable browser smoke-test checklist remains separate.

Closes #126