### PR TITLE
Clarify meal-plan shopping-list affordances

### DIFF
--- a/scripts/meal-plan-affordance-copy.js
+++ b/scripts/meal-plan-affordance-copy.js
@@ -1,0 +1,158 @@
+;(function () {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const SCHEDULE_BUTTON_SELECTOR = '.meal-card__schedule-button';
+  const MEAL_PLAN_EMPTY_SELECTOR = '.meal-plan-empty';
+  const FEEDBACK_ID = 'meal-plan-affordance-feedback';
+  const ENHANCED_BUTTON_ATTR = 'data-meal-plan-affordance-enhanced';
+  const EMPTY_TEXT =
+    'Add recipes from recipe cards to build this day. Planned recipes can feed the Smart shopping list.';
+  const BUTTON_TEXT = 'Plan & shop';
+  const HELPER_TEXT = 'Scheduled recipes can feed Smart shopping list.';
+  const FEEDBACK_TEXT = 'Added to meal plan — missing ingredients can appear in Smart shopping list.';
+  const FEEDBACK_RESET_MS = 5000;
+  let feedbackTimer = null;
+  let observer = null;
+  let enhanceQueued = false;
+
+  const getRecipeNameForButton = (button) => {
+    const card = button && typeof button.closest === 'function' ? button.closest('.meal-card') : null;
+    const title = card ? card.querySelector('.meal-card__header h3') : null;
+    const name = title && typeof title.textContent === 'string' ? title.textContent.trim() : '';
+    return name || 'this recipe';
+  };
+
+  const ensureFeedbackElement = () => {
+    let feedback = document.getElementById(FEEDBACK_ID);
+    if (feedback) {
+      return feedback;
+    }
+    feedback = document.createElement('p');
+    feedback.id = FEEDBACK_ID;
+    feedback.className = 'meal-plan-affordance__feedback';
+    feedback.hidden = true;
+    feedback.setAttribute('role', 'status');
+    feedback.setAttribute('aria-live', 'polite');
+    const mealView = document.getElementById('meal-view');
+    if (mealView) {
+      mealView.insertBefore(feedback, mealView.firstChild);
+    } else {
+      document.body.appendChild(feedback);
+    }
+    return feedback;
+  };
+
+  const showScheduleFeedback = (recipeName) => {
+    const feedback = ensureFeedbackElement();
+    const prefix = recipeName && recipeName !== 'Recipe' ? `${recipeName} added to meal plan` : 'Added to meal plan';
+    feedback.textContent = `${prefix} — missing ingredients can appear in Smart shopping list.`;
+    feedback.hidden = false;
+    if (feedbackTimer) {
+      window.clearTimeout(feedbackTimer);
+    }
+    feedbackTimer = window.setTimeout(() => {
+      feedback.hidden = true;
+      feedback.textContent = '';
+    }, FEEDBACK_RESET_MS);
+  };
+
+  const enhanceScheduleButton = (button) => {
+    if (!(button instanceof HTMLElement) || button.hasAttribute(ENHANCED_BUTTON_ATTR)) {
+      return;
+    }
+    const recipeName = getRecipeNameForButton(button);
+    button.setAttribute(ENHANCED_BUTTON_ATTR, 'true');
+    button.classList.add('meal-plan-affordance__schedule-button');
+    button.title = `Add ${recipeName} to your meal plan and Smart shopping list`;
+    button.setAttribute(
+      'aria-label',
+      `Add ${recipeName} to your meal plan; planned recipes can feed the Smart shopping list`,
+    );
+    if (!button.querySelector('.meal-plan-affordance__schedule-text')) {
+      const label = document.createElement('span');
+      label.className = 'meal-plan-affordance__schedule-text';
+      label.textContent = BUTTON_TEXT;
+      button.appendChild(label);
+    }
+    const actions = button.closest('.meal-card__header-actions');
+    if (actions instanceof HTMLElement) {
+      actions.classList.add('meal-plan-affordance__actions');
+      if (!actions.querySelector('.meal-plan-affordance__helper')) {
+        const helper = document.createElement('span');
+        helper.className = 'meal-plan-affordance__helper';
+        helper.textContent = HELPER_TEXT;
+        actions.appendChild(helper);
+      }
+    }
+  };
+
+  const enhanceScheduleButtons = () => {
+    document.querySelectorAll(SCHEDULE_BUTTON_SELECTOR).forEach(enhanceScheduleButton);
+  };
+
+  const enhanceMealPlanEmptyStates = () => {
+    document.querySelectorAll(MEAL_PLAN_EMPTY_SELECTOR).forEach((empty) => {
+      if (!(empty instanceof HTMLElement)) {
+        return;
+      }
+      empty.textContent = EMPTY_TEXT;
+    });
+  };
+
+  const enhancePage = () => {
+    enhanceQueued = false;
+    enhanceScheduleButtons();
+    enhanceMealPlanEmptyStates();
+  };
+
+  const queueEnhance = () => {
+    if (enhanceQueued) {
+      return;
+    }
+    enhanceQueued = true;
+    window.requestAnimationFrame(enhancePage);
+  };
+
+  const bindScheduleConfirmation = () => {
+    document.addEventListener('submit', (event) => {
+      const form = event.target instanceof Element ? event.target.closest('.schedule-dialog__panel') : null;
+      if (!form) {
+        return;
+      }
+      const recipeLabel = document.getElementById('schedule-dialog-recipe');
+      const recipeName = recipeLabel && typeof recipeLabel.textContent === 'string'
+        ? recipeLabel.textContent.trim()
+        : '';
+      window.setTimeout(() => {
+        const openDialog = document.querySelector('.schedule-dialog[data-open="true"]');
+        if (!openDialog) {
+          showScheduleFeedback(recipeName);
+          queueEnhance();
+        }
+      }, 0);
+    });
+  };
+
+  const startObserver = () => {
+    if (observer || !document.body) {
+      return;
+    }
+    observer = new MutationObserver(() => queueEnhance());
+    observer.observe(document.body, { childList: true, subtree: true });
+  };
+
+  const init = () => {
+    bindScheduleConfirmation();
+    ensureFeedbackElement();
+    enhancePage();
+    startObserver();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/scripts/meal-plan-affordance-copy.js
+++ b/scripts/meal-plan-affordance-copy.js
@@ -11,11 +11,18 @@
     'Add recipes from recipe cards to build this day. Planned recipes can feed the Smart shopping list.';
   const BUTTON_TEXT = 'Plan & shop';
   const HELPER_TEXT = 'Scheduled recipes can feed Smart shopping list.';
-  const FEEDBACK_TEXT = 'Added to meal plan — missing ingredients can appear in Smart shopping list.';
   const FEEDBACK_RESET_MS = 5000;
   let feedbackTimer = null;
   let observer = null;
   let enhanceQueued = false;
+
+  const scheduleFrame = (callback) => {
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(callback);
+      return;
+    }
+    window.setTimeout(callback, 0);
+  };
 
   const getRecipeNameForButton = (button) => {
     const card = button && typeof button.closest === 'function' ? button.closest('.meal-card') : null;
@@ -38,7 +45,7 @@
     const mealView = document.getElementById('meal-view');
     if (mealView) {
       mealView.insertBefore(feedback, mealView.firstChild);
-    } else {
+    } else if (document.body) {
       document.body.appendChild(feedback);
     }
     return feedback;
@@ -94,7 +101,7 @@
 
   const enhanceMealPlanEmptyStates = () => {
     document.querySelectorAll(MEAL_PLAN_EMPTY_SELECTOR).forEach((empty) => {
-      if (!(empty instanceof HTMLElement)) {
+      if (!(empty instanceof HTMLElement) || empty.textContent === EMPTY_TEXT) {
         return;
       }
       empty.textContent = EMPTY_TEXT;
@@ -112,7 +119,7 @@
       return;
     }
     enhanceQueued = true;
-    window.requestAnimationFrame(enhancePage);
+    scheduleFrame(enhancePage);
   };
 
   const bindScheduleConfirmation = () => {
@@ -136,7 +143,7 @@
   };
 
   const startObserver = () => {
-    if (observer || !document.body) {
+    if (observer || !document.body || typeof MutationObserver !== 'function') {
       return;
     }
     observer = new MutationObserver(() => queueEnhance());

--- a/scripts/productivity-settings.js
+++ b/scripts/productivity-settings.js
@@ -3,12 +3,25 @@
     return;
   }
 
-  const ensureProductivityStylesheet = () => {
-    if (document.querySelector('link[href="styles/productivity.css"]')) return;
+  const ensureStylesheet = (href) => {
+    if (document.querySelector(`link[href="${href}"]`)) return;
     const link = document.createElement('link');
     link.rel = 'stylesheet';
-    link.href = 'styles/productivity.css';
+    link.href = href;
     document.head.appendChild(link);
+  };
+
+  const ensureProductivityStylesheet = () => {
+    ensureStylesheet('styles/productivity.css');
+  };
+
+  const ensureMealPlanAffordanceAssets = () => {
+    ensureStylesheet('styles/meal-plan-affordance.css');
+    if (document.querySelector('script[src="scripts/meal-plan-affordance-copy.js"]')) return;
+    const script = document.createElement('script');
+    script.src = 'scripts/meal-plan-affordance-copy.js';
+    script.defer = true;
+    (document.body || document.head).appendChild(script);
   };
 
   const simplifySettings = () => {
@@ -60,6 +73,7 @@
   };
 
   const start = () => {
+    ensureMealPlanAffordanceAssets();
     if (simplifySettings()) return;
     window.requestAnimationFrame(() => simplifySettings());
   };

--- a/styles/meal-plan-affordance.css
+++ b/styles/meal-plan-affordance.css
@@ -1,0 +1,74 @@
+.meal-card__header-actions.meal-plan-affordance__actions {
+  flex-wrap: wrap;
+  max-inline-size: 13rem;
+}
+
+.meal-card__schedule-button.meal-plan-affordance__schedule-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  inline-size: auto;
+  min-inline-size: 36px;
+  padding-inline: 0.7rem;
+  border-radius: 999px;
+}
+
+.meal-plan-affordance__schedule-text {
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.meal-plan-affordance__helper {
+  flex: 1 0 100%;
+  margin-inline-start: auto;
+  max-inline-size: 12rem;
+  color: var(--chip-fg);
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.25;
+  opacity: 0.9;
+  text-align: right;
+}
+
+.meal-plan-affordance__feedback {
+  margin: 0 0 1rem;
+  border: 1px solid var(--border-strong);
+  border-radius: calc(var(--radius) - 8px);
+  background: var(--layer-2);
+  color: var(--text);
+  box-shadow: var(--shadow-1);
+  padding: 0.75rem 1rem;
+  font-weight: 700;
+}
+
+.meal-plan-affordance__feedback[hidden] {
+  display: none;
+}
+
+@media (max-width: 520px) {
+  .meal-card__header-actions.meal-plan-affordance__actions {
+    max-inline-size: 8.5rem;
+  }
+
+  .meal-card__schedule-button.meal-plan-affordance__schedule-button {
+    padding-inline: 0;
+    inline-size: 36px;
+  }
+
+  .meal-plan-affordance__schedule-text {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .meal-plan-affordance__helper {
+    font-size: 0.72rem;
+  }
+}


### PR DESCRIPTION
## Summary

- Add a small meal-plan affordance layer that makes recipe-card scheduling visibly connect to the Smart shopping list.
- Add a lightweight post-schedule confirmation that planned recipes can feed Smart shopping-list missing ingredients.
- Reword meal-plan empty-state copy through the affordance layer without changing shopping-list algorithms, serving behavior, duplicate handling, or date-range semantics.

## Testing

- Not run; connector-only change creation.
- Recommended before merge: `node --check scripts/productivity-settings.js scripts/meal-plan-affordance-copy.js`, `npm test`, `git diff --check`, and the browser smoke checklist for recipe-card scheduling, schedule dialog feedback, meal-plan empty state, From meal plan states, and desktop/mobile widths.

## Risks / follow-ups

- The new affordance layer is isolated in `scripts/meal-plan-affordance-copy.js` and loaded from `scripts/productivity-settings.js` to avoid a broad app-shell edit through the connector.
- Quantity aggregation, serving scaling, duplicate planned recipes, and date-range behavior remain reserved for #127.

Closes #132